### PR TITLE
feat: conquest_invasion_bonuses and conquest_theme_strings views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - gui/planetaryconquest.stb and gui/galacticcommand.stb extracted into the strings table. Conquest theme names ("Total Galactic War", "The Trade Emporium", etc.) and "Invasion Bonus" category mappings now queryable. Closes #39.
 - missions table unifying qst.* objects with mpn-prefix groupings. SWTOR's mission identity is encoded as either a qst.* object OR a unique path-prefix of mpn.* phases (alliance alerts, many class-story missions, etc. live only as the latter). Closes #34. Goes from 1,315 quest identities to ~3,950 mission identities.
 - conquest_objectives table: structured view of `ach.conquests.*` (713 rows) with category, subcategory, and cadence parsed from FQN segments. Categories: chapter / class / crafting / event / flashpoint / galactic_seasons / location / operation / spvp / uprisings / quest / weekly. Cadence: weekly / daily / null. Closes #36.
+- conquest_invasion_bonuses view exposing each "Invasion Bonus - <categories>" string from planetaryconquest as (id1, categories) rows. The theme-to-bonus rotation is server-side (per Sean: published as iCal feed); kessel publishes the static catalog of bonus category sets.
+- conquest_theme_strings view: filtered planetaryconquest strings in the theme id1 range (300-360), excluding UI chrome. Themes have inconsistent name/description ordering in the source so the view leaves pairing to consumers.
 
 ### Fixed
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -167,6 +167,36 @@ impl Database {
             CREATE VIEW IF NOT EXISTS phases AS
                 SELECT * FROM objects WHERE kind = 'Phase';
 
+            -- Conquest invasion-bonus mappings: each row is a string like
+            -- "Invasion Bonus - Flashpoints, Warzones" describing the bonus
+            -- category set highlighted by some conquest theme. The theme to
+            -- bonus pairing is engine-driven (server-side rotation); the
+            -- bonus catalog itself is static and lives here.
+            CREATE VIEW IF NOT EXISTS conquest_invasion_bonuses AS
+                SELECT id1, locale, substr(text, length('Invasion Bonus - ') + 1) AS categories
+                FROM strings
+                WHERE fqn LIKE 'str.gui.planetaryconquest%'
+                  AND text LIKE 'Invasion Bonus - %';
+
+            -- Conquest theme strings. Heuristic filter: planetaryconquest
+            -- entries that aren't UI chrome. Theme-name vs theme-description
+            -- pairing is left to consumers since the source pairing is
+            -- inconsistent (sometimes name, sometimes description first).
+            CREATE VIEW IF NOT EXISTS conquest_theme_strings AS
+                SELECT id1, locale, text
+                FROM strings
+                WHERE fqn LIKE 'str.gui.planetaryconquest%'
+                  AND id1 BETWEEN 300 AND 360
+                  AND text NOT LIKE 'Invasion Bonus - %'
+                  AND text NOT LIKE '%not authorized%'
+                  AND text NOT LIKE '%Next Objective%'
+                  AND text NOT LIKE '%Guild Rewards%'
+                  AND text NOT LIKE '%Guild Flagship%'
+                  AND text NOT LIKE '%not a member of a guild%'
+                  AND text NOT LIKE '%currently in review%'
+                  AND text NOT LIKE '%Guild Conquest point%'
+                  AND text != '%';
+
             CREATE VIEW IF NOT EXISTS abilities AS
                 SELECT * FROM objects WHERE kind = 'Ability' OR fqn LIKE 'abl.%';
 


### PR DESCRIPTION
## Summary

Stacks on PR #40 (which extracts `planetaryconquest.stb`). Adds two SQL views surfacing the conquest strings as structured data without a populate function.

## Views

### `conquest_invasion_bonuses` (16 rows en-us)

Each "Invasion Bonus - <categories>" string parsed into `(id1, locale, categories)`. Sample:

| id1 | categories |
|---|---|
| 328 | Flashpoints, Warzones |
| 333 | Operations |
| 337 | Warzones, Flashpoints, Operations, Starfighter |
| 349 | Warzones, Flashpoints, Operations, Starfighter, War Supplies |
| 352 | Uprisings |

These are the bonus-category sets each conquest theme can highlight. The theme-to-bonus rotation is server-side (per Sean: published as iCal feed); the static catalog of category sets lives in kessel.

### `conquest_theme_strings` (36 rows en-us)

Filtered planetaryconquest strings in the theme id1 range (300-360), excluding UI chrome ("not authorized", "Next Objective", "Guild Rewards", etc.).

Sample:

| id1 | text |
|---|---|
| 300 | Total Galactic War |
| 302 | The Balance of Power |
| 304 | The Dread War |
| 306 | The Trade Emporium |
| 308 | Relics of the Gree |
| 311 | Rakghoul Resurgence: Tatooine |
| 316 | Clash in Hyperspace |
| 320 | Emergency Operations |
| 322 | Death Mark |
| 324 | Flashpoint Havoc |
| 326 | The Hunter's Race |
| 340 | Revenge of the Revanites |
| 343 | The Calm Before the Storm |
| 345 | The Recruitment Initiative |
| 347 | The Power of the Force |
| 351 | Mechanical Warfare |

Source ordering of name vs description is inconsistent (most are name-first then description-next, but Rakghoul variants are reversed). Pairing left to consumers with editorial knowledge.

## Why no populate function

The data is half-structured. A heuristic populate that tries to pair name+description would have edge cases for the inconsistent ordering and would introduce magic numbers. Two SQL views over the strings table is cleaner -- consumers (huttspawn ETL with editorial join, fence with iCal cross-reference) can do the right thing for their use case.

## Test plan

- [x] cargo build clean
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo test passes (43 tests)
- [x] cargo fmt --check clean
- [x] Full extraction validates view counts: 16 invasion bonuses, 36 theme strings
- [x] Spot check: theme names match known game content (Total Galactic War, Trade Emporium, Rakghoul Resurgence, etc.)
- [x] legion-simplify gate clean

## Stacks on

PR #40 (gui/planetaryconquest.stb extraction). Without that, both views return zero rows.