### PR TITLE
fix(docs): correct id1 mapping in schema.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 - mpn.* objects now classify as `kind='Phase'` (was `kind='Quest'`). Mission phases were inflating the Quest count 8x and polluting `quest_details` with phase-shaped rows that were never real missions. New `phases` view exposes them. Closes #23.
 - Spawn-prefix fallback in populate_quest_npcs: encounters that reference a base spawn name (e.g. `spn.X.multi.isen`) which the engine resolves at runtime to variants (`isen_no_weapon`, `isen_captured`) now resolve to the underlying NPC via prefix-match. Closes the_devoted_ones case from #27.
 - string_id type-marker decoder tries 3-byte big-endian before 4-byte little-endian. The previous LE32-first order was poisoning achievement IDs by absorbing a trailing 0x00 separator byte. Achievement string_id coverage 42% -> 99.9%; conquest objectives specifically went 0% -> 100% (687/687). No regression on quests/items/talents. Closes #37.
+- docs/schema.md id1 mapping corrected: id1=0 is the canonical name, id1=1 is the description. The doc previously said id1=1 was name and id1=2 was short description, which contradicts every actual STB row. Reported by huttspawn (verified vs dark_ward / string_id 227187).
 
 ### Removed
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -153,12 +153,12 @@ SELECT o.fqn, s.text
 FROM objects o
 JOIN strings s ON s.id2 = o.string_id AND s.locale = 'en-us'
 WHERE o.kind = 'Ability'
-  AND s.id1 = (SELECT MIN(id1) FROM strings WHERE id2 = o.string_id AND locale = 'en-us');
+  AND s.id1 = 0;
 ```
 
 id1 values by content type (approximate):
-- `1` — object name
-- `2` — short description
+- `0` — object name (canonical display name)
+- `1` — description / short description
 - `200–600` — quest step descriptions
 
 ---

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -156,10 +156,14 @@ WHERE o.kind = 'Ability'
   AND s.id1 = 0;
 ```
 
-id1 values by content type (approximate):
-- `0` — object name (canonical display name)
-- `1` — description / short description
-- `200–600` — quest step descriptions
+id1 mapping varies by object kind:
+
+| Kind | Name | Description / steps |
+|------|------|----------------------|
+| Ability, Item, Npc, Talent, Achievement, Codex | `id1 = 0` | `id1 = 1` |
+| Quest (`qst.*` / `mpn.*`) | `id1 = 88` | step descriptions at `id1 = 258`, `259`, `274+` (range ~200–600) |
+
+The `quest_descriptions` view selects the first quest description string in the 200–600 range. For non-quest objects, join on `id1 = 0` for name and `id1 = 1` for description.
 
 ---
 


### PR DESCRIPTION
## Summary

- docs/schema.md said id1=1 is name, id1=2 short description -- wrong.
- Verified against dark_ward (string_id 227187): id1=0 = canonical name, id1=1 = description.
- Tightened example join from MIN(id1) subquery to s.id1 = 0.

Reported by huttspawn on the bullpen (id 019dd342-8d63-7eb3-a0cb-b0ea42dca321).

## Test plan
- [x] sqlite verification on real extraction
- [x] CHANGELOG updated under [Unreleased] / Fixed