### PR TITLE
feat: recover base-class shared abilities and add discipline/talent tables

### DIFF
--- a/src/bin/dump_npp.rs
+++ b/src/bin/dump_npp.rs
@@ -1,0 +1,197 @@
+//! Dump npp.* GOM objects for format analysis
+//!
+//! Run with: cargo run --bin dump-npp -- -i ~/swtor/assets -H ~/swtor/data/hashes_filename.txt
+
+use anyhow::Result;
+use kessel::hash::HashDictionary;
+use kessel::myp::Archive;
+use kessel::pbuk;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut input_dir = PathBuf::from(".");
+    let mut hash_path: Option<PathBuf> = None;
+    let mut limit = 20usize;
+    let mut prefix_filter = "npp".to_string();
+    let mut exact_fqns: Vec<String> = Vec::new();
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-i" | "--input" => {
+                input_dir = PathBuf::from(&args[i + 1]);
+                i += 2;
+            }
+            "-H" | "--hashes" => {
+                hash_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "-n" | "--limit" => {
+                limit = args[i + 1].parse().unwrap_or(20);
+                i += 2;
+            }
+            "-p" | "--prefix" => {
+                prefix_filter = args[i + 1].clone();
+                i += 2;
+            }
+            "-f" | "--fqn" => {
+                exact_fqns.push(args[i + 1].clone());
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+
+    let hash_path = hash_path.unwrap_or_else(|| input_dir.join("hashes_filename.txt"));
+    let mut hashes = HashDictionary::new();
+    hashes.load(&hash_path)?;
+
+    let tor_files: Vec<_> = std::fs::read_dir(&input_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false))
+        .filter(|p| {
+            p.file_name()
+                .unwrap_or_default()
+                .to_str()
+                .map(|n| n.starts_with("swtor_main") && !n.contains("anim") && !n.contains("gfx"))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    eprintln!(
+        "Scanning {} main .tor files for {}.*",
+        tor_files.len(),
+        prefix_filter
+    );
+
+    let mut found = 0;
+    'outer: for tor_path in &tor_files {
+        let mut archive = Archive::open(tor_path)?;
+        let entries: Vec<_> = archive.entries()?.cloned().collect();
+
+        for entry in &entries {
+            if entry.compressed_size == 0 {
+                continue;
+            }
+
+            let path = hashes.get(entry.filename_hash);
+            let is_bucket = path.map(|p| p.contains("/buckets/")).unwrap_or(false);
+            if !is_bucket {
+                continue;
+            }
+
+            let data = match archive.read_entry(entry) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+
+            if !pbuk::is_pbuk(&data) {
+                continue;
+            }
+
+            let objects = match pbuk::parse(&data) {
+                Ok(o) => o,
+                Err(_) => continue,
+            };
+
+            for obj in objects {
+                let matches = if !exact_fqns.is_empty() {
+                    exact_fqns.iter().any(|f| f == &obj.fqn)
+                } else {
+                    obj.fqn.split('.').next().unwrap_or("") == prefix_filter
+                };
+                if !matches {
+                    continue;
+                }
+
+                println!("=== FQN: {} ===", obj.fqn);
+                let (guid_le, guid_be) = {
+                    let h = &obj.header;
+                    if h.len() >= 8 {
+                        let b: [u8; 8] = h[0..8].try_into().unwrap_or([0u8; 8]);
+                        (
+                            format!("{:016X}", u64::from_le_bytes(b)),
+                            format!("{:016X}", u64::from_be_bytes(b)),
+                        )
+                    } else {
+                        ("0000000000000000".into(), "0000000000000000".into())
+                    }
+                };
+                println!("GUID (LE/stored): {guid_le}  (BE/display): {guid_be}");
+                println!(
+                    "Header ({} bytes): {}",
+                    obj.header.len(),
+                    obj.header
+                        .iter()
+                        .map(|b| format!("{b:02X}"))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                );
+
+                // Dump payload hex (first 512 bytes)
+                let plen = obj.payload.len().min(512);
+                println!(
+                    "Payload ({} bytes, showing first {}):",
+                    obj.payload.len(),
+                    plen
+                );
+                for row in 0..plen.div_ceil(16) {
+                    let start = row * 16;
+                    let end = (start + 16).min(plen);
+                    let hex: String = obj.payload[start..end]
+                        .iter()
+                        .map(|b| format!("{b:02X}"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let ascii: String = obj.payload[start..end]
+                        .iter()
+                        .map(|&b| {
+                            if (32..127).contains(&b) {
+                                b as char
+                            } else {
+                                '.'
+                            }
+                        })
+                        .collect();
+                    println!("  {:04X}: {:<48} {}", start, hex, ascii);
+                }
+
+                // Extract printable strings from payload
+                let mut strings: Vec<(usize, String)> = Vec::new();
+                let mut si = 0;
+                while si < obj.payload.len() {
+                    if (32..127).contains(&obj.payload[si]) {
+                        let mut sj = si;
+                        while sj < obj.payload.len() && (32..127).contains(&obj.payload[sj]) {
+                            sj += 1;
+                        }
+                        if sj - si >= 5 {
+                            let s = String::from_utf8_lossy(&obj.payload[si..sj]).to_string();
+                            strings.push((si, s));
+                        }
+                        si = sj;
+                    } else {
+                        si += 1;
+                    }
+                }
+                if !strings.is_empty() {
+                    println!("Strings:");
+                    for (pos, s) in &strings {
+                        println!("  @{pos:04X}: {}", &s[..s.len().min(120)]);
+                    }
+                }
+                println!();
+
+                found += 1;
+                if found >= limit {
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    eprintln!("Found {found} {prefix_filter}.* objects");
+    Ok(())
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -98,6 +98,9 @@ pub struct Stats {
     pub conquest_objectives: u64,
     pub mission_npcs: u64,
     pub mission_rewards: u64,
+    pub disciplines: u64,
+    pub discipline_abilities: u64,
+    pub talent_abilities: u64,
 }
 
 impl Database {
@@ -370,6 +373,47 @@ impl Database {
                     ) AS parent_quest_fqn_guess
                 FROM objects o
                 WHERE o.fqn LIKE 'mpn.%.bonus.%';
+
+            -- Disciplines: one row per (class, discipline) pair derived from
+            -- abl.{class}.skill.{discipline}.* FQN patterns.
+            CREATE TABLE IF NOT EXISTS disciplines (
+                class_code       TEXT NOT NULL,
+                discipline_name  TEXT NOT NULL,
+                fqn_prefix       TEXT NOT NULL,  -- e.g. "abl.jedi_knight.skill.defense"
+                PRIMARY KEY (class_code, discipline_name)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_disciplines_class ON disciplines(class_code);
+
+            -- Discipline abilities: every abl.* that belongs to a discipline,
+            -- with tier level and slot type derived from FQN segments.
+            -- tier_level: NULL for base abilities (no mods segment), else
+            --   15/23/27/35/39/43/47/51/60/64/68/73/78 from tal.* payload.
+            -- slot_type: 'core' | 'choice' | 'utility' | 'special' | 'passive' | 'base'
+            CREATE TABLE IF NOT EXISTS discipline_abilities (
+                discipline_fqn_prefix  TEXT NOT NULL,
+                ability_game_id        TEXT NOT NULL,
+                ability_fqn            TEXT NOT NULL,
+                tier_level             INTEGER,
+                slot_type              TEXT NOT NULL,
+                PRIMARY KEY (discipline_fqn_prefix, ability_game_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_discipline_abilities_disc ON discipline_abilities(discipline_fqn_prefix);
+            CREATE INDEX IF NOT EXISTS idx_discipline_abilities_abl  ON discipline_abilities(ability_game_id);
+
+            -- Talent → ability links: GUID refs decoded from tal.* payloads.
+            -- 37% of talents reference 1-3 abilities via CC 17E2840B + CF GUID pattern.
+            CREATE TABLE IF NOT EXISTS talent_abilities (
+                talent_game_id   TEXT NOT NULL,
+                talent_fqn       TEXT NOT NULL,
+                ability_game_id  TEXT NOT NULL,
+                ability_fqn      TEXT,           -- NULL if GUID not in our object set
+                PRIMARY KEY (talent_game_id, ability_game_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_talent_abilities_talent  ON talent_abilities(talent_game_id);
+            CREATE INDEX IF NOT EXISTS idx_talent_abilities_ability ON talent_abilities(ability_game_id);
 
             -- Extraction metadata
             CREATE TABLE IF NOT EXISTS meta (
@@ -1518,6 +1562,227 @@ impl Database {
         Ok((npc_count, reward_count))
     }
 
+    /// Populate `disciplines` and `discipline_abilities` from `abl.{class}.skill.{discipline}.*` FQNs.
+    ///
+    /// Discipline FQN structure:
+    ///   abl.{class}.skill.{discipline}.{name}              -> base/core ability
+    ///   abl.{class}.skill.{discipline}.mods.passive.{name} -> passive
+    ///   abl.{class}.skill.{discipline}.mods.tier2.{name}   -> choice (lvl 23)
+    ///   abl.{class}.skill.{discipline}.mods.tier3.{name}   -> choice (lvl 39+)
+    ///   abl.{class}.skill.{discipline}.mods.special.{name} -> special
+    ///   abl.{class}.skill.utility.{name}                   -> utility (shared)
+    ///   abl.{class}.skill.mods.tier1.{name}                -> shared mod
+    pub fn populate_disciplines(&self) -> Result<(u64, u64)> {
+        self.flush()?;
+
+        let rows: Vec<(String, String)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt =
+                conn.prepare("SELECT fqn, game_id FROM objects WHERE fqn LIKE 'abl.%.skill.%'")?;
+            let result: Vec<(String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            result
+        };
+
+        let mut disc_set: std::collections::HashSet<(String, String, String)> =
+            std::collections::HashSet::new();
+        let mut abl_rows: Vec<(String, String, String, Option<u8>, String)> = Vec::new();
+
+        for (fqn, game_id) in &rows {
+            // abl.{class}.skill.{rest}
+            let parts: Vec<&str> = fqn.split('.').collect();
+            if parts.len() < 5 {
+                continue;
+            }
+            let class_code = parts[1];
+            let discipline_name;
+            let fqn_prefix;
+            let slot_type: &str;
+            let tier_level: Option<u8>;
+
+            // abl.{class}.skill.utility.{name} -> utility, no discipline
+            if parts[3] == "utility" {
+                discipline_name = "utility";
+                fqn_prefix = format!("abl.{}.skill.utility", class_code);
+                slot_type = "utility";
+                tier_level = None;
+            } else if parts[3] == "mods" {
+                // abl.{class}.skill.mods.tierN.{name} -> shared mod
+                discipline_name = "shared";
+                fqn_prefix = format!("abl.{}.skill.mods", class_code);
+                slot_type = "shared_mod";
+                tier_level = tier_from_segment(parts.get(4).copied());
+            } else {
+                // abl.{class}.skill.{discipline}.*
+                discipline_name = parts[3];
+                fqn_prefix = format!("abl.{}.skill.{}", class_code, discipline_name);
+
+                if parts.len() >= 7 && parts[4] == "mods" {
+                    match parts[5] {
+                        "passive" => {
+                            slot_type = "passive";
+                            tier_level = None;
+                        }
+                        "special" => {
+                            slot_type = "special";
+                            tier_level = None;
+                        }
+                        s if s.starts_with("tier") => {
+                            slot_type = "choice";
+                            tier_level = tier_from_segment(Some(s));
+                        }
+                        _ => {
+                            slot_type = "mod";
+                            tier_level = None;
+                        }
+                    }
+                } else {
+                    slot_type = "core";
+                    tier_level = None;
+                }
+            }
+
+            disc_set.insert((
+                class_code.to_string(),
+                discipline_name.to_string(),
+                fqn_prefix.clone(),
+            ));
+            abl_rows.push((
+                fqn_prefix,
+                game_id.clone(),
+                fqn.clone(),
+                tier_level,
+                slot_type.to_string(),
+            ));
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+
+        let mut disc_count = 0u64;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT OR IGNORE INTO disciplines (class_code, discipline_name, fqn_prefix) VALUES (?1, ?2, ?3)",
+            )?;
+            for (class_code, discipline_name, fqn_prefix) in &disc_set {
+                stmt.execute(params![class_code, discipline_name, fqn_prefix])?;
+                disc_count += 1;
+            }
+        }
+
+        let mut abl_count = 0u64;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT OR IGNORE INTO discipline_abilities (discipline_fqn_prefix, ability_game_id, ability_fqn, tier_level, slot_type) VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for (disc_prefix, game_id, fqn, tier, slot) in &abl_rows {
+                stmt.execute(params![disc_prefix, game_id, fqn, tier, slot])?;
+                abl_count += 1;
+            }
+        }
+
+        tx.commit()?;
+        Ok((disc_count, abl_count))
+    }
+
+    /// Populate `talent_abilities` by decoding GUID refs from `tal.*` payloads.
+    ///
+    /// Pattern (from MAPPINGS.md): CC 17E2840B D001 CF E000 [8-byte GUID BE]
+    /// 37% of talents reference 1-3 abilities this way.
+    pub fn populate_talent_abilities(&self) -> Result<u64> {
+        self.flush()?;
+
+        // Load all talent payloads + their game_ids
+        let talents: Vec<(String, String, Vec<u8>)> = {
+            use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+            let conn = self.conn.lock().unwrap();
+            let mut stmt =
+                conn.prepare("SELECT game_id, fqn, json FROM objects WHERE kind = 'Talent'")?;
+            let raw: Vec<(String, String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            raw.into_iter()
+                .filter_map(|(game_id, fqn, json_str)| {
+                    let v: serde_json::Value = serde_json::from_str(&json_str).ok()?;
+                    let b64 = v.get("payload_b64")?.as_str()?;
+                    let payload = BASE64.decode(b64).ok()?;
+                    Some((game_id, fqn, payload))
+                })
+                .collect()
+        };
+
+        // Build guid → (game_id, fqn) lookup from all objects
+        let guid_map: std::collections::HashMap<String, (String, String)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare("SELECT guid, game_id, fqn FROM objects")?;
+            let rows: Vec<(String, String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows.into_iter()
+                .map(|(guid, game_id, fqn)| (guid.to_uppercase(), (game_id, fqn)))
+                .collect()
+        };
+
+        let mut links: Vec<(String, String, String, Option<String>)> = Vec::new();
+
+        for (talent_game_id, talent_fqn, payload) in &talents {
+            // Scan for CC 17E2840B (or reversed: 0B84E217) followed by D0 01 CF E0 00 ...
+            // Field marker bytes (stored as found in MAPPINGS.md): CC 17 E2 84 0B
+            // After field marker: D0 01 (int8 = 1), then CF E0 00 XX XX XX XX XX XX
+            let guids = extract_ability_guids_from_talent(payload);
+            for guid_hex in guids {
+                let entry = guid_map.get(&guid_hex);
+                links.push((
+                    talent_game_id.clone(),
+                    talent_fqn.clone(),
+                    entry
+                        .as_ref()
+                        .map_or(guid_hex.clone(), |(gid, _)| gid.clone()),
+                    entry.map(|(_, fqn)| fqn.clone()),
+                ));
+            }
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO talent_abilities (talent_game_id, talent_fqn, ability_game_id, ability_fqn) VALUES (?1, ?2, ?3, ?4)",
+        )?;
+
+        let mut count = 0u64;
+        for (talent_game_id, talent_fqn, ability_game_id, ability_fqn) in &links {
+            stmt.execute(params![
+                talent_game_id,
+                talent_fqn,
+                ability_game_id,
+                ability_fqn
+            ])?;
+            count += 1;
+        }
+
+        drop(stmt);
+        tx.commit()?;
+        Ok(count)
+    }
+
     pub fn stats(&self) -> Result<Stats> {
         // Ensure all pending data is flushed before counting
         self.flush()?;
@@ -1549,6 +1814,16 @@ impl Database {
             conn.query_row("SELECT COUNT(*) FROM mission_npcs", [], |row| row.get(0))?;
         let mission_rewards: u64 =
             conn.query_row("SELECT COUNT(*) FROM mission_rewards", [], |row| row.get(0))?;
+        let disciplines: u64 =
+            conn.query_row("SELECT COUNT(*) FROM disciplines", [], |row| row.get(0))?;
+        let discipline_abilities: u64 =
+            conn.query_row("SELECT COUNT(*) FROM discipline_abilities", [], |row| {
+                row.get(0)
+            })?;
+        let talent_abilities: u64 =
+            conn.query_row("SELECT COUNT(*) FROM talent_abilities", [], |row| {
+                row.get(0)
+            })?;
 
         Ok(Stats {
             quests,
@@ -1564,6 +1839,9 @@ impl Database {
             conquest_objectives,
             mission_npcs,
             mission_rewards,
+            disciplines,
+            discipline_abilities,
+            talent_abilities,
         })
     }
 
@@ -1700,6 +1978,88 @@ fn derive_icon_from_fqn(fqn: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Decode tier level from FQN segment like "tier2" → 23, "tier3" → 39, etc.
+/// Maps SWTOR's tier numbering to actual level requirements.
+fn tier_from_segment(seg: Option<&str>) -> Option<u8> {
+    match seg? {
+        "tier1" => Some(15),
+        "tier2" => Some(23),
+        "tier3" => Some(39),
+        "tier4" => Some(43),
+        "tier5" => Some(51),
+        "tier6" => Some(64),
+        "tier7" => Some(68),
+        "tier8" => Some(73),
+        _ => None,
+    }
+}
+
+/// Extract ability GUIDs from a `tal.*` payload using the documented pattern:
+///   CC 17 E2 84 0B  (field marker, may appear as CC 0B 84 E2 17 in some payloads)
+///   D0 01           (int8 = 1)
+///   CF E0 00 XX XX XX XX XX XX  (CF type tag + 8-byte GUID; E0 00 are GUID bytes 1-2)
+///
+/// Returns hex strings (uppercase, 16 chars) matching the objects.guid format.
+fn extract_ability_guids_from_talent(payload: &[u8]) -> Vec<String> {
+    let mut guids = Vec::new();
+    let len = payload.len();
+    if len < 16 {
+        return guids;
+    }
+
+    let mut i = 0;
+    while i + 16 <= len {
+        // Look for CC followed by field ID 17E2840B (either byte order)
+        if payload[i] != 0xCC {
+            i += 1;
+            continue;
+        }
+        let is_field = (i + 5 <= len)
+            && ((payload[i + 1] == 0x17
+                && payload[i + 2] == 0xE2
+                && payload[i + 3] == 0x84
+                && payload[i + 4] == 0x0B)
+                || (payload[i + 1] == 0x0B
+                    && payload[i + 2] == 0x84
+                    && payload[i + 3] == 0xE2
+                    && payload[i + 4] == 0x17));
+        if !is_field {
+            i += 1;
+            continue;
+        }
+        // Skip CC + 4-byte field ID + D0 01
+        let after = i + 5;
+        if after + 2 > len {
+            i += 1;
+            continue;
+        }
+        // D0 01 marker
+        let guid_start = if payload[after] == 0xD0 && payload[after + 1] == 0x01 {
+            after + 2
+        } else {
+            after
+        };
+        // CF [8-byte GUID BE]: E0 00 are the first two bytes of the GUID, not markers.
+        // Matches populate_quest_chain's format: payload[i+1..i+9] byte-concat hex.
+        if guid_start + 9 > len {
+            i += 1;
+            continue;
+        }
+        if payload[guid_start] == 0xCF
+            && payload[guid_start + 1] == 0xE0
+            && payload[guid_start + 2] == 0x00
+        {
+            let g = &payload[guid_start + 1..guid_start + 9];
+            let hex = g.iter().map(|b| format!("{b:02X}")).collect::<String>();
+            guids.push(hex);
+            i = guid_start + 9;
+        } else {
+            i += 1;
+        }
+    }
+    guids
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,7 +223,11 @@ fn main() -> Result<()> {
                         }
                     } else if pbuk::is_dblb(&data) {
                         if let Ok(objects) = pbuk::parse_dblb_direct(&data) {
-                            for obj in objects {
+                            for mut obj in objects {
+                                let Some(fqn) = normalize_fqn(&obj.fqn) else {
+                                    continue;
+                                };
+                                obj.fqn = fqn;
                                 let game_obj = schema::GameObject::from_gom(&obj);
                                 if should_extract_object(&game_obj.fqn, args.unfiltered)
                                     && !game_obj.fqn.is_empty()
@@ -242,7 +246,11 @@ fn main() -> Result<()> {
                     }
                 } else if pbuk::is_dblb(&data) {
                     if let Ok(objects) = pbuk::parse_dblb_direct(&data) {
-                        for obj in objects {
+                        for mut obj in objects {
+                            let Some(fqn) = normalize_fqn(&obj.fqn) else {
+                                continue;
+                            };
+                            obj.fqn = fqn;
                             let game_obj = schema::GameObject::from_gom(&obj);
                             if should_extract_object(&game_obj.fqn, args.unfiltered)
                                 && !game_obj.fqn.is_empty()
@@ -388,6 +396,12 @@ fn main() -> Result<()> {
     // Tenth pass: build planet_transition chain links from leaving_ quest strings
     db.populate_planet_transitions()?;
 
+    // Eleventh pass: derive disciplines and discipline→ability mappings
+    let (disc_count, disc_abl_count) = db.populate_disciplines()?;
+
+    // Twelfth pass: decode talent→ability GUID refs from tal.* payloads
+    let talent_abl_count = db.populate_talent_abilities()?;
+
     // Print summary
     let stats = db.stats()?;
     println!("\nExtraction complete!");
@@ -404,6 +418,11 @@ fn main() -> Result<()> {
         stats.missions, stats.mission_npcs, stats.mission_rewards
     );
     println!("    Abilities: {}", stats.abilities);
+    println!(
+        "    Disciplines: {} ({} ability slots, {} talent links)",
+        stats.disciplines, stats.discipline_abilities, stats.talent_abilities
+    );
+    let _ = (disc_count, disc_abl_count, talent_abl_count);
     println!("    Items: {}", stats.items);
     println!("    NPCs: {}", stats.npcs);
     println!("    Conquest objectives: {}", stats.conquest_objectives);
@@ -477,10 +496,29 @@ fn resolve_hashes_path(args: &Args) -> Result<Option<PathBuf>> {
     Ok(Some(default_path))
 }
 
+/// Normalize a GOM FQN for extraction.
+///
+/// Unversioned FQNs pass through unchanged. Versioned FQNs (`base/major/minor`)
+/// are kept only when `minor == 0` — the canonical revision — and the version
+/// suffix is stripped so the stored FQN matches the clean unversioned form.
+/// Returns None for non-zero minor versions (skip these objects).
+fn normalize_fqn(fqn: &str) -> Option<String> {
+    if !fqn.contains('/') {
+        return Some(fqn.to_string());
+    }
+    let slash1 = fqn.rfind('/')?;
+    let minor: u32 = fqn[slash1 + 1..].parse().ok()?;
+    if minor != 0 {
+        return None;
+    }
+    let base_end = fqn[..slash1].rfind('/')?;
+    Some(fqn[..base_end].to_string())
+}
+
 /// Check if a GOM object should be extracted based on FQN prefix
 fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
-    // Skip versioned duplicates: "abl.foo.bar/17/5" -> only keep base "abl.foo.bar"
-    // Always apply this - versioned paths are duplicates
+    // Safety guard: versioned FQNs should be normalized before reaching here.
+    // The extraction loops call versioned_fqn_base() first and skip non-zero minors.
     if fqn.contains('/') {
         return false;
     }
@@ -623,7 +661,11 @@ fn process_pbuk(data: &[u8], db: &db::Database, unfiltered: bool) -> Result<usiz
     let objects = pbuk::parse(data)?;
     let mut count = 0;
 
-    for obj in objects {
+    for mut obj in objects {
+        let Some(fqn) = normalize_fqn(&obj.fqn) else {
+            continue;
+        };
+        obj.fqn = fqn;
         let game_obj = schema::GameObject::from_gom(&obj);
         if should_extract_object(&game_obj.fqn, unfiltered) && !game_obj.fqn.is_empty() {
             db.insert_object(&game_obj)?;


### PR DESCRIPTION
## Problem

Base-class shared abilities (e.g. `abl.sith_inquisitor.severing_slash`) exist in the GOM data ONLY as versioned FQNs (`/major/minor`). Kessel's filter dropped all FQNs containing `/` unconditionally — these ~53 abilities were silently absent from every extraction, appearing as `abl.synthetic.*` placeholder entries in huttspawn.

## Changes

### Versioned FQN normalization
- Add `normalize_fqn()`: unversioned FQNs pass through unchanged; versioned FQNs with `minor == 0` are kept with the version suffix stripped; all non-zero minors are skipped
- Applied in all three extraction paths (PBUK, DBLB-in-bucket, DBLB-loose)
- Safety guard remains in `should_extract_object` as a backstop
- Analysis confirmed one major version per base FQN across all assets — no dedup risk

### New tables
- `disciplines`: (class_code, discipline_name, fqn_prefix) — derived from `abl.*.skill.*` FQN structure
- `discipline_abilities`: ability→discipline mapping with tier_level (from FQN segment) and slot_type (core/choice/passive/utility)
- `talent_abilities`: talent→ability GUID links decoded from `CC 17E2840B` pattern in `tal.*` payloads

### dump_npp binary
General-purpose GOM object dumper (`src/bin/dump_npp.rs`) with `-p` prefix filter for format analysis.

## Known limitations
- `discipline_abilities.tier_level` derived from FQN segment names, not from D954FB02 payload bytes
- `talent_abilities` covers ~37% of talents (those with CC 17E2840B ability refs)
- `talent_abilities.ability_fqn` NULL when referenced GUID not in extraction set