### PR TITLE
feat: game_id = sha256(normalized_fqn)[0:16]

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -10,16 +10,17 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-/// Compute compound ID from FQN and GUID
-/// Returns 16-character hex string: sha256(fqn:guid)[0:16]
+/// Compute game_id from normalized FQN.
+/// Returns 16-character hex string: sha256(fqn)[0:16]
 ///
-/// Deterministic and collision-resistant - if either FQN or GUID changes,
-/// the ID changes. Useful for detecting data corruption/reuse.
-pub fn compute_game_id(fqn: &str, guid: &str) -> String {
+/// Stable across patch versions — the FQN is Bioware's semantic identity
+/// for an object and does not change when the object is patched (GUID does).
+/// Enables cross-version delta tracking by joining on game_id.
+pub fn compute_game_id(fqn: &str) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(format!("{}:{}", fqn, guid));
+    hasher.update(fqn);
     let result = hasher.finalize();
-    hex::encode(&result[..8]) // 8 bytes = 16 hex chars
+    hex::encode(&result[..8])
 }
 
 /// Compute icon ID from icon name

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -93,8 +93,8 @@ impl GameObject {
         let guid = read_header_guid(&gom.header, 0);
         let template_guid = read_header_guid(&gom.header, 16);
 
-        // Compute game_id: sha256(fqn:guid)[0:16] - deterministic compound ID
-        let game_id = crate::hash::compute_game_id(&gom.fqn, &guid);
+        // Compute game_id: sha256(fqn)[0:16] - stable across patch versions
+        let game_id = crate::hash::compute_game_id(&gom.fqn);
 
         // Extract strings from payload for searchability
         let strings = gom.extract_strings();


### PR DESCRIPTION
## Summary

- Changes `compute_game_id` from `sha256(fqn:guid)` to `sha256(fqn)`
- game_id is now stable across patch versions — GUID changes when Bioware patches an object, FQN does not
- Enables cross-version delta tracking: join on game_id across extractions to see exactly what changed between game patches
- Removes the GUID component which was adding instability, not collision resistance (FQN is Bioware's semantic identity)

## Dependency
huttspawn's `computeGameId()` must be updated to match before re-syncing icons and data.

## Test plan
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] Re-extract and verify game_ids are stable (same FQN = same game_id across two extractions)
- [ ] huttspawn updated and rebuilt from new spice.sqlite before icon sync