### PR TITLE
feat: extract gui/planetaryconquest.stb and gui/galacticcommand.stb (closes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - quest_descriptions view exposing each quest's first journal entry (STB id1 200-600 range) -- mirrors the CSV "Mission Description" column
 - bonus_missions view flattening `mpn.*.bonus.*` mission-phase objects with their parent quest FQN guess -- helps close the kessel/CSV row-count gap (#25)
 - spawn_runtime_ids table populated from SPN-triple numerics in quest payloads -- bridges combat-log entity events to kessel's content GUIDs once the log format is verified. Closes #31.
+- gui/planetaryconquest.stb and gui/galacticcommand.stb extracted into the strings table. Conquest theme names ("Total Galactic War", "The Trade Emporium", etc.) and "Invasion Bonus" category mappings now queryable. Closes #39.
 
 ### Fixed
 

--- a/src/stb.rs
+++ b/src/stb.rs
@@ -203,17 +203,11 @@ pub fn should_extract_stb(path: &str) -> bool {
         return false;
     }
 
-    // Check if it's a root-level STB (no subdirectories after /str/)
     if let Some(str_pos) = normalized.find("/str/") {
         let after_str = &normalized[str_pos + 5..]; // skip "/str/"
 
-        // Root level means no more slashes before .stb
-        if after_str.contains('/') {
-            return false; // Has subdirectory, skip
-        }
-
-        // Check for our target files
-        let target_files = [
+        // Root-level STBs (no subdirectory): primary object kinds.
+        const ROOT_TARGETS: &[&str] = &[
             "abl.stb",
             "tal.stb",
             "itm.stb",
@@ -223,8 +217,20 @@ pub fn should_extract_stb(path: &str) -> bool {
             "ach.stb",
             "schem.stb",
         ];
+        if !after_str.contains('/') {
+            return ROOT_TARGETS.contains(&after_str);
+        }
 
-        return target_files.contains(&after_str);
+        // Selected nested STBs that contain category labels not in the
+        // root-level kind tables. planetaryconquest carries conquest theme
+        // names; galacticcommand carries Eternal Empire reward-track labels.
+        const NESTED_TARGETS: &[&str] = &["gui/planetaryconquest.stb", "gui/galacticcommand.stb"];
+        for target in NESTED_TARGETS {
+            if after_str == *target {
+                return true;
+            }
+        }
+        return false;
     }
 
     false


### PR DESCRIPTION
## Summary

Closes #39. Extracts conquest theme names and "Invasion Bonus" category mappings by adding two nested STBs to the allowlist:

- `gui/planetaryconquest.stb` (156 strings) -- conquest themes, descriptions, bonus mappings
- `gui/galacticcommand.stb` (54 strings) -- KOTFE/KOTET command system labels

## What this answers (Sean's question)

The conquest **theme catalog** lives in static binary data. Examples now queryable:

| id1 | text |
|---|---|
| 300 | "Total Galactic War" |
| 301 | "Total war has broken out on worlds across the galaxy..." |
| 302 | "The Balance of Power" |
| 304 | "The Dread War" |
| 306 | "The Trade Emporium" |
| 320 | "Emergency Operations" |
| 347 | "The Power of the Force" |

Plus per-theme "Invasion Bonus" strings (id1 328-349):

```
Invasion Bonus - Flashpoints, Warzones
Invasion Bonus - Operations, Warzones
Invasion Bonus - Crafting, War Supplies
Invasion Bonus - Warzones, Flashpoints, Operations, Starfighter, War Supplies
...
```

These map themes to their highlighted objective categories.

The week-to-theme **rotation schedule** is still server-side -- not in the binary. But the theme catalog and category mappings are now extractable.

## Implementation

`src/stb.rs::should_extract_stb` previously rejected any STB path with a subdirectory after `/str/`. Refactored to use two explicit lists:

```rust
const ROOT_TARGETS: &[&str] = &["abl.stb", "tal.stb", "itm.stb", ...];
const NESTED_TARGETS: &[&str] = &["gui/planetaryconquest.stb", "gui/galacticcommand.stb"];
```

The nested list is curated -- only STBs with structural data not in the root tables. Avoids blanket-allowing `gui/*.stb` (mostly chrome strings).

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes
- [x] cargo fmt --check clean
- [x] Full extraction: 156 planetaryconquest strings, 54 galacticcommand strings
- [x] Spot check returns theme names and invasion bonus mappings
- [x] legion-simplify gate clean

## Follow-up (separate issue)

Parse the planetaryconquest strings into a structured `conquest_themes` table:

```sql
CREATE TABLE conquest_themes (
    name TEXT PRIMARY KEY,        -- 'Total Galactic War'
    description TEXT,             -- "Total war has broken out..."
    invasion_bonus_categories TEXT  -- 'Flashpoints,Warzones'
);
```

That's a small Rust pass that walks the planetaryconquest strings, pairs name (even id1) with description (id1+1) and invasion-bonus mapping (id1 328-349 range). Will file as separate issue.

Branches off main (no stack).