### PR TITLE
feat: populate quest_chain from 0xCF big-endian GUID refs (closes #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 ### Added
 
-- quest_chain table populated from GUID refs in quest payloads, linking chain members by resolved u64 identifiers
+- quest_chain table populated from `0xCF` big-endian GUID refs in quest payloads; fixes the zero-row bug from PR #11 where bytes were read as little-endian (closes #7)
 - template_guid column on objects table, decoded from GOM header bytes 16-23 (kind-level template constant)
 - quest_npcs table populated by resolving a:enc.* references in quest payloads to npc.* FQNs through encounter object payloads (closes #14)
 - quest_rewards table populated by extracting `quest_reward_*` variable names from quest payloads (closes #24)

--- a/src/db.rs
+++ b/src/db.rs
@@ -654,13 +654,90 @@ impl Database {
         Ok(detail_count)
     }
 
-    // populate_quest_chain (PR #11) was removed in #19. Its 0xCF + 8-byte LE
-    // u64 hypothesis produced zero rows on real data: brute-force search of
-    // every payload across 260,448 objects for any quest's content GUID
-    // returned no matches. Quest content GUIDs are kessel-internal-only;
-    // they are not cross-referenced statically. quest_chain may be reused
-    // later for a different link mechanism (e.g. mpn-derived edges); keep
-    // the table but stop populating with the broken approach.
+    /// Populate `quest_chain` by scanning every quest payload for `0xCF` type
+    /// markers followed by 8 bytes that decode as a big-endian GUID belonging
+    /// to another quest object.
+    ///
+    /// The previous attempt (PR #11, removed in #19) read the 8 bytes as
+    /// little-endian and found zero matches. GUIDs in SWTOR payloads are stored
+    /// big-endian; flipping to BE produces real chain links (e.g. broken_blades
+    /// -> breaking_the_blades bonus, revanites_revealed -> intro_rishii_village).
+    pub fn populate_quest_chain(&self) -> Result<u64> {
+        let conn = self.conn.lock().unwrap();
+
+        // Build a map of GUID (uppercase hex) -> game_id for all quest objects.
+        let mut guid_to_game_id: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        {
+            let mut stmt = conn.prepare(
+                "SELECT guid, game_id FROM objects WHERE fqn LIKE 'qst.%'",
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+            for row in rows.filter_map(|r| r.ok()) {
+                guid_to_game_id.insert(row.0.to_uppercase(), row.1);
+            }
+        }
+
+        let payloads = {
+            let mut stmt = conn.prepare(
+                "SELECT guid, game_id, json_extract(json, '$.payload_b64') \
+                 FROM objects WHERE fqn LIKE 'qst.%'",
+            )?;
+            let rows: Vec<(String, String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        let mut count: u64 = 0;
+
+        for (src_guid, src_game_id, payload_b64) in &payloads {
+            use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+            let payload = match BASE64.decode(payload_b64) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+
+            let mut i = 0;
+            while i + 9 <= payload.len() {
+                if payload[i] == 0xCF {
+                    // 8 bytes big-endian GUID
+                    let ref_guid = payload[i + 1..i + 9]
+                        .iter()
+                        .map(|b| format!("{:02X}", b))
+                        .collect::<String>();
+
+                    if ref_guid != src_guid.to_uppercase() {
+                        if let Some(target_game_id) = guid_to_game_id.get(&ref_guid) {
+                            tx.execute(
+                                "INSERT OR IGNORE INTO quest_chain \
+                                 (source_game_id, target_game_id, link_type) \
+                                 VALUES (?1, ?2, 'guid_ref')",
+                                params![src_game_id, target_game_id],
+                            )?;
+                            count += 1;
+                        }
+                    }
+                    i += 9;
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        tx.commit()?;
+        Ok(count)
+    }
 }
 
 /// Parse a conquest objective FQN (`ach.conquests.<category>.<sub>...<leaf>`)

--- a/src/db.rs
+++ b/src/db.rs
@@ -669,9 +669,8 @@ impl Database {
         let mut guid_to_game_id: std::collections::HashMap<String, String> =
             std::collections::HashMap::new();
         {
-            let mut stmt = conn.prepare(
-                "SELECT guid, game_id FROM objects WHERE fqn LIKE 'qst.%'",
-            )?;
+            let mut stmt =
+                conn.prepare("SELECT guid, game_id FROM objects WHERE fqn LIKE 'qst.%'")?;
             let rows = stmt.query_map([], |row| {
                 Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
             })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,6 +382,9 @@ fn main() -> Result<()> {
     // Eighth pass: aggregate NPCs and rewards across each mission's phase tree
     db.populate_mission_data()?;
 
+    // Ninth pass: build quest chain links from 0xCF big-endian GUID refs
+    db.populate_quest_chain()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");


### PR DESCRIPTION
## Summary

- Restores `populate_quest_chain` with the correct byte order fix
- Previous attempt (PR #11, removed in #19) read 0xCF + 8 bytes as little-endian — found zero matches
- SWTOR payloads store GUIDs big-endian; switching to BE produces real chain links
- Confirmed on spice.sqlite sample: broken_blades → breaking_the_blades, revanites_revealed → intro_rishii_village

## Test plan

- [ ] `cargo build` clean
- [ ] `cargo test` 5/5 pass
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Full extraction run: `quest_chain` table non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)