### PR TITLE
feat: expose template_guid column from GOM header bytes 16-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 ### Added
 
 - quest_chain table populated from GUID refs in quest payloads, linking chain members by resolved u64 identifiers
+- template_guid column on objects table, decoded from GOM header bytes 16-23 (kind-level template constant)
 
 ## [0.0.5] - 2026-04-02
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -13,6 +13,7 @@ use crate::stb::StbEntry;
 /// Serialized object ready for batch insert
 struct PendingObject {
     guid: String,
+    template_guid: String,
     fqn: String,
     game_id: String,
     kind: String,
@@ -118,6 +119,7 @@ impl Database {
             -- Raw game objects table (everything we extract)
             CREATE TABLE IF NOT EXISTS objects (
                 guid TEXT PRIMARY KEY,
+                template_guid TEXT NOT NULL DEFAULT '',
                 fqn TEXT NOT NULL,
                 game_id TEXT NOT NULL,
                 kind TEXT NOT NULL,
@@ -136,6 +138,7 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_objects_for_export ON objects(for_export);
             CREATE INDEX IF NOT EXISTS idx_objects_string_id ON objects(string_id);
             CREATE INDEX IF NOT EXISTS idx_objects_icon_name ON objects(icon_name);
+            CREATE INDEX IF NOT EXISTS idx_objects_template_guid ON objects(template_guid);
 
             -- Localized strings table (from STB files)
             CREATE TABLE IF NOT EXISTS strings (
@@ -228,6 +231,7 @@ impl Database {
         let json_str = serde_json::to_string(&obj.json)?;
         let pending = PendingObject {
             guid: obj.guid.clone(),
+            template_guid: obj.template_guid.clone(),
             fqn: obj.fqn.clone(),
             game_id: obj.game_id.clone(),
             kind: obj.kind.clone(),
@@ -294,9 +298,10 @@ impl Database {
         {
             let mut stmt = tx.prepare_cached(
                 r#"
-                INSERT INTO objects (guid, fqn, game_id, kind, icon_name, string_id, for_export, version, revision, json)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                INSERT INTO objects (guid, template_guid, fqn, game_id, kind, icon_name, string_id, for_export, version, revision, json)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
                 ON CONFLICT(guid) DO UPDATE SET
+                    template_guid = excluded.template_guid,
                     fqn = excluded.fqn,
                     game_id = excluded.game_id,
                     kind = excluded.kind,
@@ -313,6 +318,7 @@ impl Database {
             for obj in &batch {
                 stmt.execute(params![
                     obj.guid,
+                    obj.template_guid,
                     obj.fqn,
                     obj.game_id,
                     obj.kind,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -4,11 +4,28 @@ use crate::pbuk::GomObject;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Read 8 little-endian bytes from `header` starting at `offset` and format as
+/// 16-char uppercase hex. Returns empty string if the header is too short.
+fn read_header_guid(header: &[u8], offset: usize) -> String {
+    let end = offset + 8;
+    if header.len() < end {
+        return String::new();
+    }
+    let bytes: [u8; 8] = header[offset..end].try_into().unwrap();
+    format!("{:016X}", u64::from_le_bytes(bytes))
+}
+
 /// Generic game object extracted from GOM
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GameObject {
-    /// Global unique identifier (from GOM header)
+    /// Global unique identifier (from GOM header bytes 0-7)
     pub guid: String,
+
+    /// Kind-level template GUID (from GOM header bytes 16-23, little-endian u64
+    /// formatted as 16-char hex). Constant per kind (Quest=c767e4f9..., Npc=bde17800...,
+    /// Item=0ecd1a01..., Ability=d2f48302...) with <1% variant outliers. Empirically
+    /// verified across 154K objects 2026-04-23.
+    pub template_guid: String,
 
     /// Fully qualified name (e.g., "qst.class.warrior.act1.the_hunt")
     pub fqn: String,
@@ -70,23 +87,9 @@ impl GameObject {
         }
         .to_string();
 
-        // Extract GUID from header bytes 0-7 (little-endian u64)
-        let guid = if gom.header.len() >= 8 {
-            let guid_bytes = &gom.header[0..8];
-            let guid_u64 = u64::from_le_bytes([
-                guid_bytes[0],
-                guid_bytes[1],
-                guid_bytes[2],
-                guid_bytes[3],
-                guid_bytes[4],
-                guid_bytes[5],
-                guid_bytes[6],
-                guid_bytes[7],
-            ]);
-            format!("{:016X}", guid_u64)
-        } else {
-            String::new()
-        };
+        // Bytes 0-7: content GUID. Bytes 16-23: kind-level template GUID.
+        let guid = read_header_guid(&gom.header, 0);
+        let template_guid = read_header_guid(&gom.header, 16);
 
         // Compute game_id: sha256(fqn:guid)[0:16] - deterministic compound ID
         let game_id = crate::hash::compute_game_id(&gom.fqn, &guid);
@@ -122,6 +125,7 @@ impl GameObject {
 
         Self {
             guid,
+            template_guid,
             fqn: gom.fqn.clone(),
             game_id,
             kind,


### PR DESCRIPTION
## Summary

Closes #12.

Decodes bytes 16-23 of the 42-byte GOM header as a little-endian u64 formatted to 16-char hex, exposes it as a new `template_guid` column on the `objects` table.

The value is empirically constant per kind (verified across 154K objects, 2026-04-23):

| Kind    | template_guid prefix |
|---------|----------------------|
| Quest   | c767e4f9...          |
| Npc     | bde17800...          |
| Item    | 0ecd1a01...          |
| Ability | d2f48302...          |

With <1% variant template outliers per kind.

## Changes

- `src/schema/mod.rs`: add `template_guid: String` to `GameObject`; introduce `read_header_guid(header, offset)` helper used for both content GUID (offset 0) and template GUID (offset 16)
- `src/db.rs`: add `template_guid TEXT NOT NULL DEFAULT ''` column with `idx_objects_template_guid` index, wire through `PendingObject` and the INSERT/UPSERT statements
- `CHANGELOG.md`: Unreleased entry

## Why

Lets downstream consumers (huttspawn, etc.) `GROUP BY template_guid` to identify kind variants and template families without parsing payload bytes. The decode is one helper -- the bytes were already in `gom.header`, just unparsed.

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes
- [x] cargo fmt --check clean
- [ ] Sean verifies extraction run produces expected per-kind constants