### PR TITLE
feat: missions table unifying qst.* and mpn-prefix mission identities (closes #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - bonus_missions view flattening `mpn.*.bonus.*` mission-phase objects with their parent quest FQN guess -- helps close the kessel/CSV row-count gap (#25)
 - spawn_runtime_ids table populated from SPN-triple numerics in quest payloads -- bridges combat-log entity events to kessel's content GUIDs once the log format is verified. Closes #31.
 - gui/planetaryconquest.stb and gui/galacticcommand.stb extracted into the strings table. Conquest theme names ("Total Galactic War", "The Trade Emporium", etc.) and "Invasion Bonus" category mappings now queryable. Closes #39.
+- missions table unifying qst.* objects with mpn-prefix groupings. SWTOR's mission identity is encoded as either a qst.* object OR a unique path-prefix of mpn.* phases (alliance alerts, many class-story missions, etc. live only as the latter). Closes #34. Goes from 1,315 quest identities to ~3,950 mission identities.
 
 ### Fixed
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -94,6 +94,7 @@ pub struct Stats {
     pub npc_links: u64,
     pub reward_links: u64,
     pub runtime_ids: u64,
+    pub missions: u64,
 }
 
 impl Database {
@@ -218,6 +219,23 @@ impl Database {
                 link_type TEXT NOT NULL,
                 PRIMARY KEY (source_game_id, target_game_id)
             );
+
+            -- Missions: unified mission identities from two sources.
+            --
+            -- 1. Every qst.* object is a mission (source='qst').
+            -- 2. Every unique mpn-prefix grouping (a path-prefix of mpn.* objects
+            --    formed by dropping the leaf segment) that has no qst.* parent
+            --    is also a mission (source='mpn-prefix'). These are typically
+            --    alliance alerts, side missions encoded purely as phase trees,
+            --    and other content that lives only as mpn.* phases.
+            --
+            -- Closes the 3.9k vs 1.3k gap from #34.
+            CREATE TABLE IF NOT EXISTS missions (
+                mission_fqn TEXT PRIMARY KEY,
+                source      TEXT NOT NULL  -- 'qst' or 'mpn-prefix'
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_missions_source ON missions(source);
 
             -- Spawn runtime IDs: every SPN triple `spn.X;target.Y;<id>` in a
             -- quest payload becomes one row. The numeric ID may be the runtime
@@ -828,6 +846,80 @@ impl Database {
         Ok(count)
     }
 
+    /// Populate `missions` from two sources:
+    ///
+    /// 1. Every `qst.*` object becomes a row with `source='qst'`.
+    /// 2. Every unique mpn-prefix (path with the leaf phase segment dropped)
+    ///    that does not already exist as a qst.* counterpart becomes a row
+    ///    with `source='mpn-prefix'`.
+    ///
+    /// The mpn-prefix derivation: for `mpn.A.B.C.D`, the mission identity
+    /// is `mpn.A.B.C` (drop the last segment). The qst.* counterpart check
+    /// rewrites `mpn.X` -> `qst.X` and looks for that fqn in the qst set.
+    pub fn populate_missions(&self) -> Result<u64> {
+        use std::collections::HashSet;
+
+        let (qst_fqns, phase_fqns): (Vec<String>, Vec<String>) = {
+            let conn = self.conn.lock().unwrap();
+
+            let mut qst_stmt = conn.prepare("SELECT fqn FROM objects WHERE kind = 'Quest'")?;
+            let qst_fqns: Vec<String> = qst_stmt
+                .query_map([], |row| row.get::<_, String>(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+            drop(qst_stmt);
+
+            let mut phase_stmt = conn.prepare("SELECT fqn FROM objects WHERE kind = 'Phase'")?;
+            let phase_fqns: Vec<String> = phase_stmt
+                .query_map([], |row| row.get::<_, String>(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+            drop(phase_stmt);
+
+            (qst_fqns, phase_fqns)
+        };
+
+        let qst_set: HashSet<&str> = qst_fqns.iter().map(|s| s.as_str()).collect();
+
+        // Derive mpn-prefix groupings: for each phase, drop the last segment
+        // and compute the qst.* counterpart. Skip if a qst.* counterpart exists.
+        let mut mpn_prefixes: HashSet<String> = HashSet::new();
+        for phase in &phase_fqns {
+            // Phase is `mpn.A.B.C.D`; mission prefix is `mpn.A.B.C`.
+            let Some(last_dot) = phase.rfind('.') else {
+                continue;
+            };
+            let prefix = &phase[..last_dot];
+            // Skip if the qst.* counterpart already covers this mission identity.
+            // mpn-prefix `mpn.X` -> qst.* `qst.X`.
+            let qst_equivalent = format!("qst{}", &prefix[3..]);
+            if qst_set.contains(qst_equivalent.as_str()) {
+                continue;
+            }
+            mpn_prefixes.insert(prefix.to_string());
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO missions (mission_fqn, source) VALUES (?1, ?2)",
+        )?;
+
+        let mut count = 0u64;
+        for fqn in &qst_fqns {
+            stmt.execute(rusqlite::params![fqn, "qst"])?;
+            count += 1;
+        }
+        for prefix in &mpn_prefixes {
+            stmt.execute(rusqlite::params![prefix, "mpn-prefix"])?;
+            count += 1;
+        }
+
+        drop(stmt);
+        tx.commit()?;
+        Ok(count)
+    }
+
     pub fn stats(&self) -> Result<Stats> {
         // Ensure all pending data is flushed before counting
         self.flush()?;
@@ -849,6 +941,8 @@ impl Database {
             conn.query_row("SELECT COUNT(*) FROM spawn_runtime_ids", [], |row| {
                 row.get(0)
             })?;
+        let missions: u64 =
+            conn.query_row("SELECT COUNT(*) FROM missions", [], |row| row.get(0))?;
 
         Ok(Stats {
             quests,
@@ -860,6 +954,7 @@ impl Database {
             npc_links,
             reward_links,
             runtime_ids,
+            missions,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,6 +373,9 @@ fn main() -> Result<()> {
     // Fifth pass: extract spawn runtime IDs from SPN triples (combat-log bridge)
     db.populate_spawn_runtime_ids()?;
 
+    // Seventh pass: derive mission identities from qst.* + mpn-prefix groupings
+    db.populate_missions()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");
@@ -384,6 +387,7 @@ fn main() -> Result<()> {
         "    Quests: {} ({} classified, {} chain links, {} npc links, {} reward links, {} runtime ids)",
         stats.quests, quest_count, stats.chain_links, stats.npc_links, stats.reward_links, stats.runtime_ids
     );
+    println!("    Missions (qst + mpn-prefix): {}", stats.missions);
     println!("    Abilities: {}", stats.abilities);
     println!("    Items: {}", stats.items);
     println!("    NPCs: {}", stats.npcs);


### PR DESCRIPTION
## Summary

Closes #34. Triples kessel's mission identity coverage from 1,315 to 3,949, much closer to the CSV's 4,988 unique mission names.

## The finding

SWTOR encodes mission identity in two ways:

1. **`qst.*` objects** (1,315 of them) -- standalone quest definitions
2. **mpn-prefix groupings** (2,634) -- a unique path-prefix of `mpn.*` phases where there's no corresponding `qst.*` parent. Alliance alerts, many class-story side missions, and content that lives purely as a phase tree without a top-level quest object.

Before this PR, kessel only counted #1. Spot examples of missions that exist only as mpn-prefix:

- `mpn.location.ord_mantell.class.trooper.mannett_point` -- Trooper class story Mannett Point
- `mpn.alliance.alerts.companions.bowdaar` -- Bowdaar alliance alert
- `mpn.location.hutta.world.keeping_secrets` -- Hutta side quest

These are real, named, in-game missions that kessel was not surfacing as quest identities at all.

## Schema

```sql
CREATE TABLE missions (
    mission_fqn TEXT PRIMARY KEY,
    source      TEXT NOT NULL  -- 'qst' or 'mpn-prefix'
);
CREATE INDEX idx_missions_source ON missions(source);
```

## Result

| | Count |
|---|---|
| `missions` total | **3,949** |
| ↳ source=`qst` | 1,315 |
| ↳ source=`mpn-prefix` | 2,634 |

The remaining gap to 4,988 CSV unique names is likely:
- Conquest objectives (different object kind)
- Dynamic encounters (also different)
- Deeper-nested mpn paths the simple "drop last segment" rule doesn't catch

Worth follow-up issues, but this PR closes the bulk of the gap.

## Implementation

- New `populate_missions` method, seventh extraction pass.
- For each `kind='Quest'` object: insert with `source='qst'`.
- For each `kind='Phase'` object: derive prefix (drop leaf segment), compute `qst.X` counterpart, skip if it exists, otherwise insert as `source='mpn-prefix'`.
- `Stats.missions` count, run-summary print.

## What this enables (follow-up issues)

- Re-target `populate_quest_npcs` / `_phases` / `_rewards` to operate on missions instead of just `kind='Quest'`. mpn-only missions then collect refs from their phase tree (alliance alerts get their giver via the cnv-ref pattern, etc.).
- Add `mission_phases` join table mapping each `mpn.*` phase to its `mission_fqn`.

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes (43 tests)
- [x] cargo fmt --check clean
- [x] **Full extraction verifies 3,949 missions**
- [x] Spot checks pass: bowdaar (2 qst.* alerts + 1 mpn-prefix grouping), mannett_point (mpn-prefix only)
- [x] legion-simplify gate clean

Branches off main (no stack).