### PR TITLE
fix: string_id decoder tries BE24 before LE32 (closes #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - String scanner recognises a third encoding pattern: `0xD2 0x01 <index> <len> <ASCII>` for array-element strings in encounter payloads. The previous heuristic produced truncated strings (e.g. `Gspn.location...ban` instead of the full FQN).
 - mpn.* objects now classify as `kind='Phase'` (was `kind='Quest'`). Mission phases were inflating the Quest count 8x and polluting `quest_details` with phase-shaped rows that were never real missions. New `phases` view exposes them. Closes #23.
 - Spawn-prefix fallback in populate_quest_npcs: encounters that reference a base spawn name (e.g. `spn.X.multi.isen`) which the engine resolves at runtime to variants (`isen_no_weapon`, `isen_captured`) now resolve to the underlying NPC via prefix-match. Closes the_devoted_ones case from #27.
+- string_id type-marker decoder tries 3-byte big-endian before 4-byte little-endian. The previous LE32-first order was poisoning achievement IDs by absorbing a trailing 0x00 separator byte. Achievement string_id coverage 42% -> 99.9%; conquest objectives specifically went 0% -> 100% (687/687). No regression on quests/items/talents. Closes #37.
 
 ## [0.0.5] - 2026-04-02
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -228,18 +228,23 @@ impl GameObject {
                 {
                     let id_bytes = &payload[after_type + 2..after_type + 6];
 
-                    // Try 4-byte little-endian first (discipline talents)
-                    let le32 =
-                        u32::from_le_bytes([id_bytes[0], id_bytes[1], id_bytes[2], id_bytes[3]]);
-                    if (MIN_STRING_ID..=MAX_STRING_ID).contains(&le32) {
-                        return Some(le32);
-                    }
-
-                    // Fall back to 3-byte big-endian (GSF talents: tal.spvp.*)
+                    // Try 3-byte big-endian first -- the canonical GOM encoding
+                    // for string IDs after CE markers (qst, npc, itm, ach, cnv).
+                    // A 0x00 separator/flag byte typically follows the 3-byte
+                    // ID, which the LE32 decode would incorrectly absorb.
                     let be24 =
                         (id_bytes[0] as u32) << 16 | (id_bytes[1] as u32) << 8 | id_bytes[2] as u32;
                     if (MIN_STRING_ID..=MAX_STRING_ID).contains(&be24) {
                         return Some(be24);
+                    }
+
+                    // Fall back to 4-byte little-endian -- discipline talents
+                    // and a few other contexts use this. Order swapped from
+                    // pre-#37 because LE32 was poisoning achievement IDs.
+                    let le32 =
+                        u32::from_le_bytes([id_bytes[0], id_bytes[1], id_bytes[2], id_bytes[3]]);
+                    if (MIN_STRING_ID..=MAX_STRING_ID).contains(&le32) {
+                        return Some(le32);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Closes #37. Two-line order swap that takes achievement `string_id` coverage from 42% to 99.9% and conquest objectives from 0% to 100%.

## Bug

`extract_string_id_via_type_marker` tried 4-byte little-endian before 3-byte big-endian. The LE32 path was added for discipline talents but accepted wrong values for achievements where the encoding is BE24 followed by a separator byte.

## Repro

`ach.conquests.class.bounty_hunter.abilities.carbonize`'s payload contains, after the string-table type marker (`CF 40 00 00 11 5C E8 74 88`):

```
02 ce 0e cb 63 00 ...
```

- LE32 of `0e cb 63 00`: `0x0063CB0E` = **6540046** (in range, but the trailing `00` was a separator, not part of the ID; not in strings table)
- BE24 of `0e cb 63`: `0x0ECB63` = **969571** (correct; matches `str.ach.*.969571`)

## Fix

Two-line swap with updated comments:

```rust
// Try 3-byte big-endian first -- the canonical GOM encoding for string IDs
// after CE markers (qst, npc, itm, ach, cnv). A 0x00 separator/flag byte
// typically follows the 3-byte ID, which the LE32 decode would absorb.
let be24 = ...;
if (MIN..=MAX).contains(&be24) { return Some(be24); }

// Fall back to 4-byte little-endian for the discipline-talent path.
let le32 = ...;
if (MIN..=MAX).contains(&le32) { return Some(le32); }
```

## Validation (full extraction)

| | Before | After |
|---|---|---|
| Achievements with string_id hit | 2,735 / 6,476 (42%) | **6,469 / 6,476 (99.9%)** |
| Conquest objectives specifically | 0 / 687 | **687 / 687 (100%)** |
| Quests (regression check) | 90.6% | 90.6% |
| Items | 99.9% | 99.9% |
| Talents | 98.9% | 98.9% |
| NPCs | 83.5% | 83.5% |

## Spot check

`ach.conquests.location.tatooine.worldboss_infinite` (Tatooine conquest objective) now resolves to:

| id1 | text |
|---|---|
| 0 | "Tatooine: Trapjaw Eternal" |
| 1 | "Defeat Trapjaw on Tatooine." |
| 256 | "Defeat Trapjaw" |

Conquest objective names and descriptions are now fully accessible. Unblocks #36 (conquest_objectives table extraction).

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes (43 tests)
- [x] cargo fmt --check clean
- [x] Full extraction verifies the coverage numbers above
- [x] Spot check on Tatooine conquest objective shows correct name + description
- [x] No regression on quests / items / talents / NPCs
- [x] legion-simplify gate clean

Branches off main (no stack).