### PR TITLE
feat: planet_transition chain links from leaving_ quest strings (closes #46)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -826,8 +826,9 @@ impl Database {
 /// Extract the destination planet component from a transit tracking/journal string.
 ///
 /// Matches strings containing `_to_{dest}` where `{dest}` consists of lowercase
-/// letters and underscores. Strips a leading `the_` if present (e.g. `the_imperial_transit_station`
-/// is returned as-is; the caller filters by checking for a matching intro quest).
+/// letters and underscores. Strips a leading `the_` if present. The caller filters
+/// by checking for a matching intro quest, so non-planet results (e.g. `imperial_transit_station`)
+/// are silently dropped.
 fn extract_transit_dest(s: &str) -> Option<String> {
     let idx = s.find("_to_")?;
     let after = &s[idx + 4..];

--- a/src/db.rs
+++ b/src/db.rs
@@ -737,6 +737,106 @@ impl Database {
         tx.commit()?;
         Ok(count)
     }
+
+    /// Populate `quest_chain` with `planet_transition` links by scanning every
+    /// `leaving_{planet}` quest for strings that name the destination.
+    ///
+    /// Pattern: strings containing `_to_{planet}` (e.g. `jrn_start_take_the_shuttle_to_dromund_kaas`)
+    /// are used to locate the class intro quest at that planet. Strings that name
+    /// intermediate stops (e.g. `the_imperial_transit_station`) produce no match
+    /// and are silently skipped.
+    pub fn populate_planet_transitions(&self) -> Result<u64> {
+        let conn = self.conn.lock().unwrap();
+
+        // Build lookup: fqn -> game_id for all intro quests.
+        let mut intro_map: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+        {
+            let mut stmt = conn.prepare(
+                "SELECT fqn, game_id FROM objects WHERE fqn LIKE 'qst.location.%.class.%.intro'",
+            )?;
+            let rows =
+                stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+            for row in rows.filter_map(|r| r.ok()) {
+                intro_map.insert(row.0, row.1);
+            }
+        }
+
+        let mut leaving_quests: Vec<(String, String, String)> = Vec::new();
+        {
+            let mut stmt = conn.prepare(
+                "SELECT fqn, game_id, json_extract(json, '$.strings') \
+                 FROM objects \
+                 WHERE fqn LIKE 'qst.location.%.class.%.leaving_%' \
+                   AND json_extract(json, '$.strings') IS NOT NULL",
+            )?;
+            let rows = stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })?;
+            for row in rows.filter_map(|r| r.ok()) {
+                leaving_quests.push(row);
+            }
+        }
+
+        let tx = conn.unchecked_transaction()?;
+        let mut count: u64 = 0;
+
+        for (fqn, game_id, strings_json) in &leaving_quests {
+            // Extract class segment: qst.location.{planet}.class.{class}.leaving_{planet}
+            let parts: Vec<&str> = fqn.split('.').collect();
+            let class_pos = parts.iter().position(|&p| p == "class");
+            let class = match class_pos {
+                Some(i) if i + 1 < parts.len() => parts[i + 1],
+                _ => continue,
+            };
+
+            let strings: Vec<String> = match serde_json::from_str(strings_json) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            // Scan strings for `_to_{dest}` patterns; try each as a planet FQN component.
+            for s in &strings {
+                if let Some(dest) = extract_transit_dest(s) {
+                    let intro_fqn =
+                        format!("qst.location.{}.class.{}.intro", dest, class);
+                    if let Some(target_game_id) = intro_map.get(&intro_fqn) {
+                        tx.execute(
+                            "INSERT OR IGNORE INTO quest_chain \
+                             (source_game_id, target_game_id, link_type) \
+                             VALUES (?1, ?2, 'planet_transition')",
+                            params![game_id, target_game_id],
+                        )?;
+                        count += 1;
+                        break;
+                    }
+                }
+            }
+        }
+
+        tx.commit()?;
+        Ok(count)
+    }
+}
+
+/// Extract the destination planet component from a transit tracking/journal string.
+///
+/// Matches strings containing `_to_{dest}` where `{dest}` consists of lowercase
+/// letters and underscores. Strips a leading `the_` if present (e.g. `the_imperial_transit_station`
+/// is returned as-is; the caller filters by checking for a matching intro quest).
+fn extract_transit_dest(s: &str) -> Option<String> {
+    let idx = s.find("_to_")?;
+    let after = &s[idx + 4..];
+    let dest = after.strip_prefix("the_").unwrap_or(after);
+    if !dest.is_empty() && dest.chars().all(|c| c.is_ascii_lowercase() || c == '_') {
+        Some(dest.to_string())
+    } else {
+        None
+    }
 }
 
 /// Parse a conquest objective FQN (`ach.conquests.<category>.<sub>...<leaf>`)

--- a/src/db.rs
+++ b/src/db.rs
@@ -755,8 +755,9 @@ impl Database {
             let mut stmt = conn.prepare(
                 "SELECT fqn, game_id FROM objects WHERE fqn LIKE 'qst.location.%.class.%.intro'",
             )?;
-            let rows =
-                stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?;
+            let rows = stmt.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
             for row in rows.filter_map(|r| r.ok()) {
                 intro_map.insert(row.0, row.1);
             }
@@ -802,8 +803,7 @@ impl Database {
             // Scan strings for `_to_{dest}` patterns; try each as a planet FQN component.
             for s in &strings {
                 if let Some(dest) = extract_transit_dest(s) {
-                    let intro_fqn =
-                        format!("qst.location.{}.class.{}.intro", dest, class);
+                    let intro_fqn = format!("qst.location.{}.class.{}.intro", dest, class);
                     if let Some(target_game_id) = intro_map.get(&intro_fqn) {
                         tx.execute(
                             "INSERT OR IGNORE INTO quest_chain \

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,6 +385,9 @@ fn main() -> Result<()> {
     // Ninth pass: build quest chain links from 0xCF big-endian GUID refs
     db.populate_quest_chain()?;
 
+    // Tenth pass: build planet_transition chain links from leaving_ quest strings
+    db.populate_planet_transitions()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");


### PR DESCRIPTION
## Summary

- Adds `populate_planet_transitions()` to `db.rs` — scans every `qst.location.%.class.%.leaving_%` quest for strings containing `_to_{dest}`, strips leading `the_` if present, then looks up `qst.location.{dest}.class.{class}.intro` to create a `planet_transition` link in `quest_chain`
- Adds `extract_transit_dest()` helper that normalizes transit strings to candidate planet FQN components
- Wired in `main.rs` as the tenth extraction pass after `populate_quest_chain`

## How it works

`leaving_korriban` strings include `track_take_the_shuttle_to_dromund_kaas` → dest = `dromund_kaas` → links to `qst.location.dromund_kaas.class.sith_warrior.intro`. Strings naming intermediate stops (e.g. `imperial_transit_station` after stripping `the_`) produce no match and are silently skipped. No hardcoded planet lists — driven entirely by what intro quests exist in the database.

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Full extraction: `quest_chain` now includes `planet_transition` rows alongside existing `guid_ref` rows
- [ ] Verify Korriban→DK warrior link: `SELECT * FROM quest_chain WHERE link_type='planet_transition'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)