### PR TITLE
fix: CI green -- g++ for DDS libs, cargo fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # intel_tex_2 compiles C++ but doesn't link libstdc++ on Linux
+  RUSTFLAGS: "-C link-arg=-lstdc++"
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y g++
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check
@@ -24,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y g++
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
@@ -33,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y g++
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/src/db.rs
+++ b/src/db.rs
@@ -396,8 +396,7 @@ impl Database {
             let mut name_cache: std::collections::HashMap<u32, String> =
                 std::collections::HashMap::new();
             {
-                let mut stmt =
-                    conn.prepare("SELECT id2, text FROM strings WHERE id1 = 88")?;
+                let mut stmt = conn.prepare("SELECT id2, text FROM strings WHERE id1 = 88")?;
                 let name_rows = stmt.query_map([], |row| {
                     Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?))
                 })?;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -103,9 +103,8 @@ impl GameObject {
         };
 
         // Extract string_id: try FQN-based first (finds 91% of quests), then type-marker fallback
-        let string_id =
-            Self::extract_string_id_via_fqn_with(&gom.payload, Some(&gom.fqn))
-                .or_else(|| Self::extract_string_id_via_type_marker(&gom.payload));
+        let string_id = Self::extract_string_id_via_fqn_with(&gom.payload, Some(&gom.fqn))
+            .or_else(|| Self::extract_string_id_via_type_marker(&gom.payload));
 
         // Encode raw payload as base64 for later analysis
         use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
@@ -211,8 +210,7 @@ impl GameObject {
     /// Fallback extraction: search for string table type marker CF 400000115CE87488.
     /// Handles talents and objects where FQN-based extraction fails.
     fn extract_string_id_via_type_marker(payload: &[u8]) -> Option<u32> {
-        const STRING_TABLE_TYPE: [u8; 9] =
-            [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
+        const STRING_TABLE_TYPE: [u8; 9] = [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
         const MIN_STRING_ID: u32 = 1_000;
         const MAX_STRING_ID: u32 = 10_000_000;
 
@@ -233,9 +231,8 @@ impl GameObject {
                     }
 
                     // Fall back to 3-byte big-endian (GSF talents: tal.spvp.*)
-                    let be24 = (id_bytes[0] as u32) << 16
-                        | (id_bytes[1] as u32) << 8
-                        | id_bytes[2] as u32;
+                    let be24 =
+                        (id_bytes[0] as u32) << 16 | (id_bytes[1] as u32) << 8 | id_bytes[2] as u32;
                     if (MIN_STRING_ID..=MAX_STRING_ID).contains(&be24) {
                         return Some(be24);
                     }


### PR DESCRIPTION
## Summary

- Install `g++` on Ubuntu runners for C++ DDS texture dependencies (`intel_tex_2`, `bcndecode-sys`)
- Apply `cargo fmt` to fix formatting diffs

## Root cause

`__gxx_personality_v0` undefined symbol -- C++ standard library not linked because `g++` not installed on runner.

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)