### PR TITLE
feat: resolve a:enc.* refs in quest payloads to populate quest_npcs (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 - quest_chain table populated from GUID refs in quest payloads, linking chain members by resolved u64 identifiers
 - template_guid column on objects table, decoded from GOM header bytes 16-23 (kind-level template constant)
+- quest_npcs table populated by resolving a:enc.* references in quest payloads to npc.* FQNs through encounter object payloads (closes #14)
 
 ## [0.0.5] - 2026-04-02
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -91,6 +91,7 @@ pub struct Stats {
     pub npcs: u64,
     pub strings: u64,
     pub chain_links: u64,
+    pub npc_links: u64,
 }
 
 impl Database {
@@ -584,6 +585,95 @@ impl Database {
         Ok(link_count)
     }
 
+    /// Resolve `a:enc.*` references in quest payloads to `npc.*` FQNs by
+    /// scanning each referenced encounter's payload, then write rows into
+    /// `quest_npcs`. Runs after quest tables are populated.
+    ///
+    /// Two-hop resolution: quest payload contains `a:enc.<faction>.<planet>...`
+    /// strings; encounter object payload contains `npc.*` strings. The `a:`
+    /// prefix is a payload-side type marker and is stripped before the lookup.
+    pub fn populate_quest_npcs(&self) -> Result<u64> {
+        use crate::pbuk::extract_strings_from_payload;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+        use std::collections::HashMap;
+
+        fn fetch_fqn_payloads(conn: &Connection, kind: &str) -> Result<Vec<(String, String)>> {
+            let mut stmt = conn.prepare(
+                "SELECT fqn, json_extract(json, '$.payload_b64') FROM objects WHERE kind = ?1",
+            )?;
+            let rows: Vec<(String, String)> = stmt
+                .query_map([kind], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            Ok(rows)
+        }
+
+        // Pull encounter and quest rows under one lock; both are needed before writes.
+        let (enc_rows, quest_rows) = {
+            let conn = self.conn.lock().unwrap();
+            let enc_rows = fetch_fqn_payloads(&conn, "Encounter")?;
+            let quest_rows = fetch_fqn_payloads(&conn, "Quest")?;
+            (enc_rows, quest_rows)
+        };
+
+        // Build enc_fqn -> Vec<npc_fqn> by scanning each encounter payload once.
+        let mut enc_to_npcs: HashMap<String, Vec<String>> = HashMap::new();
+        for (enc_fqn, payload_b64) in enc_rows {
+            let Ok(payload) = BASE64.decode(&payload_b64) else {
+                continue;
+            };
+            let mut npcs: Vec<String> = extract_strings_from_payload(&payload)
+                .into_iter()
+                .filter(|s| s.starts_with("npc."))
+                .collect();
+            npcs.sort();
+            npcs.dedup();
+            if !npcs.is_empty() {
+                enc_to_npcs.insert(enc_fqn, npcs);
+            }
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut npc_stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO quest_npcs (quest_fqn, npc_fqn) VALUES (?1, ?2)",
+        )?;
+
+        let mut link_count = 0u64;
+        for (quest_fqn, payload_b64) in &quest_rows {
+            let Ok(payload) = BASE64.decode(payload_b64) else {
+                continue;
+            };
+            let strings = extract_strings_from_payload(&payload);
+
+            // Quest payloads reference encounters as `a:enc.*`. The `a:` is a
+            // payload-side type marker. Match either with or without the prefix.
+            let mut seen_pairs = std::collections::HashSet::new();
+            for s in &strings {
+                let enc_fqn = match s.strip_prefix("a:") {
+                    Some(rest) if rest.starts_with("enc.") => rest,
+                    _ if s.starts_with("enc.") => s.as_str(),
+                    _ => continue,
+                };
+
+                if let Some(npcs) = enc_to_npcs.get(enc_fqn) {
+                    for npc_fqn in npcs {
+                        if seen_pairs.insert((quest_fqn.clone(), npc_fqn.clone())) {
+                            npc_stmt.execute(rusqlite::params![quest_fqn, npc_fqn])?;
+                            link_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        drop(npc_stmt);
+        tx.commit()?;
+        Ok(link_count)
+    }
+
     pub fn stats(&self) -> Result<Stats> {
         // Ensure all pending data is flushed before counting
         self.flush()?;
@@ -597,6 +687,8 @@ impl Database {
         let strings: u64 = conn.query_row("SELECT COUNT(*) FROM strings", [], |row| row.get(0))?;
         let chain_links: u64 =
             conn.query_row("SELECT COUNT(*) FROM quest_chain", [], |row| row.get(0))?;
+        let npc_links: u64 =
+            conn.query_row("SELECT COUNT(*) FROM quest_npcs", [], |row| row.get(0))?;
 
         Ok(Stats {
             quests,
@@ -605,6 +697,7 @@ impl Database {
             npcs,
             strings,
             chain_links,
+            npc_links,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,9 @@ fn main() -> Result<()> {
     // Third pass: build quest chain links from GUID refs in payloads
     db.populate_quest_chain()?;
 
+    // Fourth pass: resolve a:enc.* refs in quest payloads to npc.* via encounter payloads
+    db.populate_quest_npcs()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");
@@ -372,8 +375,8 @@ fn main() -> Result<()> {
     println!();
     println!("  Objects: {}", total_objects);
     println!(
-        "    Quests: {} ({} classified, {} chain links)",
-        stats.quests, quest_count, stats.chain_links
+        "    Quests: {} ({} classified, {} chain links, {} npc links)",
+        stats.quests, quest_count, stats.chain_links, stats.npc_links
     );
     println!("    Abilities: {}", stats.abilities);
     println!("    Items: {}", stats.items);

--- a/src/pbuk.rs
+++ b/src/pbuk.rs
@@ -64,29 +64,36 @@ pub struct GomObject {
     pub payload: Vec<u8>,
 }
 
+/// Extract length-prefixed ASCII strings from a raw GOM payload.
+///
+/// Each string is stored as a length byte followed by `len` ASCII bytes (32-126).
+/// Strings shorter than 2 bytes or longer than 199 are skipped as noise.
+pub fn extract_strings_from_payload(payload: &[u8]) -> Vec<String> {
+    let mut strings = Vec::new();
+    let mut i = 0;
+
+    while i < payload.len() {
+        let len = payload[i] as usize;
+        if (2..200).contains(&len) && i + 1 + len <= payload.len() {
+            let candidate = &payload[i + 1..i + 1 + len];
+            if candidate.iter().all(|&b| (32..127).contains(&b)) {
+                if let Ok(s) = std::str::from_utf8(candidate) {
+                    strings.push(s.to_string());
+                }
+                i += 1 + len;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    strings
+}
+
 impl GomObject {
     /// Try to extract strings from the binary payload
     pub fn extract_strings(&self) -> Vec<String> {
-        let mut strings = Vec::new();
-        let mut i = 0;
-
-        while i < self.payload.len() {
-            // Look for length-prefixed strings (common in GOM format)
-            let len = self.payload[i] as usize;
-            if len > 0 && len < 200 && i + 1 + len <= self.payload.len() {
-                let potential_string = &self.payload[i + 1..i + 1 + len];
-                if potential_string.iter().all(|&b| (32..127).contains(&b)) && len >= 2 {
-                    if let Ok(s) = std::str::from_utf8(potential_string) {
-                        strings.push(s.to_string());
-                    }
-                    i += 1 + len;
-                    continue;
-                }
-            }
-            i += 1;
-        }
-
-        strings
+        extract_strings_from_payload(&self.payload)
     }
 }
 
@@ -340,5 +347,45 @@ pub fn parse_dblb_direct(data: &[u8]) -> Result<Vec<GomObject>> {
         parse_object_dblb(&data[16..])
     } else {
         parse_object_dblb(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pack(strings: &[&str]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for s in strings {
+            buf.push(s.len() as u8);
+            buf.extend_from_slice(s.as_bytes());
+        }
+        buf
+    }
+
+    #[test]
+    fn extract_strings_finds_length_prefixed_ascii() {
+        let payload = pack(&["npc.korriban.foo", "enc.korriban.bar"]);
+        let strings = extract_strings_from_payload(&payload);
+        assert!(strings.contains(&"npc.korriban.foo".to_string()));
+        assert!(strings.contains(&"enc.korriban.bar".to_string()));
+    }
+
+    #[test]
+    fn extract_strings_skips_short_runs() {
+        // Length 1 is below the minimum (2) and should be skipped, not yielded.
+        let payload = pack(&["x", "npc.real"]);
+        let strings = extract_strings_from_payload(&payload);
+        assert!(!strings.iter().any(|s| s == "x"));
+        assert!(strings.iter().any(|s| s == "npc.real"));
+    }
+
+    #[test]
+    fn extract_strings_handles_a_prefix_encounter_refs() {
+        // Quest payloads reference encounters with the `a:` type marker.
+        // The free function returns the raw string; callers strip the prefix.
+        let payload = pack(&["a:enc.korriban.tomb"]);
+        let strings = extract_strings_from_payload(&payload);
+        assert!(strings.iter().any(|s| s == "a:enc.korriban.tomb"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #14.

Populates the `quest_npcs` table (empty after every prior extraction) by resolving the two-hop reference chain quest payload → encounter object → NPC FQN.

Quest payloads do not reference NPCs directly. They reference encounters via `a:enc.<faction>.<planet>.<segment>` strings. Each encounter object's payload then references one or more `npc.*` FQNs. This PR walks both hops at extraction time and writes (quest_fqn, npc_fqn) pairs.

## Changes

- `src/pbuk.rs`: extract the inline string-scan logic into a free function `extract_strings_from_payload(&[u8])` so it can be called on raw decoded payload bytes from db.rs. `GomObject::extract_strings` now delegates. Adds three unit tests.
- `src/db.rs`: new `populate_quest_npcs` method, modeled after `populate_quest_chain`. Builds enc_fqn → Vec<npc_fqn> map up front, then scans quest payloads for `a:enc.*` refs (with the `a:` type marker stripped) and INSERTs pairs. Adds a small `fetch_fqn_payloads(conn, kind)` helper to deduplicate the two row-loading blocks. Adds `npc_links` to Stats.
- `src/main.rs`: wires the fourth pass after `populate_quest_chain`, prints `npc links` in the summary line.
- `CHANGELOG.md`: Unreleased entry.

## Why this shape

- **Two-hop resolution at extraction time** rather than at consumer query time: keeps spice.sqlite normalized (one row per quest-NPC pair) and downstream readers don't need to know the encounter indirection. Matches the existing `populate_quest_chain` pattern.
- **`a:` prefix stripped at the call site** (not in `extract_strings_from_payload`): the prefix is a payload type marker, not part of the FQN. Other callers may or may not want it stripped, so the responsibility lives at the matching site.
- **No new GOM decoding**: rests on the already-implemented length-prefixed ASCII scan. No binary research needed for this issue.

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes (41 tests, 3 new for the string-scan refactor)
- [x] cargo fmt --check clean
- [x] legion-simplify gate recorded clean (caught duplicate query_map blocks; extracted fetch_fqn_payloads helper)
- [ ] Sean verifies extraction run produces non-zero quest_npcs row count
- [ ] CSV-validation script in `vault-2026/research/kessel/scripts/` confirms >=80% of mapped quests have at least one NPC row matching the Mission Giver column

## What's deferred

- The CSV validation script itself is research, lives in the vault, runs after the next full extraction. Not part of this PR.
- Edge cases where encounters reference NPCs via filters or runtime spawns (rather than embedded npc.* strings) are not covered. If those leave gaps in the validation report, follow-up issue.