### PR TITLE
fix: pick highest-quality variant per FQN (cuts ability NULL string_id 77% -> 14%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 ## [Unreleased]
 
+### Fixed
+
+- Per-FQN extraction now keeps the highest-quality variant instead of the first-encountered. Multiple GOM objects can share an FQN across archives (canonical objects with full payload alongside stub references); the previous `HashSet`-based dedup picked whichever appeared first in archive iteration order, which produced 77% NULL string_id and 80% NULL icon_name for abilities because stubs commonly came first. `accept_variant` now scores candidates by (has string_id, has icon_name, payload size) and skips inferior ones. A `dedup_objects_by_fqn` SQL pass runs after extraction to collapse any remaining multi-GUID FQN rows down to the single best variant.
+
 ### Added
 
 - quest_chain table populated from `0xCF` big-endian GUID refs in quest payloads; fixes the zero-row bug from PR #11 where bytes were read as little-endian (closes #7)

--- a/src/db.rs
+++ b/src/db.rs
@@ -597,6 +597,41 @@ impl Database {
     /// Reads all quest objects, classifies them by FQN, and extracts embedded
     /// references (NPCs, phases, prerequisites) from the base64 payload.
     /// Must be called after all objects and strings are flushed.
+    /// Collapse multi-GUID FQN rows down to one "best" row per FQN.
+    ///
+    /// During extraction, the same FQN can appear under multiple GUIDs --
+    /// canonical objects with full payload, plus stub references that share
+    /// the FQN. The in-memory accept_variant filter blocks inferior variants
+    /// that follow a superior one, but cannot retroactively remove a stub
+    /// that was inserted before the canonical version arrived. This pass
+    /// keeps the row with the highest "extraction quality" per FQN: prefers
+    /// non-NULL string_id, then non-NULL icon_name, then larger json payload.
+    pub fn dedup_objects_by_fqn(&self) -> Result<u64> {
+        self.flush()?;
+        let conn = self.conn.lock().unwrap();
+        let before: u64 = conn.query_row("SELECT COUNT(*) FROM objects", [], |r| r.get(0))?;
+
+        conn.execute(
+            r#"
+            DELETE FROM objects WHERE rowid IN (
+                SELECT rowid FROM (
+                    SELECT rowid, ROW_NUMBER() OVER (
+                        PARTITION BY fqn
+                        ORDER BY (string_id IS NOT NULL) DESC,
+                                 (icon_name IS NOT NULL) DESC,
+                                 length(json) DESC,
+                                 guid ASC
+                    ) AS rn FROM objects
+                ) WHERE rn > 1
+            )
+            "#,
+            [],
+        )?;
+
+        let after: u64 = conn.query_row("SELECT COUNT(*) FROM objects", [], |r| r.get(0))?;
+        Ok(before - after)
+    }
+
     pub fn populate_quest_tables(&self) -> Result<u64> {
         self.flush()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -157,7 +157,16 @@ fn main() -> Result<()> {
     let mut total_objects = 0usize;
     let mut total_icons = 0usize;
     let mut seen_hashes: HashSet<u64> = HashSet::new();
-    let mut versioned_seen: HashSet<String> = HashSet::new();
+    // Per-FQN best-variant score so far. Many FQNs appear multiple times
+    // across archives -- some as canonical objects with full payload, some as
+    // stub references. Picking first-seen (the prior HashSet behaviour)
+    // produced 77% NULL string_id and 80% NULL icon_name for abilities because
+    // stubs frequently came first in iteration order. Scoring prefers
+    // candidates that resolved a string_id, then icon_name, then larger
+    // payloads. Better candidates are still inserted; inferior ones are
+    // skipped. A SQL dedup pass after extraction collapses any remaining
+    // multi-GUID FQNs to the best row.
+    let mut versioned_seen: HashMap<String, u64> = HashMap::new();
 
     // Buffer icons until objects are processed (need icon_name → game_id mapping)
     let mut pending_icons: Vec<(Vec<u8>, String)> = Vec::new(); // (dds_data, icon_path)
@@ -244,14 +253,14 @@ fn main() -> Result<()> {
                                 let Some(fqn) = normalize_fqn(&obj.fqn) else {
                                     continue;
                                 };
-                                if !versioned_seen.insert(fqn.clone()) {
-                                    continue;
-                                }
-                                obj.fqn = fqn;
+                                obj.fqn = fqn.clone();
                                 let game_obj = schema::GameObject::from_gom_with_overrides(
                                     &obj,
                                     icon_overrides.as_ref(),
                                 );
+                                if !accept_variant(&mut versioned_seen, &fqn, &game_obj) {
+                                    continue;
+                                }
                                 if should_extract_object(&game_obj.fqn, args.unfiltered)
                                     && !game_obj.fqn.is_empty()
                                     && db.insert_object(&game_obj).is_ok()
@@ -279,14 +288,14 @@ fn main() -> Result<()> {
                             let Some(fqn) = normalize_fqn(&obj.fqn) else {
                                 continue;
                             };
-                            if !versioned_seen.insert(fqn.clone()) {
-                                continue;
-                            }
-                            obj.fqn = fqn;
+                            obj.fqn = fqn.clone();
                             let game_obj = schema::GameObject::from_gom_with_overrides(
                                 &obj,
                                 icon_overrides.as_ref(),
                             );
+                            if !accept_variant(&mut versioned_seen, &fqn, &game_obj) {
+                                continue;
+                            }
                             if should_extract_object(&game_obj.fqn, args.unfiltered)
                                 && !game_obj.fqn.is_empty()
                                 && db.insert_object(&game_obj).is_ok()
@@ -399,6 +408,15 @@ fn main() -> Result<()> {
         if unmapped_icons > 0 {
             println!("  Unmapped icons (fallback naming): {}", unmapped_icons);
         }
+    }
+
+    // First post-extraction pass: collapse any multi-GUID FQN rows down to
+    // the single best variant per FQN. accept_variant blocked most inferior
+    // variants in-stream, but stubs inserted before a later canonical row
+    // still need cleanup here.
+    let removed_dupes = db.dedup_objects_by_fqn()?;
+    if removed_dupes > 0 {
+        println!("  Deduplicated {} inferior FQN variants", removed_dupes);
     }
 
     // Second pass: populate quest tables from extracted objects
@@ -532,7 +550,9 @@ fn resolve_hashes_path(args: &Args) -> Result<Option<PathBuf>> {
 }
 
 /// Strip `/major/minor` version suffix from a GOM FQN, or return as-is if unversioned.
-/// Callers deduplicate via `versioned_seen` so only the first-encountered variant per base FQN inserts.
+/// Callers deduplicate via `accept_variant`, which keeps the highest-quality
+/// variant per base FQN (preferring objects that resolved a string_id, then
+/// icon_name, then larger payload).
 fn normalize_fqn(fqn: &str) -> Option<String> {
     if !fqn.contains('/') {
         return Some(fqn.to_string());
@@ -689,7 +709,7 @@ fn process_pbuk(
     db: &db::Database,
     unfiltered: bool,
     overrides: Option<&icon_overrides::IconOverrides>,
-    versioned_seen: &mut HashSet<String>,
+    versioned_seen: &mut HashMap<String, u64>,
 ) -> Result<usize> {
     let objects = pbuk::parse(data)?;
     let mut count = 0;
@@ -698,11 +718,11 @@ fn process_pbuk(
         let Some(fqn) = normalize_fqn(&obj.fqn) else {
             continue;
         };
-        if !versioned_seen.insert(fqn.clone()) {
+        obj.fqn = fqn.clone();
+        let game_obj = schema::GameObject::from_gom_with_overrides(&obj, overrides);
+        if !accept_variant(versioned_seen, &fqn, &game_obj) {
             continue;
         }
-        obj.fqn = fqn;
-        let game_obj = schema::GameObject::from_gom_with_overrides(&obj, overrides);
         if should_extract_object(&game_obj.fqn, unfiltered) && !game_obj.fqn.is_empty() {
             db.insert_object(&game_obj)?;
             count += 1;
@@ -710,4 +730,33 @@ fn process_pbuk(
     }
 
     Ok(count)
+}
+
+/// Score a candidate object: prefer those that extracted a string_id, then
+/// those with an icon_name, then larger payloads. Returns a single u64 so
+/// callers can compare with `>`.
+fn score_variant(obj: &schema::GameObject) -> u64 {
+    let payload_size = obj
+        .json
+        .get("payload_size")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let has_string = obj.string_id.is_some() as u64;
+    let has_icon = obj.icon_name.is_some() as u64;
+    (has_string << 40) + (has_icon << 30) + payload_size
+}
+
+/// Return `true` if `obj` is a strictly better variant for this FQN than
+/// anything seen so far, updating the per-FQN best score. Inferior or
+/// duplicate-quality variants return `false` and should be skipped. A
+/// post-extraction SQL dedup collapses any remaining multi-GUID rows.
+fn accept_variant(seen: &mut HashMap<String, u64>, fqn: &str, obj: &schema::GameObject) -> bool {
+    let score = score_variant(obj);
+    match seen.get(fqn).copied() {
+        Some(prev) if prev >= score => false,
+        _ => {
+            seen.insert(fqn.to_string(), score);
+            true
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The same GOM FQN can appear under multiple GUIDs across archives -- a canonical object with full payload alongside stub references that share the FQN. The previous \`HashSet<String>\` dedup picked whichever variant appeared first in archive iteration order, which routinely picked the stub.

Result, against ~/swtor/Assets (7.8.1.c-v2):
- 77% of Ability rows had NULL \`string_id\` (2583/3350)
- 80% of Ability rows had NULL \`icon_name\` (2668/3350)
- Items, NPCs, and other kinds had the same shape of bug, just less visible

\`abl.agent.orbital_strike\` was the smoking gun: \`dump_npp\` showed a 1340-byte canonical payload with \`string_id=499492\` ("Orbital Strike") and \`icon_name=orbitalbombardment\`, but the DB held GUID \`E0002E6E1796D27D\` -- a stub variant with both fields NULL. Six other variants of the same FQN existed in the source data; the canonical one was being filtered out.

## Fix

1. Replace the in-stream \`HashSet<String>\` with \`HashMap<String, u64>\` via \`accept_variant\`, scoring each candidate by:
   - has \`string_id\` (40-bit shift -- dominant)
   - has \`icon_name\` (30-bit shift)
   - payload size (raw bytes)

   Inferior variants are skipped at insertion. Better variants still insert under their own GUID; the prior stub may already be in the DB.

2. Add \`dedup_objects_by_fqn\` -- a single SQL pass that runs immediately after extraction. Uses \`ROW_NUMBER() OVER (PARTITION BY fqn ORDER BY (string_id IS NOT NULL) DESC, (icon_name IS NOT NULL) DESC, length(json) DESC, guid ASC)\` to keep one row per FQN and delete the rest.

The two layers are belt-and-suspenders: \`accept_variant\` cheaply blocks bad candidates in-stream so they never even insert; \`dedup_objects_by_fqn\` is the safety net for rows that landed before a canonical one arrived.

## Results

| metric | before | after |
|---|---:|---:|
| Abilities NULL string_id | 2583 (77%) | **459 (14%)** |
| Abilities NULL icon_name | 2668 (80%) | **909 (27%)** |
| Items | 98833 | 98843 |
| Inferior variants pruned by SQL pass | 0 | 3267 |
| Total objects | 261017 | 264294 |

\`abl.agent.orbital_strike\` now resolves to the canonical row (\`string_id=499492\`, \`icon_name=orbitalbombardment\`).

## Test plan

- [x] \`cargo test --lib\` -- 49 tests pass
- [x] \`cargo clippy --release --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Full extraction against \`~/swtor/Assets\` -- coverage numbers above

## Cross-repo

This is the root cause for the huttspawn 2026-04-28 ping about \`abl.sith_inquisitor.overcharge_saber\` and \`abl.sith_inquisitor.phantom_stride\` having NULL \`string_id\` even though the strings exist. NODE-only abilities (Saber Strike) are still a separate gap (#57), but a meaningful chunk of the "missing strings" backlog is just FQN-dedup picking the wrong variant.