### PR TITLE
fix: prefix-match fallback for spawn variants (closes the_devoted_ones case)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - quest_chain table populated from GUID refs in quest payloads, linking chain members by resolved u64 identifiers
 - template_guid column on objects table, decoded from GOM header bytes 16-23 (kind-level template constant)
 - quest_npcs table populated by resolving a:enc.* references in quest payloads to npc.* FQNs through encounter object payloads (closes #14)
+- quest_rewards table populated by extracting `quest_reward_*` variable names from quest payloads (closes #24)
+- quest_descriptions view exposing each quest's first journal entry (STB id1 200-600 range) -- mirrors the CSV "Mission Description" column
+- bonus_missions view flattening `mpn.*.bonus.*` mission-phase objects with their parent quest FQN guess -- helps close the kessel/CSV row-count gap (#25)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 ### Fixed
 
 - enc / spn / plc FQN prefixes added to extraction allowlist. quest_npcs was empty after every extraction because encounter objects were filtered out before populate_quest_npcs could resolve them.
+- Extended quest_npcs resolution to three hops (quest -> enc -> spn -> npc). Encounter payloads contain spawn references, not NPC references directly; without the spawn-to-NPC step, encounter resolution found zero rows.
+- String scanner recognises a third encoding pattern: `0xD2 0x01 <index> <len> <ASCII>` for array-element strings in encounter payloads. The previous heuristic produced truncated strings (e.g. `Gspn.location...ban` instead of the full FQN).
 
 ## [0.0.5] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - template_guid column on objects table, decoded from GOM header bytes 16-23 (kind-level template constant)
 - quest_npcs table populated by resolving a:enc.* references in quest payloads to npc.* FQNs through encounter object payloads (closes #14)
 
+### Fixed
+
+- enc / spn / plc FQN prefixes added to extraction allowlist. quest_npcs was empty after every extraction because encounter objects were filtered out before populate_quest_npcs could resolve them.
+
 ## [0.0.5] - 2026-04-02
 
 First tagged release. Extracts structured SWTOR game data from .tor archives to SQLite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - Extended quest_npcs resolution to three hops (quest -> enc -> spn -> npc). Encounter payloads contain spawn references, not NPC references directly; without the spawn-to-NPC step, encounter resolution found zero rows.
 - String scanner recognises a third encoding pattern: `0xD2 0x01 <index> <len> <ASCII>` for array-element strings in encounter payloads. The previous heuristic produced truncated strings (e.g. `Gspn.location...ban` instead of the full FQN).
 - mpn.* objects now classify as `kind='Phase'` (was `kind='Quest'`). Mission phases were inflating the Quest count 8x and polluting `quest_details` with phase-shaped rows that were never real missions. New `phases` view exposes them. Closes #23.
+- Spawn-prefix fallback in populate_quest_npcs: encounters that reference a base spawn name (e.g. `spn.X.multi.isen`) which the engine resolves at runtime to variants (`isen_no_weapon`, `isen_captured`) now resolve to the underlying NPC via prefix-match. Closes the_devoted_ones case from #27.
 
 ## [0.0.5] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - enc / spn / plc FQN prefixes added to extraction allowlist. quest_npcs was empty after every extraction because encounter objects were filtered out before populate_quest_npcs could resolve them.
 - Extended quest_npcs resolution to three hops (quest -> enc -> spn -> npc). Encounter payloads contain spawn references, not NPC references directly; without the spawn-to-NPC step, encounter resolution found zero rows.
 - String scanner recognises a third encoding pattern: `0xD2 0x01 <index> <len> <ASCII>` for array-element strings in encounter payloads. The previous heuristic produced truncated strings (e.g. `Gspn.location...ban` instead of the full FQN).
+- mpn.* objects now classify as `kind='Phase'` (was `kind='Quest'`). Mission phases were inflating the Quest count 8x and polluting `quest_details` with phase-shaped rows that were never real missions. New `phases` view exposes them. Closes #23.
 
 ## [0.0.5] - 2026-04-02
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -584,7 +584,33 @@ impl Database {
         tx.commit()?;
         Ok(link_count)
     }
+}
 
+/// Parse the SPN-triple format that appears in quest payloads:
+///
+/// ```text
+/// spn.<faction.planet.path>;<target_fqn>;<numeric_id>
+/// ```
+///
+/// The middle segment is the entity that spawns at this point -- typically
+/// `npc.*`, sometimes `plc.*` or other kinds. Return the embedded FQN only
+/// if it starts with `npc.` (other kinds are ignored here -- this helper is
+/// scoped to NPC resolution).
+fn npc_from_spn_triple(s: &str) -> Option<String> {
+    if !s.starts_with("spn.") {
+        return None;
+    }
+    let mut parts = s.splitn(3, ';');
+    let _spn = parts.next()?;
+    let target = parts.next()?;
+    if target.starts_with("npc.") {
+        Some(target.to_string())
+    } else {
+        None
+    }
+}
+
+impl Database {
     /// Resolve `a:enc.*` references in quest payloads to `npc.*` FQNs by
     /// scanning each referenced encounter's payload, then write rows into
     /// `quest_npcs`. Runs after quest tables are populated.
@@ -648,22 +674,35 @@ impl Database {
             };
             let strings = extract_strings_from_payload(&payload);
 
-            // Quest payloads reference encounters as `a:enc.*`. The `a:` is a
-            // payload-side type marker. Match either with or without the prefix.
             let mut seen_pairs = std::collections::HashSet::new();
+            let mut emit = |npc_fqn: String, count: &mut u64| -> Result<()> {
+                if seen_pairs.insert((quest_fqn.clone(), npc_fqn.clone())) {
+                    npc_stmt.execute(rusqlite::params![quest_fqn, npc_fqn])?;
+                    *count += 1;
+                }
+                Ok(())
+            };
+
             for s in &strings {
+                // Path 1: SPN triple in quest payload -- `spn.X;npc.Y;<numeric_id>`.
+                // The middle segment is the NPC that spawns at this point. This
+                // is the direct quest -> npc reference path.
+                if let Some(npc_fqn) = npc_from_spn_triple(s) {
+                    emit(npc_fqn, &mut link_count)?;
+                    continue;
+                }
+
+                // Path 2: encounter reference (`a:enc.*` or `enc.*`) -- two-hop
+                // resolution through enc_to_npcs map. Encounters often spawn
+                // NPCs that the quest does not name directly.
                 let enc_fqn = match s.strip_prefix("a:") {
                     Some(rest) if rest.starts_with("enc.") => rest,
                     _ if s.starts_with("enc.") => s.as_str(),
                     _ => continue,
                 };
-
                 if let Some(npcs) = enc_to_npcs.get(enc_fqn) {
                     for npc_fqn in npcs {
-                        if seen_pairs.insert((quest_fqn.clone(), npc_fqn.clone())) {
-                            npc_stmt.execute(rusqlite::params![quest_fqn, npc_fqn])?;
-                            link_count += 1;
-                        }
+                        emit(npc_fqn.clone(), &mut link_count)?;
                     }
                 }
             }
@@ -834,4 +873,33 @@ fn derive_icon_from_fqn(fqn: &str) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npc_from_spn_triple_extracts_middle_segment() {
+        let s = "spn.location.korriban.class.sith_warrior.judge_and_executioner.jailer_knash;npc.location.korriban.class.sith_warrior.judge_and_executioner.jailer_knash;291310451818496";
+        assert_eq!(
+            npc_from_spn_triple(s).as_deref(),
+            Some("npc.location.korriban.class.sith_warrior.judge_and_executioner.jailer_knash")
+        );
+    }
+
+    #[test]
+    fn npc_from_spn_triple_rejects_non_spn_strings() {
+        assert!(npc_from_spn_triple("npc.korriban.foo").is_none());
+        assert!(npc_from_spn_triple("a:enc.korriban.tomb").is_none());
+        assert!(npc_from_spn_triple("Always").is_none());
+    }
+
+    #[test]
+    fn npc_from_spn_triple_rejects_non_npc_targets() {
+        // Spawn triples can also reference plc.* (placeables); this helper is
+        // scoped to NPC-only and must reject them.
+        let s = "spn.korriban.x;plc.korriban.carving;123";
+        assert!(npc_from_spn_triple(s).is_none());
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -155,9 +155,14 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_strings_locale ON strings(locale);
             CREATE INDEX IF NOT EXISTS idx_strings_id2 ON strings(id2);
 
-            -- Typed views for convenience
+            -- Typed views for convenience.
+            -- Post-#23: kind='Quest' includes only qst.* objects.
+            -- Mission phases (mpn.*) are kind='Phase' -- see `phases` view.
             CREATE VIEW IF NOT EXISTS quests AS
-                SELECT * FROM objects WHERE kind = 'Quest' OR fqn LIKE 'qst.%';
+                SELECT * FROM objects WHERE kind = 'Quest';
+
+            CREATE VIEW IF NOT EXISTS phases AS
+                SELECT * FROM objects WHERE kind = 'Phase';
 
             CREATE VIEW IF NOT EXISTS abilities AS
                 SELECT * FROM objects WHERE kind = 'Ability' OR fqn LIKE 'abl.%';
@@ -462,9 +467,8 @@ impl Database {
                 }
             }
 
-            let mut stmt = conn.prepare(
-                "SELECT fqn, string_id, json FROM objects WHERE fqn LIKE 'qst.%' OR kind = 'Quest'",
-            )?;
+            let mut stmt =
+                conn.prepare("SELECT fqn, string_id, json FROM objects WHERE kind = 'Quest'")?;
             let rows: Vec<(String, Option<u32>, String)> = stmt
                 .query_map([], |row| {
                     Ok((

--- a/src/db.rs
+++ b/src/db.rs
@@ -736,6 +736,18 @@ impl Database {
                 } else if s.starts_with("spn.") {
                     if let Some(spn_npcs) = spn_to_npcs.get(s) {
                         npcs.extend(spn_npcs.iter().cloned());
+                    } else {
+                        // Some encounters reference a base spawn name like
+                        // `spn.X.multi.isen` that the engine resolves at
+                        // runtime to a variant (`isen_no_weapon`,
+                        // `isen_captured`). Fall back to prefix-match on
+                        // `<base>_*` so the underlying character resolves.
+                        let prefix = format!("{}_", s);
+                        for (spn_fqn, spn_npcs) in &spn_to_npcs {
+                            if spn_fqn.starts_with(&prefix) {
+                                npcs.extend(spn_npcs.iter().cloned());
+                            }
+                        }
                     }
                 }
             }

--- a/src/db.rs
+++ b/src/db.rs
@@ -92,6 +92,7 @@ pub struct Stats {
     pub strings: u64,
     pub chain_links: u64,
     pub npc_links: u64,
+    pub reward_links: u64,
 }
 
 impl Database {
@@ -211,6 +212,53 @@ impl Database {
                 link_type TEXT NOT NULL,
                 PRIMARY KEY (source_game_id, target_game_id)
             );
+
+            -- Quest rewards (variable names extracted from payloads, e.g.
+            -- 'quest_reward_adrenal'). Variable names are categories
+            -- (adrenal, medpac, alignment) -- specific items are engine-
+            -- resolved at runtime and not in payload data.
+            CREATE TABLE IF NOT EXISTS quest_rewards (
+                quest_fqn       TEXT NOT NULL,
+                reward_variable TEXT NOT NULL,
+                PRIMARY KEY (quest_fqn, reward_variable)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_quest_rewards_variable ON quest_rewards(reward_variable);
+
+            -- Quest descriptions: first journal entry per quest, surfaced as
+            -- a view over the strings table. Mirrors the CSV's "Mission
+            -- Description" column. Per the design doc, journal text is at
+            -- STB id1 200-600 range; the first entry is the description.
+            CREATE VIEW IF NOT EXISTS quest_descriptions AS
+                SELECT
+                    o.fqn AS quest_fqn,
+                    s.text AS description
+                FROM objects o
+                JOIN strings s ON s.id2 = o.string_id
+                WHERE o.kind = 'Quest'
+                  AND s.id1 BETWEEN 200 AND 600
+                  AND s.id1 = (
+                      SELECT MIN(s2.id1) FROM strings s2
+                      WHERE s2.id2 = o.string_id AND s2.id1 BETWEEN 200 AND 600
+                  );
+
+            -- Bonus missions flattened from mpn.*.bonus.* phases. The CSV
+            -- treats these as separate mission rows; in GOM data they are
+            -- mission phases of a parent quest. This view exposes them
+            -- with parent FQN for editorial/CSV-style queries.
+            CREATE VIEW IF NOT EXISTS bonus_missions AS
+                SELECT
+                    o.fqn AS bonus_fqn,
+                    -- Parent quest FQN: drop the trailing `.bonus.<name>`
+                    -- and any segments after `.bonus`. The mpn.* prefix
+                    -- swaps to qst.* for the parent.
+                    'qst.' || substr(
+                        o.fqn,
+                        5,
+                        instr(o.fqn, '.bonus.') - 5
+                    ) AS parent_quest_fqn_guess
+                FROM objects o
+                WHERE o.fqn LIKE 'mpn.%.bonus.%';
 
             -- Extraction metadata
             CREATE TABLE IF NOT EXISTS meta (
@@ -586,6 +634,20 @@ impl Database {
     }
 }
 
+/// Pull `(fqn, payload_b64)` tuples for every object of `kind`. Used by
+/// the populate_* passes that need to walk binary payloads.
+fn fetch_fqn_payloads(conn: &Connection, kind: &str) -> Result<Vec<(String, String)>> {
+    let mut stmt = conn
+        .prepare("SELECT fqn, json_extract(json, '$.payload_b64') FROM objects WHERE kind = ?1")?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map([kind], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(rows)
+}
+
 /// Parse the SPN-triple format that appears in quest payloads:
 ///
 /// ```text
@@ -622,19 +684,6 @@ impl Database {
         use crate::pbuk::extract_strings_from_payload;
         use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
         use std::collections::HashMap;
-
-        fn fetch_fqn_payloads(conn: &Connection, kind: &str) -> Result<Vec<(String, String)>> {
-            let mut stmt = conn.prepare(
-                "SELECT fqn, json_extract(json, '$.payload_b64') FROM objects WHERE kind = ?1",
-            )?;
-            let rows: Vec<(String, String)> = stmt
-                .query_map([kind], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                })?
-                .filter_map(|r| r.ok())
-                .collect();
-            Ok(rows)
-        }
 
         // Pull encounter, spawn, and quest rows under one lock.
         let (enc_rows, spawn_rows, quest_rows) = {
@@ -745,6 +794,43 @@ impl Database {
         Ok(link_count)
     }
 
+    /// Extract `quest_reward_*` variable names from each quest payload and
+    /// write rows into `quest_rewards`. Variable names are categories
+    /// (adrenal, medpac, alignment, gift); specific items are runtime-resolved
+    /// by the engine and not in payload data.
+    pub fn populate_quest_rewards(&self) -> Result<u64> {
+        use crate::pbuk::extract_strings_from_payload;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let quest_rows: Vec<(String, String)> = {
+            let conn = self.conn.lock().unwrap();
+            fetch_fqn_payloads(&conn, "Quest")?
+        };
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO quest_rewards (quest_fqn, reward_variable) VALUES (?1, ?2)",
+        )?;
+
+        let mut count = 0u64;
+        for (quest_fqn, payload_b64) in &quest_rows {
+            let Ok(payload) = BASE64.decode(payload_b64) else {
+                continue;
+            };
+            for s in extract_strings_from_payload(&payload) {
+                if s.starts_with("quest_reward_") {
+                    stmt.execute(rusqlite::params![quest_fqn, s])?;
+                    count += 1;
+                }
+            }
+        }
+
+        drop(stmt);
+        tx.commit()?;
+        Ok(count)
+    }
+
     pub fn stats(&self) -> Result<Stats> {
         // Ensure all pending data is flushed before counting
         self.flush()?;
@@ -760,6 +846,8 @@ impl Database {
             conn.query_row("SELECT COUNT(*) FROM quest_chain", [], |row| row.get(0))?;
         let npc_links: u64 =
             conn.query_row("SELECT COUNT(*) FROM quest_npcs", [], |row| row.get(0))?;
+        let reward_links: u64 =
+            conn.query_row("SELECT COUNT(*) FROM quest_rewards", [], |row| row.get(0))?;
 
         Ok(Stats {
             quests,
@@ -769,6 +857,7 @@ impl Database {
             strings,
             chain_links,
             npc_links,
+            reward_links,
         })
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -636,17 +636,22 @@ impl Database {
             Ok(rows)
         }
 
-        // Pull encounter and quest rows under one lock; both are needed before writes.
-        let (enc_rows, quest_rows) = {
+        // Pull encounter, spawn, and quest rows under one lock.
+        let (enc_rows, spawn_rows, quest_rows) = {
             let conn = self.conn.lock().unwrap();
             let enc_rows = fetch_fqn_payloads(&conn, "Encounter")?;
+            let spawn_rows = fetch_fqn_payloads(&conn, "Spawn")?;
             let quest_rows = fetch_fqn_payloads(&conn, "Quest")?;
-            (enc_rows, quest_rows)
+            (enc_rows, spawn_rows, quest_rows)
         };
 
-        // Build enc_fqn -> Vec<npc_fqn> by scanning each encounter payload once.
-        let mut enc_to_npcs: HashMap<String, Vec<String>> = HashMap::new();
-        for (enc_fqn, payload_b64) in enc_rows {
+        // Build spn_fqn -> Vec<npc_fqn> by scanning each spawn payload once.
+        // Spawns are the layer between encounters and NPCs: encounter payloads
+        // reference `spn.*`, spawn payloads reference `npc.*`. Without this
+        // map, the enc -> npc resolution finds only the small subset of
+        // encounters that name NPCs directly (~166 of 9652).
+        let mut spn_to_npcs: HashMap<String, Vec<String>> = HashMap::new();
+        for (spn_fqn, payload_b64) in spawn_rows {
             let Ok(payload) = BASE64.decode(&payload_b64) else {
                 continue;
             };
@@ -654,6 +659,33 @@ impl Database {
                 .into_iter()
                 .filter(|s| s.starts_with("npc."))
                 .collect();
+            npcs.sort();
+            npcs.dedup();
+            if !npcs.is_empty() {
+                spn_to_npcs.insert(spn_fqn, npcs);
+            }
+        }
+
+        // Build enc_fqn -> Vec<npc_fqn>. An encounter's NPCs come from two
+        // sources, joined together:
+        //   1. npc.* strings directly in the encounter payload
+        //   2. spn.* strings in the encounter payload, resolved via spn_to_npcs
+        let mut enc_to_npcs: HashMap<String, Vec<String>> = HashMap::new();
+        for (enc_fqn, payload_b64) in enc_rows {
+            let Ok(payload) = BASE64.decode(&payload_b64) else {
+                continue;
+            };
+            let strings = extract_strings_from_payload(&payload);
+            let mut npcs: Vec<String> = Vec::new();
+            for s in &strings {
+                if s.starts_with("npc.") {
+                    npcs.push(s.clone());
+                } else if s.starts_with("spn.") {
+                    if let Some(spn_npcs) = spn_to_npcs.get(s) {
+                        npcs.extend(spn_npcs.iter().cloned());
+                    }
+                }
+            }
             npcs.sort();
             npcs.dedup();
             if !npcs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,6 +367,9 @@ fn main() -> Result<()> {
     // Fourth pass: resolve a:enc.* refs in quest payloads to npc.* via encounter payloads
     db.populate_quest_npcs()?;
 
+    // Fifth pass: extract quest_reward_* variable names from quest payloads
+    db.populate_quest_rewards()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");
@@ -375,8 +378,8 @@ fn main() -> Result<()> {
     println!();
     println!("  Objects: {}", total_objects);
     println!(
-        "    Quests: {} ({} classified, {} chain links, {} npc links)",
-        stats.quests, quest_count, stats.chain_links, stats.npc_links
+        "    Quests: {} ({} classified, {} chain links, {} npc links, {} reward links)",
+        stats.quests, quest_count, stats.chain_links, stats.npc_links, stats.reward_links
     );
     println!("    Abilities: {}", stats.abilities);
     println!("    Items: {}", stats.items);

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,11 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
         None => fqn,
     };
 
-    // Must be a known prefix type (always applied)
+    // Must be a known prefix type (always applied).
+    // enc/spn/plc are required for quest_npcs population: quest payloads
+    // reference NPCs through encounter (enc.*) and spawn (spn.*) intermediaries
+    // and through placeable (plc.*) targets. Without these, populate_quest_npcs
+    // sees an empty resolution map and writes zero rows.
     if !matches!(
         prefix,
         "abl"
@@ -482,6 +486,9 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
             | "cnv"
             | "apc"
             | "class"
+            | "enc"
+            | "spn"
+            | "plc"
     ) {
         return false;
     }

--- a/src/pbuk.rs
+++ b/src/pbuk.rs
@@ -66,28 +66,48 @@ pub struct GomObject {
 
 /// Extract ASCII strings from a raw GOM payload.
 ///
-/// GOM uses at least two encodings empirically:
+/// GOM uses at least three string encodings empirically:
 ///
-/// 1. Canonical: `0x06 <length_byte> <ASCII>` -- common in spawn/encounter payloads.
-/// 2. With prefix: `0x06 <flag bytes> <length_byte> <ASCII>` -- common in quest payloads,
-///    e.g., `0x06 01 01 01 <len> <ASCII>`. The intermediate bytes appear to be
-///    flag/array-count metadata between the marker and the actual string.
+/// 1. Canonical: `0x06 <len> <ASCII>` -- common in spawn payloads.
+/// 2. With prefix: `0x06 <flag bytes> <len> <ASCII>` -- common in quest payloads
+///    (e.g. `0x06 01 01 01 a7 ...`). Intermediate bytes are array-count or
+///    flag metadata between the marker and the actual length.
+/// 3. Array element: `0xD2 0x01 <index> <len> <ASCII>` -- common in encounter
+///    payloads. `0xD2 0x01` is an array-element header followed by an
+///    incrementing 1-byte index ('A', 'B', 'C', ...) before the length.
 ///
-/// To catch both, we combine two heuristics: prefer the canonical 0x06 marker
-/// pattern, and fall back to a plain `<length_byte> <ASCII>` scan everywhere
-/// else. The fallback recovers strings whose marker is followed by
-/// intermediate bytes -- it lands on the actual length byte since the
-/// intermediates fail the canonical check.
+/// We try in priority: array element first (strictest signature), canonical
+/// 0x06 next, and a bare-length fallback last. The fallback recovers strings
+/// whose marker is followed by intermediate bytes by landing on the actual
+/// length byte once the more specific patterns walk past.
 ///
-/// This is a heuristic, not a full msgpack-style decode. If a future format
+/// This is heuristic, not a full msgpack-style decode. If a future format
 /// change introduces ambiguity, the right fix is to decode the type-tag
-/// stream properly rather than to refine the heuristics.
+/// stream properly rather than to refine the heuristics further.
 pub fn extract_strings_from_payload(payload: &[u8]) -> Vec<String> {
     let mut strings = Vec::new();
     let mut i = 0;
 
-    while i + 2 <= payload.len() {
-        // Canonical: 0x06 <len> <ascii>
+    while i + 4 <= payload.len() {
+        // Pattern 3: array element `0xD2 0x01 <index> <len> <ASCII>`.
+        if payload[i] == 0xD2 && payload[i + 1] == 0x01 {
+            let len = payload[i + 3] as usize;
+            let start = i + 4;
+            if (2..200).contains(&len) && start + len <= payload.len() {
+                let candidate = &payload[start..start + len];
+                if candidate.iter().all(|&b| (32..127).contains(&b)) {
+                    if let Ok(s) = std::str::from_utf8(candidate) {
+                        strings.push(s.to_string());
+                        i = start + len;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        // Pattern 1: canonical `0x06 <len> <ASCII>`.
         if payload[i] == 0x06 {
             let len = payload[i + 1] as usize;
             let start = i + 2;
@@ -105,10 +125,8 @@ pub fn extract_strings_from_payload(payload: &[u8]) -> Vec<String> {
             continue;
         }
 
-        // Fallback: <len> <ascii> directly. Catches strings preceded by
-        // intermediate bytes after the 0x06 marker (e.g., `06 01 01 01 a7 ...`)
-        // by landing on the actual length byte once the canonical scan has
-        // walked past the intermediates.
+        // Fallback: `<len> <ASCII>` directly. Catches pattern 2 by landing
+        // on the actual length byte once intermediates have been skipped.
         let len = payload[i] as usize;
         let start = i + 1;
         if (2..200).contains(&len) && start + len <= payload.len() {
@@ -459,6 +477,22 @@ mod tests {
         assert_eq!(strings.len(), 1);
         assert!(strings[0].starts_with("spn."));
         assert!(strings[0].contains(";npc."));
+    }
+
+    #[test]
+    fn extract_strings_recognises_array_element_d2_01_marker() {
+        // Encounter payloads encode array-element strings as
+        // `0xD2 0x01 <index> <len> <ASCII>`. Without this case the scanner's
+        // fallback heuristic produces a truncated string starting with the
+        // index byte ('A'/'B'/...) misread as length.
+        let mut payload = vec![0xD2, 0x01, b'A', 0x40]; // header + index='A' + len=0x40 (64)
+        let content = b"spn.location.tatooine.mob.hub4.green.shared.poi00_wilderness.bnt";
+        assert_eq!(content.len(), 64);
+        payload.extend_from_slice(content);
+        let strings = extract_strings_from_payload(&payload);
+        assert_eq!(strings.len(), 1);
+        assert_eq!(strings[0].as_bytes(), content);
+        assert!(!strings[0].starts_with('A'), "must not include index byte");
     }
 
     #[test]

--- a/src/pbuk.rs
+++ b/src/pbuk.rs
@@ -64,24 +64,61 @@ pub struct GomObject {
     pub payload: Vec<u8>,
 }
 
-/// Extract length-prefixed ASCII strings from a raw GOM payload.
+/// Extract ASCII strings from a raw GOM payload.
 ///
-/// Each string is stored as a length byte followed by `len` ASCII bytes (32-126).
-/// Strings shorter than 2 bytes or longer than 199 are skipped as noise.
+/// GOM uses at least two encodings empirically:
+///
+/// 1. Canonical: `0x06 <length_byte> <ASCII>` -- common in spawn/encounter payloads.
+/// 2. With prefix: `0x06 <flag bytes> <length_byte> <ASCII>` -- common in quest payloads,
+///    e.g., `0x06 01 01 01 <len> <ASCII>`. The intermediate bytes appear to be
+///    flag/array-count metadata between the marker and the actual string.
+///
+/// To catch both, we combine two heuristics: prefer the canonical 0x06 marker
+/// pattern, and fall back to a plain `<length_byte> <ASCII>` scan everywhere
+/// else. The fallback recovers strings whose marker is followed by
+/// intermediate bytes -- it lands on the actual length byte since the
+/// intermediates fail the canonical check.
+///
+/// This is a heuristic, not a full msgpack-style decode. If a future format
+/// change introduces ambiguity, the right fix is to decode the type-tag
+/// stream properly rather than to refine the heuristics.
 pub fn extract_strings_from_payload(payload: &[u8]) -> Vec<String> {
     let mut strings = Vec::new();
     let mut i = 0;
 
-    while i < payload.len() {
+    while i + 2 <= payload.len() {
+        // Canonical: 0x06 <len> <ascii>
+        if payload[i] == 0x06 {
+            let len = payload[i + 1] as usize;
+            let start = i + 2;
+            if (2..200).contains(&len) && start + len <= payload.len() {
+                let candidate = &payload[start..start + len];
+                if candidate.iter().all(|&b| (32..127).contains(&b)) {
+                    if let Ok(s) = std::str::from_utf8(candidate) {
+                        strings.push(s.to_string());
+                        i = start + len;
+                        continue;
+                    }
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        // Fallback: <len> <ascii> directly. Catches strings preceded by
+        // intermediate bytes after the 0x06 marker (e.g., `06 01 01 01 a7 ...`)
+        // by landing on the actual length byte once the canonical scan has
+        // walked past the intermediates.
         let len = payload[i] as usize;
-        if (2..200).contains(&len) && i + 1 + len <= payload.len() {
-            let candidate = &payload[i + 1..i + 1 + len];
+        let start = i + 1;
+        if (2..200).contains(&len) && start + len <= payload.len() {
+            let candidate = &payload[start..start + len];
             if candidate.iter().all(|&b| (32..127).contains(&b)) {
                 if let Ok(s) = std::str::from_utf8(candidate) {
                     strings.push(s.to_string());
+                    i = start + len;
+                    continue;
                 }
-                i += 1 + len;
-                continue;
             }
         }
         i += 1;
@@ -354,9 +391,11 @@ pub fn parse_dblb_direct(data: &[u8]) -> Result<Vec<GomObject>> {
 mod tests {
     use super::*;
 
+    /// Encode strings the way GOM does: `0x06 <length> <ASCII>`.
     fn pack(strings: &[&str]) -> Vec<u8> {
         let mut buf = Vec::new();
         for s in strings {
+            buf.push(0x06);
             buf.push(s.len() as u8);
             buf.extend_from_slice(s.as_bytes());
         }
@@ -364,7 +403,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_strings_finds_length_prefixed_ascii() {
+    fn extract_strings_finds_marker_prefixed_ascii() {
         let payload = pack(&["npc.korriban.foo", "enc.korriban.bar"]);
         let strings = extract_strings_from_payload(&payload);
         assert!(strings.contains(&"npc.korriban.foo".to_string()));
@@ -387,5 +426,55 @@ mod tests {
         let payload = pack(&["a:enc.korriban.tomb"]);
         let strings = extract_strings_from_payload(&payload);
         assert!(strings.iter().any(|s| s == "a:enc.korriban.tomb"));
+    }
+
+    #[test]
+    fn extract_strings_uses_fallback_when_marker_is_absent() {
+        // When the canonical 0x06 marker is preceded by intermediate bytes
+        // before the length byte, the fallback heuristic recovers the string
+        // by reading directly at the length byte.
+        let mut payload = vec![0x06, 0x01, 0x01, 0x01, 0x41]; // marker + intermediates + length=65
+        payload.extend_from_slice(
+            b"spn.location.korriban.mob.tomb_2_marka_ragnos.mob02.standard_m_01",
+        );
+        let strings = extract_strings_from_payload(&payload);
+        assert!(
+            strings
+                .iter()
+                .any(|s| s.starts_with("spn.location.korriban")),
+            "fallback must recover string after intermediate bytes, got {:?}",
+            strings
+        );
+    }
+
+    #[test]
+    fn extract_strings_finds_spn_triple_in_quest_payload() {
+        // Quest payloads embed NPC references inside semicolon-delimited triples:
+        // `spn.X;npc.Y;<numeric_id>`. The whole triple is one string in GOM,
+        // so the scanner must yield it intact for downstream parsing.
+        let triple = b"spn.location.korriban.class.sith_warrior.judge_and_executioner.jailer_knash;npc.location.korriban.class.sith_warrior.judge_and_executioner.jailer_knash;291310451818496";
+        let mut payload = vec![0x06, triple.len() as u8];
+        payload.extend_from_slice(triple);
+        let strings = extract_strings_from_payload(&payload);
+        assert_eq!(strings.len(), 1);
+        assert!(strings[0].starts_with("spn."));
+        assert!(strings[0].contains(";npc."));
+    }
+
+    #[test]
+    fn extract_strings_finds_full_fqn_when_marker_is_a_substring_byte() {
+        // The length byte 0x41 ('A') is itself printable ASCII. The previous
+        // heuristic incorrectly emitted "Aspn.l" because it read the marker
+        // 0x06 as length=6. With the marker scan, the full 65-char FQN is
+        // emitted instead.
+        let mut payload = vec![0x06, 0x41];
+        payload.extend_from_slice(
+            b"spn.location.korriban.mob.tomb_2_marka_ragnos.mob02.standard_m_01",
+        );
+        let strings = extract_strings_from_payload(&payload);
+        assert_eq!(
+            strings,
+            vec!["spn.location.korriban.mob.tomb_2_marka_ragnos.mob02.standard_m_01".to_string()]
+        );
     }
 }

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -67,7 +67,8 @@ impl GameObject {
         // Extract kind from FQN prefix (e.g., "itm" from "itm.gen.lots...")
         let kind = if let Some(pos) = gom.fqn.find('.') {
             match &gom.fqn[..pos] {
-                "qst" | "mpn" => "Quest",
+                "qst" => "Quest",
+                "mpn" => "Phase",
                 "abl" => "Ability",
                 "itm" => "Item",
                 "npc" => "Npc",


### PR DESCRIPTION
## Summary

Closes one of the six unresolved cases in #27. Stacks on PR #30.

## What this fixes

Some encounters reference a base spawn name like `spn.X.multi.isen`. The engine resolves this at runtime to one of several variants (`isen_no_weapon`, `isen_captured`) representing the same character in different states. Each variant is its own kessel object with its own `npc.*` reference.

`populate_quest_npcs` exact-matches `spn_to_npcs.get(s)`. For base names that exist only as variants, the lookup fails and the underlying NPC isn't recorded.

This PR adds a prefix-match fallback: when the exact lookup misses, scan for `spn.<base>_*` keys and take their npcs. Restricted to underscore-suffix matches to avoid false positives on unrelated names.

## Result

`qst.exp.02.yavin_4.world_arc.republic.the_devoted_ones`:
- Before: 0 npcs (`spn.X.multi.isen` referenced; only `isen_no_weapon` and `isen_captured` exist)
- After: both Isen variants resolve to the underlying NPC

| | Before | After |
|---|---|---|
| `quest_npcs` rows | 2,134 | **2,149** (+15) |
| Distinct quests covered | 925 | **926** (+1) |
| `the_devoted_ones` -> Isen | ✗ | ✓ |
| J&E -> Tremel (regression) | ✓ | ✓ |

The fallback fires rarely. Most spawn lookups resolve directly. But for runtime-variant cases this is the structural fix.

## Implementation

```rust
} else {
    // Some encounters reference a base spawn name like
    // `spn.X.multi.isen` that the engine resolves at runtime to a
    // variant (`isen_no_weapon`, `isen_captured`). Fall back to
    // prefix-match on `<base>_*` so the underlying character resolves.
    let prefix = format!("{}_", s);
    for (spn_fqn, spn_npcs) in &spn_to_npcs {
        if spn_fqn.starts_with(&prefix) {
            npcs.extend(spn_npcs.iter().cloned());
        }
    }
}
```

The `_` requirement after the base prevents `spn.X.foo` matching `spn.X.foobar` (different character, just shared prefix).

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes (40 tests)
- [x] cargo fmt --check clean
- [x] **Full extraction validates**: the_devoted_ones now resolves
- [x] J&E regression spot-check passes
- [x] legion-simplify gate clean

## Stacks on

PR #30 -> #29 -> #26 -> #18.