### PR TITLE
feat: populate quest_chain from GUID refs in payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sqlite
 *.log
 /icons/
+.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 ## [Unreleased]
 
+### Added
+
+- quest_chain table populated from GUID refs in quest payloads, linking chain members by resolved u64 identifiers
+
 ## [0.0.5] - 2026-04-02
 
 First tagged release. Extracts structured SWTOR game data from .tor archives to SQLite.

--- a/src/db.rs
+++ b/src/db.rs
@@ -549,17 +549,9 @@ impl Database {
             let mut i = 0;
             while i + 9 <= payload.len() {
                 if payload[i] == 0xCF {
-                    let guid_bytes = &payload[i + 1..i + 9];
-                    let guid_u64 = u64::from_le_bytes([
-                        guid_bytes[0],
-                        guid_bytes[1],
-                        guid_bytes[2],
-                        guid_bytes[3],
-                        guid_bytes[4],
-                        guid_bytes[5],
-                        guid_bytes[6],
-                        guid_bytes[7],
-                    ]);
+                    let guid_u64 = u64::from_le_bytes(
+                        payload[i + 1..i + 9].try_into().expect("slice is 8 bytes"),
+                    );
                     let guid_hex = format!("{:016X}", guid_u64);
 
                     if let Some(target_game_id) = guid_to_game_id.get(&guid_hex) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -89,6 +89,7 @@ pub struct Stats {
     pub items: u64,
     pub npcs: u64,
     pub strings: u64,
+    pub chain_links: u64,
 }
 
 impl Database {
@@ -488,6 +489,103 @@ impl Database {
         Ok(detail_count)
     }
 
+    /// Build quest chain links from GUID references in quest payloads.
+    ///
+    /// Scans each quest's binary payload for 0xCF + 8-byte LE GUID patterns.
+    /// Each resolved GUID that belongs to another quest object becomes a
+    /// "guid_ref" link in the quest_chain table. This is a second-pass operation
+    /// that must run after all objects are inserted.
+    pub fn populate_quest_chain(&self) -> Result<u64> {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        // Build guid → game_id map for all quest objects
+        let (guid_to_game_id, quest_rows) = {
+            let conn = self.conn.lock().unwrap();
+
+            let mut guid_map: std::collections::HashMap<String, String> =
+                std::collections::HashMap::new();
+            {
+                let mut stmt =
+                    conn.prepare("SELECT guid, game_id FROM objects WHERE kind = 'Quest'")?;
+                let rows = stmt.query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
+                for row in rows {
+                    let (guid, game_id) = row?;
+                    guid_map.insert(guid, game_id);
+                }
+            }
+
+            // Load quest payloads: game_id + payload_b64 from stored JSON
+            let mut payload_stmt = conn.prepare(
+                "SELECT game_id, json_extract(json, '$.payload_b64') FROM objects WHERE kind = 'Quest'",
+            )?;
+            let rows: Vec<(String, String)> = payload_stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+
+            (guid_map, rows)
+        };
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+
+        let mut chain_stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO quest_chain (source_game_id, target_game_id, link_type) VALUES (?1, ?2, ?3)",
+        )?;
+
+        let mut link_count = 0u64;
+
+        for (source_game_id, payload_b64) in &quest_rows {
+            let payload = match BASE64.decode(payload_b64) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            // Scan payload for 0xCF + 8-byte LE GUID patterns
+            let mut i = 0;
+            while i + 9 <= payload.len() {
+                if payload[i] == 0xCF {
+                    let guid_bytes = &payload[i + 1..i + 9];
+                    let guid_u64 = u64::from_le_bytes([
+                        guid_bytes[0],
+                        guid_bytes[1],
+                        guid_bytes[2],
+                        guid_bytes[3],
+                        guid_bytes[4],
+                        guid_bytes[5],
+                        guid_bytes[6],
+                        guid_bytes[7],
+                    ]);
+                    let guid_hex = format!("{:016X}", guid_u64);
+
+                    if let Some(target_game_id) = guid_to_game_id.get(&guid_hex) {
+                        // Skip self-references
+                        if target_game_id != source_game_id {
+                            chain_stmt.execute(rusqlite::params![
+                                source_game_id,
+                                target_game_id,
+                                "guid_ref",
+                            ])?;
+                            link_count += 1;
+                        }
+                    }
+
+                    i += 9; // skip past the 8 GUID bytes
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        drop(chain_stmt);
+        tx.commit()?;
+        Ok(link_count)
+    }
+
     pub fn stats(&self) -> Result<Stats> {
         // Ensure all pending data is flushed before counting
         self.flush()?;
@@ -499,6 +597,8 @@ impl Database {
         let items: u64 = conn.query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))?;
         let npcs: u64 = conn.query_row("SELECT COUNT(*) FROM npcs", [], |row| row.get(0))?;
         let strings: u64 = conn.query_row("SELECT COUNT(*) FROM strings", [], |row| row.get(0))?;
+        let chain_links: u64 =
+            conn.query_row("SELECT COUNT(*) FROM quest_chain", [], |row| row.get(0))?;
 
         Ok(Stats {
             quests,
@@ -506,6 +606,7 @@ impl Database {
             items,
             npcs,
             strings,
+            chain_links,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,9 @@ fn main() -> Result<()> {
     // Second pass: populate quest tables from extracted objects
     let quest_count = db.populate_quest_tables()?;
 
+    // Third pass: build quest chain links from GUID refs in payloads
+    db.populate_quest_chain()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");
@@ -368,7 +371,10 @@ fn main() -> Result<()> {
     println!("  File hashes scanned: {}", seen_hashes.len());
     println!();
     println!("  Objects: {}", total_objects);
-    println!("    Quests: {} ({} classified)", stats.quests, quest_count);
+    println!(
+        "    Quests: {} ({} classified, {} chain links)",
+        stats.quests, quest_count, stats.chain_links
+    );
     println!("    Abilities: {}", stats.abilities);
     println!("    Items: {}", stats.items);
     println!("    NPCs: {}", stats.npcs);

--- a/src/xml_parser.rs
+++ b/src/xml_parser.rs
@@ -37,11 +37,7 @@ pub fn parse(data: &[u8]) -> Result<GameObject> {
 
                     match key.as_str() {
                         "GUID" => obj.guid = value,
-                        "fqn" | "Id" => {
-                            if obj.fqn.is_empty() {
-                                obj.fqn = value;
-                            }
-                        }
+                        "fqn" | "Id" if obj.fqn.is_empty() => obj.fqn = value,
                         "Version" => obj.version = value.parse().unwrap_or(0),
                         "Revision" => obj.revision = value.parse().unwrap_or(0),
                         _ => {}


### PR DESCRIPTION
## Summary

Implements quest chain link population for #7.

- `Database::populate_quest_chain` scans each quest object's base64 payload for `0xCF` + 8-byte little-endian GUID patterns. Each pattern that resolves to a known quest GUID becomes a `guid_ref` link in the `quest_chain` table.
- The schema was already in place; this adds the population logic.
- Runs as a third pass after `populate_quest_tables`, so all quest objects are available for lookup.
- `Stats` gains `chain_links`, counted from `quest_chain` after population.
- Summary output: `Quests: N (M classified, K chain links)`.

## Design notes

Uses `game_id` (not FQN) per the issue spec -- FQN is not unique across the objects table. `INSERT OR IGNORE` deduplicates multiple refs to the same target within a payload. Self-references skipped. `link_type = "guid_ref"` for this pass; prerequisite-graph and milestone links can be added as follow-up PRs using the same table.

## Test plan

- [x] cargo build --release clean
- [x] cargo test 43/43 pass
- [x] cargo clippy -- -D warnings clean
- [x] cargo fmt --check clean

Full extraction test requires SWTOR assets (known gap per CLAUDE.md).

Closes #7

Generated with Claude Code