### PR TITLE
feat: icon_overrides.toml for base-class abilities without embedded icon refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kessel
 
-SWTOR data miner -- extracts game objects, localized strings, and icons from `.tor` archives into SQLite.
+SWTOR data miner — extracts game objects, localized strings, and icons from `.tor` archives into SQLite.
 
 Named after the spice mines of Kessel.
 
@@ -8,120 +8,73 @@ Named after the spice mines of Kessel.
 
 Kessel reads SWTOR's `.tor` archive files and produces:
 
-- **SQLite database** with 176k+ game objects (abilities, items, NPCs, quests, talents, etc.)
-- **557k+ localized strings** extracted from STB string tables
-- **WebP icons** converted from DDS textures, named by deterministic game_id
+- **SQLite database** with 260k+ game objects (abilities, items, NPCs, quests, talents, and more)
+- **558k+ localized strings** extracted from STB string tables
+- **WebP icons** converted from DDS textures, named by deterministic `game_id`
 
-Descriptions are automatically cleaned via embedded grammar rules that strip SWTOR's template syntax (`<<1[%d seconds/%d second/%d seconds]>>` becomes natural English).
+Descriptions are automatically cleaned via embedded grammar rules that strip SWTOR's template syntax (`<<1[%d seconds/%d second/%d seconds]>>` → natural English).
 
-## Usage
+## Quick start
 
 ```bash
 cargo build --release
 
-# Extract game objects and strings
-./target/release/kessel \
-  --input ~/swtor/Assets \
-  --output spice.sqlite
-
-# With icon extraction
 ./target/release/kessel \
   --input ~/swtor/Assets \
   --output spice.sqlite \
   --icons \
   --icons-output ./icons
-
-# Unfiltered (skip content filters, keep everything)
-./target/release/kessel \
-  --input ~/swtor/Assets \
-  --output spice.sqlite \
-  --unfiltered
 ```
 
-The hash dictionary auto-downloads from Jedipedia on first run.
+The hash dictionary auto-downloads from Jedipedia on first run. See [docs/cli.md](docs/cli.md) for all flags.
 
-### CLI flags
+## Data pipeline
 
-| Flag | Description |
-|------|-------------|
-| `-i, --input <DIR>` | SWTOR Assets directory (required) |
-| `-o, --output <PATH>` | SQLite output path (default: `raw.sqlite`) |
-| `-H, --hashes <FILE>` | Hash dictionary (auto-downloads if missing) |
-| `--icons` | Enable DDS to WebP icon extraction |
-| `--icons-output <DIR>` | Icon output directory (default: `./icons`) |
-| `--unfiltered` | Skip content filters (keeps NPC abilities, internal items, etc.) |
-| `-v, --verbose` | Verbose logging |
-| `--unknowns <FILE>` | Track unknown patterns to JSONL |
+```mermaid
+flowchart LR
+    TOR[".tor archives\n(MYP format)"]
+    PBUK["PBUK containers\n(GOM object bundles)"]
+    GOM["GOM objects\n(header + FQN + payload)"]
+    STB["STB string tables\n(.stb files)"]
+    DDS["DDS textures\n(/gfx/icons/)"]
+    DB[("SQLite\nspice.sqlite")]
+    ICONS["WebP icons\n{game_id}.webp"]
 
-### Filtering
-
-By default, kessel applies content filters to skip internal/NPC objects. Use `--unfiltered` to extract everything.
-
-Both modes always skip: versioned duplicates (FQN containing `/`), test/debug/deprecated content.
-
-Extracted FQN prefixes: `abl` (abilities), `tal` (talents), `itm` (items), `npc` (NPCs), `qst` (quests), `cdx` (codex), `ach` (achievements), `schem` (schematics), `mpn` (map pins), `pkg` (packages), `loot` (loot tables), `rew` (rewards), `cnv` (conversations), `apc` (appearances), `class` (class definitions).
-
-## Output schema
-
-```sql
-CREATE TABLE objects (
-    guid TEXT PRIMARY KEY,
-    fqn TEXT NOT NULL,
-    game_id TEXT NOT NULL,      -- sha256(fqn:guid)[0:16]
-    kind TEXT NOT NULL,
-    icon_name TEXT,
-    string_id INTEGER,          -- links to strings.id2
-    for_export INTEGER DEFAULT 1,
-    version INTEGER DEFAULT 0,
-    revision INTEGER DEFAULT 0,
-    json TEXT NOT NULL,
-    created_at INTEGER DEFAULT (unixepoch())
-);
-
-CREATE TABLE strings (
-    fqn TEXT PRIMARY KEY,
-    locale TEXT NOT NULL,
-    id1 INTEGER NOT NULL,
-    id2 INTEGER NOT NULL,       -- links to objects.string_id
-    text TEXT NOT NULL,
-    version INTEGER DEFAULT 0
-);
+    TOR -->|"hash dict resolves\n64-bit file hashes"| PBUK
+    PBUK -->|"zstd decompress\nDRLB blocks"| GOM
+    TOR --> STB
+    TOR --> DDS
+    GOM -->|"schema extraction\nguid, fqn, kind,\nicon_name, string_id"| DB
+    STB -->|"grammar rules\nclean template syntax"| DB
+    DDS -->|"DDS → WebP\nnamed by game_id"| ICONS
 ```
 
-Views: `abilities`, `items`, `npcs`, `quests`.
+## Output
 
-### Querying
+### Database tables
 
-```bash
-# Object counts by type
-sqlite3 spice.sqlite "SELECT kind, COUNT(*) FROM objects GROUP BY kind ORDER BY 2 DESC;"
+Core: `objects`, `strings`
 
-# Find an ability by name
-sqlite3 spice.sqlite "
-  SELECT o.fqn, s.text
-  FROM objects o
-  JOIN strings s ON s.id2 = o.string_id AND s.locale = 'en-us' AND s.id1 = 1
-  WHERE o.kind = 'Ability' AND s.text LIKE '%Ravage%';
-"
+Quest graph: `quest_details`, `quest_chain`, `quest_npcs`, `quest_phases`, `quest_prerequisites`, `quest_rewards`
+
+Missions: `missions`, `mission_npcs`, `mission_rewards`
+
+Disciplines: `disciplines`, `discipline_abilities`, `talent_abilities`
+
+Other: `conquest_objectives`, `spawn_runtime_ids`, `meta`
+
+Views: `abilities`, `items`, `npcs`, `quests`, `phases`, `quest_descriptions`, `bonus_missions`, `conquest_invasion_bonuses`, `conquest_theme_strings`
+
+See [docs/schema.md](docs/schema.md) for full column definitions and join patterns.
+
+### Icons
+
 ```
-
-## How it works
-
-SWTOR stores game data in layered binary containers:
-
+icons/
+  abilities/   {game_id}.webp
+  items/       {game_id}.webp
+  talents/     {game_id}.webp
 ```
-.tor archive (MYP format)
-  -> Files identified by 64-bit hash
-    -> PBUK containers (game object bundles)
-      -> DBLB blocks (database blocks)
-        -> GOM objects (42-byte header + FQN + ZSTD-compressed payload)
-```
-
-Kessel reads the archive, resolves hashes to paths via a dictionary, decompresses each layer (zstd or zlib), and extracts structured data from the binary GOM payloads.
-
-String tables (`.stb` files) are parsed separately and linked to objects via `string_id`.
-
-Icons are DDS textures converted to lossless WebP, organized by object kind (`abilities/`, `items/`, `talents/`, etc.) and named by `game_id` for deterministic frontend lookup.
 
 ## Project structure
 
@@ -129,26 +82,27 @@ Icons are DDS textures converted to lossless WebP, organized by object kind (`ab
 kessel/
   Cargo.toml
   grammar.toml          # Description cleanup rules (embedded at compile time)
+  icon_overrides.toml   # FQN → icon_name overrides for abilities without embedded icon refs
+  docs/
+    cli.md              # CLI flags and examples
+    schema.md           # Full database schema reference
   src/
     main.rs             # CLI entry point and extraction pipeline
     lib.rs              # Library exports
-    myp.rs              # MYP archive reader (decompress .tor files)
-    pbuk.rs             # PBUK/DBLB parser (extract GOM objects)
+    myp.rs              # MYP archive reader (.tor files)
+    pbuk.rs             # PBUK/DBLB parser (GOM objects)
     stb.rs              # STB string table parser
-    db.rs               # SQLite database (batch inserts, grammar application)
-    dds.rs              # DDS to WebP icon conversion
+    db.rs               # SQLite (batch inserts, grammar application, derived tables)
+    dds.rs              # DDS to WebP conversion
     hash.rs             # Hash dictionary and game_id computation
     grammar.rs          # Template/literal/cleanup rule processor
+    icon_overrides.rs   # Compile-time FQN → icon_name override map
     gifts.rs            # Gift item FQN classification
     unknowns.rs         # Unknown pattern tracking
-    schema/mod.rs       # GameObject struct and binary extraction
+    schema/mod.rs       # GameObject struct and binary payload extraction
     bin/
-      analyze_headers.rs  # DDS header analysis utility
+      dump_npp.rs       # Debug utility: dump GOM objects by FQN prefix or exact match
   tests/
-    schema_test.rs
-    pbuk_test.rs
-    myp_test.rs
-    xml_parser_test.rs
 ```
 
 ## License

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,101 @@
+# Kessel CLI
+
+## Synopsis
+
+```
+kessel --input <DIR> --output <PATH> [OPTIONS]
+```
+
+## Required flags
+
+| Flag | Description |
+|------|-------------|
+| `-i, --input <DIR>` | SWTOR Assets directory containing `.tor` files |
+| `-o, --output <PATH>` | SQLite output path (default: `raw.sqlite`) |
+
+## Optional flags
+
+| Flag | Description |
+|------|-------------|
+| `-H, --hashes <FILE>` | Hash dictionary path. Auto-downloads from Jedipedia if not provided. The downloaded file is saved alongside the input directory as `hashes_filename.txt`. |
+| `--icons` | Enable DDS-to-WebP icon extraction. |
+| `--icons-output <DIR>` | Icon output directory (default: `./icons`). Has no effect without `--icons`. |
+| `--unfiltered` | Skip content filters. See [Filtering](#filtering) below. |
+| `--unknowns <FILE>` | Write unrecognized payload patterns to a JSONL file for analysis. |
+| `-v, --verbose` | Print additional debug output. |
+
+## Examples
+
+```bash
+# Minimal — hash dictionary auto-downloads
+./target/release/kessel -i ~/swtor/Assets -o spice.sqlite
+
+# With icon extraction
+./target/release/kessel \
+  -i ~/swtor/Assets \
+  -o spice.sqlite \
+  --icons \
+  --icons-output ./icons
+
+# Explicit hash dictionary
+./target/release/kessel \
+  -i ~/swtor/Assets \
+  -o spice.sqlite \
+  -H ~/swtor/data/hashes_filename.txt
+
+# Unfiltered (keep everything, including NPC abilities and internal items)
+./target/release/kessel \
+  -i ~/swtor/Assets \
+  -o spice.sqlite \
+  --unfiltered
+```
+
+## Filtering
+
+By default kessel applies content filters to skip objects that aren't useful for player-facing tools:
+
+- Internal/NPC-only abilities (FQNs containing `npc`, `world_design`, `test`, `deprecated`, etc.)
+- Items flagged as internal or not for sale
+- Objects with no localized strings
+
+Use `--unfiltered` to bypass these filters. Both modes always:
+
+- Skip versioned FQN duplicates — multiple `/major/minor` variants of the same ability are collapsed to one row, first-encountered wins
+- Skip objects with empty FQNs
+
+### Extracted FQN prefixes (filtered mode)
+
+`abl` abilities · `tal` talents · `itm` items · `npc` NPCs · `qst` quests · `mpn` phases · `cdx` codex · `ach` achievements · `cnv` conversations · `enc` encounters · `spn` spawns · `plc` placeables
+
+## Icons
+
+When `--icons` is set, kessel extracts DDS textures from the archive and converts them to lossless WebP. Icons are organized by object kind:
+
+```
+icons/
+  abilities/   {game_id}.webp
+  items/       {game_id}.webp
+  talents/     {game_id}.webp
+  ...
+```
+
+The filename is always the object's `game_id` — a deterministic 16-character hex string (`sha256(fqn:guid)[0:16]`). This is the stable name to use for frontend CDN paths.
+
+For abilities whose GOM payloads don't embed an icon reference (base-class shared abilities recovered from versioned FQNs), `icon_overrides.toml` provides a compile-time FQN→icon_name mapping.
+
+## Utilities
+
+### dump-npp
+
+Debug binary for dumping GOM objects matching a prefix or exact FQN:
+
+```bash
+cargo run --bin dump-npp -- \
+  -i ~/swtor/Assets \
+  -H ~/swtor/data/hashes_filename.txt \
+  -p npp \        # prefix filter (default: npp)
+  -n 20 \         # result limit (default: 20)
+  -f abl.sith_warrior.force_charge   # exact FQN (can repeat; overrides -p)
+```
+
+Prints header bytes, payload hex, and extracted strings for each matching object.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,296 @@
+# Database Schema
+
+## Overview
+
+```mermaid
+erDiagram
+    objects {
+        TEXT guid PK
+        TEXT template_guid
+        TEXT fqn
+        TEXT game_id
+        TEXT kind
+        TEXT icon_name
+        INTEGER string_id
+        INTEGER for_export
+        INTEGER version
+        INTEGER revision
+        TEXT json
+        INTEGER created_at
+    }
+    strings {
+        TEXT fqn PK
+        TEXT locale
+        INTEGER id1
+        INTEGER id2
+        TEXT text
+        INTEGER version
+    }
+    quest_details {
+        TEXT fqn PK
+        TEXT mission_type
+        TEXT faction
+        TEXT planet
+        TEXT class_code
+        TEXT companion_class
+        INTEGER step_count
+    }
+    quest_chain {
+        TEXT source_game_id PK
+        TEXT target_game_id PK
+        TEXT link_type
+    }
+    quest_npcs {
+        TEXT quest_fqn PK
+        TEXT npc_fqn PK
+    }
+    quest_phases {
+        TEXT quest_fqn PK
+        TEXT phase_fqn PK
+    }
+    quest_prerequisites {
+        TEXT fqn PK
+        TEXT variable PK
+    }
+    quest_rewards {
+        TEXT quest_fqn PK
+        TEXT reward_variable PK
+    }
+    missions {
+        TEXT mission_fqn PK
+        TEXT source
+    }
+    mission_npcs {
+        TEXT mission_fqn PK
+        TEXT npc_fqn PK
+    }
+    mission_rewards {
+        TEXT mission_fqn PK
+        TEXT reward_variable PK
+    }
+    disciplines {
+        TEXT class_code PK
+        TEXT discipline_name PK
+        TEXT fqn_prefix
+    }
+    discipline_abilities {
+        TEXT discipline_fqn_prefix PK
+        TEXT ability_game_id PK
+        TEXT ability_fqn
+        INTEGER tier_level
+        TEXT slot_type
+    }
+    talent_abilities {
+        TEXT talent_game_id PK
+        TEXT talent_fqn
+        TEXT ability_game_id PK
+        TEXT ability_fqn
+    }
+    spawn_runtime_ids {
+        TEXT spn_fqn PK
+        TEXT target_fqn PK
+        INTEGER runtime_id PK
+    }
+    conquest_objectives {
+        TEXT fqn PK
+        TEXT category
+        TEXT subcategory
+        TEXT cadence
+        INTEGER string_id
+    }
+    meta {
+        TEXT key PK
+        TEXT value
+    }
+
+    objects ||--o{ strings : "string_id = id2"
+    objects ||--o| quest_details : "fqn"
+    objects ||--o{ quest_npcs : "quest_fqn"
+    objects ||--o{ quest_phases : "quest_fqn"
+    objects ||--o{ quest_chain : "game_id"
+    objects ||--o{ discipline_abilities : "game_id"
+    objects ||--o{ talent_abilities : "game_id"
+    disciplines ||--o{ discipline_abilities : "fqn_prefix"
+```
+
+## Core tables
+
+### objects
+
+Every game object extracted from GOM payloads. The single source of truth for all abilities, items, NPCs, quests, talents, and other types.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `guid` | TEXT PK | 16-char uppercase hex from GOM header bytes 0–7 (LE u64). Unique per object. |
+| `template_guid` | TEXT | 16-char hex from header bytes 16–23. Constant per kind (~99% of the time). |
+| `fqn` | TEXT | Fully qualified name, e.g. `abl.sith_warrior.force_charge`. Dot-separated, prefix determines kind. |
+| `game_id` | TEXT | `sha256(fqn:guid)[0:16]`. Deterministic compound ID used for icon filenames and frontend lookups. |
+| `kind` | TEXT | Object type: `Ability`, `Item`, `Npc`, `Quest`, `Talent`, `Phase`, `Codex`, `Achievement`, `Conversation`, `Encounter`, `Spawn`, `Placeable` |
+| `icon_name` | TEXT | SWTOR DDS basename (without `.dds`). Matched to icon files during extraction. NULL if no icon found. |
+| `string_id` | INTEGER | Links to `strings.id2` for localized name/description lookup. |
+| `for_export` | INTEGER | 1 = include in consumer exports, 0 = internal only. |
+| `json` | TEXT | Full extracted metadata as JSON. Includes `fqn`, `header_hex`, `payload_b64`, `strings`, `string_id`. |
+| `created_at` | INTEGER | Unix epoch at insert time. |
+
+**Views:** `abilities`, `items`, `npcs`, `quests`, `phases` — each filters `objects` by kind.
+
+### strings
+
+Localized text extracted from STB string tables.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `fqn` | TEXT PK | String path, e.g. `str.abl.sith_warrior.force_charge`. |
+| `locale` | TEXT | Locale code, e.g. `en-us`. |
+| `id1` | INTEGER | STB row ID. Different id1 values for the same id2 represent different text fields (name, description, etc.). |
+| `id2` | INTEGER | Links to `objects.string_id`. |
+| `text` | TEXT | Display text, cleaned of SWTOR template syntax by grammar rules. |
+
+**Joining objects to strings:**
+
+```sql
+SELECT o.fqn, s.text
+FROM objects o
+JOIN strings s ON s.id2 = o.string_id AND s.locale = 'en-us'
+WHERE o.kind = 'Ability'
+  AND s.id1 = (SELECT MIN(id1) FROM strings WHERE id2 = o.string_id AND locale = 'en-us');
+```
+
+id1 values by content type (approximate):
+- `1` — object name
+- `2` — short description
+- `200–600` — quest step descriptions
+
+---
+
+## Quest tables
+
+### quest_details
+
+Structured metadata derived from quest FQN and payload analysis.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `fqn` | TEXT PK | Quest FQN. |
+| `mission_type` | TEXT | `class`, `planet`, `flashpoint`, `operation`, `heroic`, `bonus`, `daily`, `weekly`, `event`, `gsf`, `unknown` |
+| `faction` | TEXT | `republic`, `empire`, `neutral`, NULL |
+| `planet` | TEXT | Planet slug, e.g. `tython`, `dromund_kaas`. NULL if not planet-specific. |
+| `class_code` | TEXT | `jedi_knight`, `sith_warrior`, etc. NULL if not class-specific. |
+| `step_count` | INTEGER | Number of quest steps extracted from payload. |
+
+### quest_chain
+
+Directed edges connecting quests in sequence (next quest, prerequisite, follow-up).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `source_game_id` | TEXT | `game_id` of the quest that links outward. |
+| `target_game_id` | TEXT | `game_id` of the quest being linked to. |
+| `link_type` | TEXT | `next`, `prereq`, `followup`, `planet_transition` |
+
+### quest_npcs / quest_phases / quest_prerequisites / quest_rewards
+
+Junction tables linking quests to related objects.
+
+| Table | Links |
+|-------|-------|
+| `quest_npcs` | quest → NPCs involved (via encounter/spawn intermediaries) |
+| `quest_phases` | quest → `mpn.*` phase objects |
+| `quest_prerequisites` | quest → prerequisite variable strings |
+| `quest_rewards` | quest → reward variable strings |
+
+**Views:**
+- `quest_descriptions` — joins quests to their first description string (id1 200–600)
+- `bonus_missions` — mpn.*. bonus.* objects with a best-guess parent quest FQN
+
+---
+
+## Mission tables
+
+Missions are the union of `qst.*` and `mpn.*` objects.
+
+### missions
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `mission_fqn` | TEXT PK | FQN of the mission (qst.* or mpn.*). |
+| `source` | TEXT | `qst` or the mpn prefix. |
+
+### mission_npcs / mission_rewards
+
+Same shape as quest_npcs / quest_rewards but scoped to the missions union.
+
+---
+
+## Discipline tables
+
+### disciplines
+
+One row per discipline (advanced class specialization).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `class_code` | TEXT | e.g. `sith_inquisitor`, `jedi_knight` |
+| `discipline_name` | TEXT | e.g. `hatred`, `deception`, `darkness` |
+| `fqn_prefix` | TEXT | Ability FQN prefix for this discipline, e.g. `abl.sith_inquisitor.skill.hatred` |
+
+### discipline_abilities
+
+Ability slots within a discipline, ordered by tier.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `discipline_fqn_prefix` | TEXT | Links to `disciplines.fqn_prefix`. |
+| `ability_game_id` | TEXT | Links to `objects.game_id`. |
+| `ability_fqn` | TEXT | Ability FQN for direct lookup. |
+| `tier_level` | INTEGER | Unlock level within the discipline (15, 23, 39, 43, 51, 64, 68, 73). |
+| `slot_type` | TEXT | `active`, `passive`, `stance`, `buff` |
+
+### talent_abilities
+
+Abilities granted or modified by talents (passive skill nodes).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `talent_game_id` | TEXT | Links to `objects.game_id` for the `tal.*` object. |
+| `talent_fqn` | TEXT | Talent FQN. |
+| `ability_game_id` | TEXT | 16-char hex GUID from talent payload — may not be in the objects table. |
+| `ability_fqn` | TEXT | Resolved FQN if the GUID matches an extracted object. NULL otherwise. |
+
+---
+
+## Other tables
+
+### conquest_objectives
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `fqn` | TEXT PK | Conquest objective FQN. |
+| `category` | TEXT | `chapter`, `class`, `crafting`, `event`, `flashpoint`, `galactic_seasons`, `location`, `operation`, `spvp`, `uprisings`, `quest`, `weekly` |
+| `subcategory` | TEXT | e.g. `tatooine` (location), `bounty_hunter` (class) |
+| `cadence` | TEXT | `weekly`, `daily`, NULL |
+| `string_id` | INTEGER | Links to strings. |
+
+**Views:** `conquest_invasion_bonuses`, `conquest_theme_strings`
+
+### spawn_runtime_ids
+
+Maps spawn objects to their runtime NPC IDs. Used to resolve NPC links in quest payloads.
+
+### meta
+
+Key/value store for extraction metadata (schema version, extraction timestamp, game version).
+
+---
+
+## Icon lookup
+
+Icons are stored as `{game_id}.webp` under a per-kind subdirectory. Given an object, the CDN path is:
+
+```
+/icons/{kind_slug}/{game_id}.webp
+```
+
+Where `kind_slug` is the lowercase kind: `abilities`, `items`, `talents`, `npcs`, etc.
+
+`game_id` is stable across extractions as long as the object's FQN and GUID don't change. It will change if the object is replaced by a new GUID (e.g. after a major patch rewrite).

--- a/icon_overrides.toml
+++ b/icon_overrides.toml
@@ -1,0 +1,26 @@
+# Icon overrides for abilities whose payloads do not embed an icon reference.
+# These are typically base-class shared abilities recovered from versioned FQNs
+# where the GOM payload uses a different structure that omits the 0x06 icon tag.
+#
+# Format: [[overrides]]  fqn = "..."  icon_name = "..."
+# icon_name must match the DDS basename in /resources/gfx/icons/ (without .dds)
+
+[[overrides]]
+fqn = "abl.sith_warrior.saber_reflect"
+icon_name = "saberreflectjuggernaut"
+
+[[overrides]]
+fqn = "abl.jedi_knight.saber_reflect"
+icon_name = "saberreflectguardian"
+
+[[overrides]]
+fqn = "abl.sith_inquisitor.severing_slash"
+icon_name = "severing_slash_6_0"
+
+[[overrides]]
+fqn = "abl.sith_inquisitor.phantom_stride"
+icon_name = "ass_phantom_stride"
+
+[[overrides]]
+fqn = "abl.sith_inquisitor.skill.hatred.languishing_lashes"
+icon_name = "ass_pass_languishing_lashes"

--- a/src/icon_overrides.rs
+++ b/src/icon_overrides.rs
@@ -1,0 +1,40 @@
+//! Compile-time icon name overrides for abilities that don't embed icon refs in their GOM payload.
+
+use std::collections::HashMap;
+
+const EMBEDDED: &str = include_str!("../icon_overrides.toml");
+
+#[derive(Debug, Default)]
+pub struct IconOverrides {
+    map: HashMap<String, String>,
+}
+
+impl IconOverrides {
+    pub fn from_embedded() -> anyhow::Result<Self> {
+        Self::from_str(EMBEDDED)
+    }
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        #[derive(serde::Deserialize)]
+        struct File {
+            overrides: Vec<Entry>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Entry {
+            fqn: String,
+            icon_name: String,
+        }
+
+        let file: File = toml::from_str(s)?;
+        let map = file
+            .overrides
+            .into_iter()
+            .map(|e| (e.fqn, e.icon_name))
+            .collect();
+        Ok(Self { map })
+    }
+
+    pub fn get(&self, fqn: &str) -> Option<&str> {
+        self.map.get(fqn).map(String::as_str)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dds;
 pub mod gifts;
 pub mod grammar;
 pub mod hash;
+pub mod icon_overrides;
 pub mod myp;
 pub mod pbuk;
 pub mod quest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod dds;
 mod gifts;
 mod grammar;
 mod hash;
+mod icon_overrides;
 mod myp;
 mod pbuk;
 mod quest;
@@ -75,6 +76,15 @@ fn main() -> Result<()> {
         Ok(g) => Some(std::sync::Arc::new(g)),
         Err(e) => {
             eprintln!("Warning: Failed to load grammar rules: {}", e);
+            None
+        }
+    };
+
+    // Load embedded icon overrides (compiled into binary)
+    let icon_overrides = match icon_overrides::IconOverrides::from_embedded() {
+        Ok(o) => Some(o),
+        Err(e) => {
+            eprintln!("Warning: Failed to load icon overrides: {}", e);
             None
         }
     };
@@ -147,6 +157,7 @@ fn main() -> Result<()> {
     let mut total_objects = 0usize;
     let mut total_icons = 0usize;
     let mut seen_hashes: HashSet<u64> = HashSet::new();
+    let mut versioned_seen: HashSet<String> = HashSet::new();
 
     // Buffer icons until objects are processed (need icon_name → game_id mapping)
     let mut pending_icons: Vec<(Vec<u8>, String)> = Vec::new(); // (dds_data, icon_path)
@@ -218,7 +229,13 @@ fn main() -> Result<()> {
                 // Process bucket files (PBUK format)
                 else if is_bucket {
                     if pbuk::is_pbuk(&data) {
-                        if let Ok(count) = process_pbuk(&data, &db, args.unfiltered) {
+                        if let Ok(count) = process_pbuk(
+                            &data,
+                            &db,
+                            args.unfiltered,
+                            icon_overrides.as_ref(),
+                            &mut versioned_seen,
+                        ) {
                             total_objects += count;
                         }
                     } else if pbuk::is_dblb(&data) {
@@ -227,8 +244,14 @@ fn main() -> Result<()> {
                                 let Some(fqn) = normalize_fqn(&obj.fqn) else {
                                     continue;
                                 };
+                                if !versioned_seen.insert(fqn.clone()) {
+                                    continue;
+                                }
                                 obj.fqn = fqn;
-                                let game_obj = schema::GameObject::from_gom(&obj);
+                                let game_obj = schema::GameObject::from_gom_with_overrides(
+                                    &obj,
+                                    icon_overrides.as_ref(),
+                                );
                                 if should_extract_object(&game_obj.fqn, args.unfiltered)
                                     && !game_obj.fqn.is_empty()
                                     && db.insert_object(&game_obj).is_ok()
@@ -241,7 +264,13 @@ fn main() -> Result<()> {
                 }
                 // Process loose PBUK/DBLB files
                 else if pbuk::is_pbuk(&data) {
-                    if let Ok(count) = process_pbuk(&data, &db, args.unfiltered) {
+                    if let Ok(count) = process_pbuk(
+                        &data,
+                        &db,
+                        args.unfiltered,
+                        icon_overrides.as_ref(),
+                        &mut versioned_seen,
+                    ) {
                         total_objects += count;
                     }
                 } else if pbuk::is_dblb(&data) {
@@ -250,8 +279,14 @@ fn main() -> Result<()> {
                             let Some(fqn) = normalize_fqn(&obj.fqn) else {
                                 continue;
                             };
+                            if !versioned_seen.insert(fqn.clone()) {
+                                continue;
+                            }
                             obj.fqn = fqn;
-                            let game_obj = schema::GameObject::from_gom(&obj);
+                            let game_obj = schema::GameObject::from_gom_with_overrides(
+                                &obj,
+                                icon_overrides.as_ref(),
+                            );
                             if should_extract_object(&game_obj.fqn, args.unfiltered)
                                 && !game_obj.fqn.is_empty()
                                 && db.insert_object(&game_obj).is_ok()
@@ -496,21 +531,13 @@ fn resolve_hashes_path(args: &Args) -> Result<Option<PathBuf>> {
     Ok(Some(default_path))
 }
 
-/// Normalize a GOM FQN for extraction.
-///
-/// Unversioned FQNs pass through unchanged. Versioned FQNs (`base/major/minor`)
-/// are kept only when `minor == 0` — the canonical revision — and the version
-/// suffix is stripped so the stored FQN matches the clean unversioned form.
-/// Returns None for non-zero minor versions (skip these objects).
+/// Strip `/major/minor` version suffix from a GOM FQN, or return as-is if unversioned.
+/// Callers deduplicate via `versioned_seen` so only the first-encountered variant per base FQN inserts.
 fn normalize_fqn(fqn: &str) -> Option<String> {
     if !fqn.contains('/') {
         return Some(fqn.to_string());
     }
     let slash1 = fqn.rfind('/')?;
-    let minor: u32 = fqn[slash1 + 1..].parse().ok()?;
-    if minor != 0 {
-        return None;
-    }
     let base_end = fqn[..slash1].rfind('/')?;
     Some(fqn[..base_end].to_string())
 }
@@ -657,7 +684,13 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
     true
 }
 
-fn process_pbuk(data: &[u8], db: &db::Database, unfiltered: bool) -> Result<usize> {
+fn process_pbuk(
+    data: &[u8],
+    db: &db::Database,
+    unfiltered: bool,
+    overrides: Option<&icon_overrides::IconOverrides>,
+    versioned_seen: &mut HashSet<String>,
+) -> Result<usize> {
     let objects = pbuk::parse(data)?;
     let mut count = 0;
 
@@ -665,8 +698,11 @@ fn process_pbuk(data: &[u8], db: &db::Database, unfiltered: bool) -> Result<usiz
         let Some(fqn) = normalize_fqn(&obj.fqn) else {
             continue;
         };
+        if !versioned_seen.insert(fqn.clone()) {
+            continue;
+        }
         obj.fqn = fqn;
-        let game_obj = schema::GameObject::from_gom(&obj);
+        let game_obj = schema::GameObject::from_gom_with_overrides(&obj, overrides);
         if should_extract_object(&game_obj.fqn, unfiltered) && !game_obj.fqn.is_empty() {
             db.insert_object(&game_obj)?;
             count += 1;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,5 +1,6 @@
 //! Schema definitions for SWTOR game objects
 
+use crate::icon_overrides::IconOverrides;
 use crate::pbuk::GomObject;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -63,7 +64,7 @@ impl GameObject {
     /// - GUID extracted from header bytes (first 8 bytes as hex)
     /// - game_id = sha256(fqn:guid)[0:16] for consistent asset naming
     /// - Payload stored as base64 in JSON for later parsing
-    pub fn from_gom(gom: &GomObject) -> Self {
+    pub fn from_gom_with_overrides(gom: &GomObject, overrides: Option<&IconOverrides>) -> Self {
         // Extract kind from FQN prefix (e.g., "itm" from "itm.gen.lots...")
         let kind = if let Some(pos) = gom.fqn.find('.') {
             match &gom.fqn[..pos] {
@@ -100,10 +101,13 @@ impl GameObject {
 
         // Extract visual reference / icon name from payload
         // Abilities: icon at start, Talents: icon at end
+        // Fall back to compiled-in icon_overrides.toml for abilities whose payloads
+        // don't embed the icon reference (e.g. versioned-origin base-class abilities).
         let icon_name = if gom.fqn.starts_with("tal.") {
             Self::extract_visual_ref_reverse(&gom.payload)
         } else {
             Self::extract_visual_ref(&gom.payload)
+                .or_else(|| overrides.and_then(|o| o.get(&gom.fqn).map(str::to_string)))
         };
 
         // Extract string_id: try FQN-based first (finds 91% of quests), then type-marker fallback

--- a/tests/schema_test.rs
+++ b/tests/schema_test.rs
@@ -35,7 +35,7 @@ fn test_icon_name_extraction_ability() {
     payload[19..19 + icon.len()].copy_from_slice(icon);
 
     let gom = make_gom("abl.sith_warrior.rage", payload);
-    let obj = GameObject::from_gom(&gom);
+    let obj = GameObject::from_gom_with_overrides(&gom, None);
 
     assert_eq!(obj.icon_name, Some("abl_sw_rage_icon".to_string()));
     assert_eq!(obj.kind, "Ability");
@@ -56,7 +56,7 @@ fn test_icon_name_extraction_talent() {
     payload[icon_offset + 2..icon_offset + 2 + icon_name.len()].copy_from_slice(icon_name);
 
     let gom = make_gom("tal.bounty_hunter.skill.utility.kolto_surge", payload);
-    let obj = GameObject::from_gom(&gom);
+    let obj = GameObject::from_gom_with_overrides(&gom, None);
 
     assert_eq!(obj.icon_name, Some("abl_bh_me_kolto_surge".to_string()));
     // Talents get kind mapped like other prefixes
@@ -68,7 +68,7 @@ fn test_icon_name_no_match() {
     // Payload with no valid icon pattern
     let payload = vec![0u8; 100];
     let gom = make_gom("abl.test.ability", payload);
-    let obj = GameObject::from_gom(&gom);
+    let obj = GameObject::from_gom_with_overrides(&gom, None);
 
     assert!(obj.icon_name.is_none());
 }
@@ -89,7 +89,7 @@ fn test_icon_name_skips_str_prefix() {
     payload[192..200].copy_from_slice(b"railshot");
 
     let gom = make_gom("tal.test.talent", payload);
-    let obj = GameObject::from_gom(&gom);
+    let obj = GameObject::from_gom_with_overrides(&gom, None);
 
     // Should get railshot, not str.tal
     assert_eq!(obj.icon_name, Some("railshot".to_string()));


### PR DESCRIPTION
## Summary

- Adds `icon_overrides.toml` at repo root — compile-time FQN→icon_name mappings for abilities whose GOM payloads don't embed a `0x06` icon tag (versioned-origin base-class abilities recovered in #53)
- New `src/icon_overrides.rs` module follows grammar.toml pattern: `include_str!`, `from_embedded()`, warn-and-continue on load failure
- `from_gom_with_overrides` in schema applies overrides as fallback after payload extraction fails
- `versioned_seen: HashSet<String>` added to all extraction paths — prevents multiple versioned variants of the same ability from inserting as separate rows with different game_ids
- Initial mappings: `saber_reflect` (SW/JK), `severing_slash`, `phantom_stride`, `languishing_lashes`
- Closes #55 partially (tracking issue for remaining mappings)

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Re-extract with `--icons` and verify `icon_name` is populated for the 5 mapped abilities
- [ ] Verify abilities table has no duplicate FQN rows after extraction