### PR TITLE
remove: populate_quest_chain (closes #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - mpn.* objects now classify as `kind='Phase'` (was `kind='Quest'`). Mission phases were inflating the Quest count 8x and polluting `quest_details` with phase-shaped rows that were never real missions. New `phases` view exposes them. Closes #23.
 - Spawn-prefix fallback in populate_quest_npcs: encounters that reference a base spawn name (e.g. `spn.X.multi.isen`) which the engine resolves at runtime to variants (`isen_no_weapon`, `isen_captured`) now resolve to the underlying NPC via prefix-match. Closes the_devoted_ones case from #27.
 
+### Removed
+
+- populate_quest_chain (PR #11's 0xCF GUID-ref hypothesis). Brute-force search confirmed quest content GUIDs are not cross-referenced statically -- the function produced zero rows on every real extraction. Closes #19. The `quest_chain` table is retained for future link mechanisms (e.g. mpn-derived edges).
+
 ## [0.0.5] - 2026-04-02
 
 First tagged release. Extracts structured SWTOR game data from .tor archives to SQLite.

--- a/src/db.rs
+++ b/src/db.rs
@@ -564,94 +564,13 @@ impl Database {
         Ok(detail_count)
     }
 
-    /// Build quest chain links from GUID references in quest payloads.
-    ///
-    /// Scans each quest's binary payload for 0xCF + 8-byte LE GUID patterns.
-    /// Each resolved GUID that belongs to another quest object becomes a
-    /// "guid_ref" link in the quest_chain table. This is a second-pass operation
-    /// that must run after all objects are inserted.
-    pub fn populate_quest_chain(&self) -> Result<u64> {
-        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-
-        // Build guid → game_id map for all quest objects
-        let (guid_to_game_id, quest_rows) = {
-            let conn = self.conn.lock().unwrap();
-
-            let mut guid_map: std::collections::HashMap<String, String> =
-                std::collections::HashMap::new();
-            {
-                let mut stmt =
-                    conn.prepare("SELECT guid, game_id FROM objects WHERE kind = 'Quest'")?;
-                let rows = stmt.query_map([], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                })?;
-                for row in rows {
-                    let (guid, game_id) = row?;
-                    guid_map.insert(guid, game_id);
-                }
-            }
-
-            // Load quest payloads: game_id + payload_b64 from stored JSON
-            let mut payload_stmt = conn.prepare(
-                "SELECT game_id, json_extract(json, '$.payload_b64') FROM objects WHERE kind = 'Quest'",
-            )?;
-            let rows: Vec<(String, String)> = payload_stmt
-                .query_map([], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                })?
-                .filter_map(|r| r.ok())
-                .collect();
-
-            (guid_map, rows)
-        };
-
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-
-        let mut chain_stmt = tx.prepare_cached(
-            "INSERT OR IGNORE INTO quest_chain (source_game_id, target_game_id, link_type) VALUES (?1, ?2, ?3)",
-        )?;
-
-        let mut link_count = 0u64;
-
-        for (source_game_id, payload_b64) in &quest_rows {
-            let payload = match BASE64.decode(payload_b64) {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-
-            // Scan payload for 0xCF + 8-byte LE GUID patterns
-            let mut i = 0;
-            while i + 9 <= payload.len() {
-                if payload[i] == 0xCF {
-                    let guid_u64 = u64::from_le_bytes(
-                        payload[i + 1..i + 9].try_into().expect("slice is 8 bytes"),
-                    );
-                    let guid_hex = format!("{:016X}", guid_u64);
-
-                    if let Some(target_game_id) = guid_to_game_id.get(&guid_hex) {
-                        // Skip self-references
-                        if target_game_id != source_game_id {
-                            chain_stmt.execute(rusqlite::params![
-                                source_game_id,
-                                target_game_id,
-                                "guid_ref",
-                            ])?;
-                            link_count += 1;
-                        }
-                    }
-
-                    i += 9; // skip past the 8 GUID bytes
-                } else {
-                    i += 1;
-                }
-            }
-        }
-
-        drop(chain_stmt);
-        tx.commit()?;
-        Ok(link_count)
-    }
+    // populate_quest_chain (PR #11) was removed in #19. Its 0xCF + 8-byte LE
+    // u64 hypothesis produced zero rows on real data: brute-force search of
+    // every payload across 260,448 objects for any quest's content GUID
+    // returned no matches. Quest content GUIDs are kessel-internal-only;
+    // they are not cross-referenced statically. quest_chain may be reused
+    // later for a different link mechanism (e.g. mpn-derived edges); keep
+    // the table but stop populating with the broken approach.
 }
 
 /// Pull `(fqn, payload_b64)` tuples for every object of `kind`. Used by

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,16 +361,16 @@ fn main() -> Result<()> {
     // Second pass: populate quest tables from extracted objects
     let quest_count = db.populate_quest_tables()?;
 
-    // Third pass: build quest chain links from GUID refs in payloads
-    db.populate_quest_chain()?;
+    // (Quest chain population removed in #19: PR #11's 0xCF GUID-ref
+    // hypothesis produced zero rows on real data.)
 
-    // Fourth pass: resolve a:enc.* refs in quest payloads to npc.* via encounter payloads
+    // Third pass: resolve a:enc.* refs in quest payloads to npc.* via encounter payloads
     db.populate_quest_npcs()?;
 
-    // Fifth pass: extract quest_reward_* variable names from quest payloads
+    // Fourth pass: extract quest_reward_* variable names from quest payloads
     db.populate_quest_rewards()?;
 
-    // Sixth pass: extract spawn runtime IDs from SPN triples (combat-log bridge)
+    // Fifth pass: extract spawn runtime IDs from SPN triples (combat-log bridge)
     db.populate_spawn_runtime_ids()?;
 
     // Print summary


### PR DESCRIPTION
## Summary

Closes #19. Removes `populate_quest_chain` (PR #11's 0xCF GUID-ref hypothesis).

## Why

Brute-force verified across 260,448 payloads: J&E's content GUID `E0005CFB931E7ACB` appears in **zero** other objects' payloads in any byte alignment. Same for every quest GUID (E000 prefix). Quest content GUIDs are kessel-internal-only -- they are not cross-referenced statically anywhere.

The result: `populate_quest_chain` ran on every extraction and inserted 0 rows. Wasted pass.

## What's removed

- `Database::populate_quest_chain` method (~85 lines)
- Call from `main.rs`
- Pass renumbering: Third (was chain) -> Third (now NPC), Fourth -> Fourth (rewards), etc.

## What stays

- `quest_chain` table schema -- retained for future link mechanisms (mpn-derived edges, cnv-derived edges).
- `Stats.chain_links` field -- still queried; will read 0 until a real link mechanism populates the table.

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes (43 tests)
- [x] cargo fmt --check clean
- [x] Full extraction completes successfully (no functional behaviour change beyond removing the dead pass)
- [x] legion-simplify gate clean

Branches off main (no stack).