### PR TITLE
feat: extract epp.spvp.* and add GSF companion-loadout probes

### DIFF
--- a/src/bin/probe_companion_byteref.rs
+++ b/src/bin/probe_companion_byteref.rs
@@ -1,0 +1,95 @@
+//! Search every object payload + header for byte-level references to ANY of
+//! the 8 GSF companion NPC GUIDs. Mirrors probe_evasion_byteref but flipped:
+//! "does anything point at a spvp companion?" rather than "does anything
+//! point at a crew talent?"
+
+use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: probe_companion_byteref <spice.sqlite>");
+        std::process::exit(2);
+    }
+    let path = PathBuf::from(&args[1]);
+    let conn = Connection::open(&path)?;
+
+    // 1. Load companion guids.
+    let mut companions: HashMap<[u8; 8], String> = HashMap::new();
+    let mut stmt =
+        conn.prepare("SELECT fqn, guid FROM objects WHERE fqn LIKE 'npc.companion.spvp.%'")?;
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+    for row in rows.filter_map(|r| r.ok()) {
+        let (fqn, guid_hex) = row;
+        let guid = u64::from_str_radix(&guid_hex, 16)?;
+        companions.insert(guid.to_le_bytes(), fqn);
+    }
+    println!("companion GUIDs loaded: {}", companions.len());
+    for (b, f) in &companions {
+        println!("  {} (LE: {:02X?})", f, b);
+    }
+    println!();
+
+    // 2. Scan all objects.
+    let mut stmt = conn.prepare(
+        "SELECT fqn, \
+                json_extract(json, '$.payload_b64'), \
+                json_extract(json, '$.header_hex') \
+         FROM objects",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    })?;
+
+    let mut hits: Vec<(String, String, &'static str)> = Vec::new();
+    let mut total = 0usize;
+    for row in rows.filter_map(|r| r.ok()) {
+        total += 1;
+        let (fqn, payload_b64, header_hex) = row;
+        let payload = BASE64.decode(payload_b64.as_bytes()).unwrap_or_default();
+        let header = hex::decode(&header_hex).unwrap_or_default();
+
+        // Skip the companion's own row in payload+header.
+        if fqn.starts_with("npc.companion.spvp.") {
+            continue;
+        }
+
+        for win_size in [8usize] {
+            for buf in [(&payload[..], "payload"), (&header[..], "header")] {
+                let (bytes, source) = buf;
+                if bytes.len() < win_size {
+                    continue;
+                }
+                for w in bytes.windows(win_size) {
+                    let arr: [u8; 8] = w.try_into().unwrap();
+                    if let Some(comp_fqn) = companions.get(&arr) {
+                        hits.push((fqn.clone(), comp_fqn.clone(), source));
+                    }
+                }
+            }
+        }
+    }
+
+    println!(
+        "scanned {} objects (excluding the 8 companions themselves)",
+        total
+    );
+    println!("\n=== hits ===");
+    if hits.is_empty() {
+        println!("(none)");
+    } else {
+        for (owner, target, source) in &hits {
+            println!("  {} ({})  ->  {}", owner, source, target);
+        }
+    }
+
+    Ok(())
+}

--- a/src/bin/probe_evasion_byteref.rs
+++ b/src/bin/probe_evasion_byteref.rs
@@ -1,0 +1,119 @@
+//! Search every object payload for byte-level references to
+//! `tal.spvp.crew.defensive.evasion` (the +5% Evasion crew talent):
+//!   - GUID  E000263B65AEA214 as LE u64 in payload
+//!   - GUID  E000263B65AEA214 as LE u64 in header
+//!   - string_id 770237 (0xBC0BD) as LE u32 in payload
+//!   - same as LE u16 (in case it's a smaller field)
+//!
+//! Reports any object whose bytes match -- which would be a candidate "owner"
+//! that grants this crew talent.
+
+use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+const TARGET_GUID_HEX: &str = "E000263B65AEA214";
+const TARGET_STRING_ID: u32 = 770237;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: probe_evasion_byteref <spice.sqlite>");
+        std::process::exit(2);
+    }
+    let path = PathBuf::from(&args[1]);
+    let conn = Connection::open(&path)?;
+
+    let target_guid = u64::from_str_radix(TARGET_GUID_HEX, 16)?;
+    let guid_le_bytes = target_guid.to_le_bytes();
+    let guid_be_bytes = target_guid.to_be_bytes();
+    let sid_le4 = TARGET_STRING_ID.to_le_bytes();
+    let sid_le2 = (TARGET_STRING_ID as u16).to_le_bytes();
+
+    println!("target talent: tal.spvp.crew.defensive.evasion");
+    println!(
+        "  guid: {} (LE bytes: {:02X?}, BE bytes: {:02X?})",
+        TARGET_GUID_HEX, guid_le_bytes, guid_be_bytes
+    );
+    println!(
+        "  string_id: {} (LE u32 bytes: {:02X?})",
+        TARGET_STRING_ID, sid_le4
+    );
+    println!();
+
+    let mut stmt = conn.prepare(
+        "SELECT fqn, \
+                json_extract(json, '$.payload_b64'), \
+                json_extract(json, '$.header_hex') \
+         FROM objects",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    })?;
+
+    let mut total = 0usize;
+    let mut hit_guid_payload_le = Vec::new();
+    let mut hit_guid_payload_be = Vec::new();
+    let mut hit_guid_header_le = Vec::new();
+    let mut hit_sid_payload_u32 = Vec::new();
+    let mut hit_sid_payload_u16 = Vec::new();
+
+    for row in rows.filter_map(|r| r.ok()) {
+        total += 1;
+        let (fqn, payload_b64, header_hex) = row;
+        let payload = match BASE64.decode(payload_b64.as_bytes()) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let header = hex::decode(&header_hex).unwrap_or_default();
+
+        if find_window(&payload, &guid_le_bytes) {
+            hit_guid_payload_le.push(fqn.clone());
+        }
+        if find_window(&payload, &guid_be_bytes) {
+            hit_guid_payload_be.push(fqn.clone());
+        }
+        if find_window(&header, &guid_le_bytes) {
+            hit_guid_header_le.push(fqn.clone());
+        }
+        if find_window(&payload, &sid_le4) {
+            hit_sid_payload_u32.push(fqn.clone());
+        }
+        if find_window(&payload, &sid_le2) {
+            hit_sid_payload_u16.push(fqn.clone());
+        }
+    }
+
+    println!("scanned {} objects\n", total);
+
+    fn report(label: &str, hits: &[String]) {
+        println!("=== {} -- {} hit(s) ===", label, hits.len());
+        for h in hits.iter().take(60) {
+            println!("  {}", h);
+        }
+        if hits.len() > 60 {
+            println!("  ... ({} more)", hits.len() - 60);
+        }
+        println!();
+    }
+
+    report("GUID match in payload (LE)", &hit_guid_payload_le);
+    report("GUID match in payload (BE)", &hit_guid_payload_be);
+    report("GUID match in header (LE)", &hit_guid_header_le);
+    report("string_id match in payload (LE u32)", &hit_sid_payload_u32);
+    report("string_id match in payload (LE u16)", &hit_sid_payload_u16);
+
+    Ok(())
+}
+
+fn find_window(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return false;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}

--- a/src/bin/probe_gsf_companion_loadouts.rs
+++ b/src/bin/probe_gsf_companion_loadouts.rs
@@ -1,0 +1,286 @@
+//! Probe whether `npc.companion.spvp.*` payloads embed GUID references to the
+//! crew talent (`tal.spvp.crew.*`) and crew ability (`abl.spvp.crew.*`)
+//! objects that define each GSF companion's two passive stat modifiers and
+//! single active ability.
+//!
+//! Strategy: build a GUID -> fqn map for every `tal.spvp.crew.*` and
+//! `abl.spvp.crew.*` object, then for each `npc.companion.spvp.*` decode
+//! its payload and (a) pull every `cf XX..` GUID-marker record and (b)
+//! brute-force every overlapping 8-byte window against the crew GUID set
+//! to catch references that don't use the `cf` marker. Report matches
+//! per companion plus a summary.
+//!
+//! Usage: ./target/release/probe_gsf_companion_loadouts <spice.sqlite>
+
+use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use rusqlite::Connection;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: probe_gsf_companion_loadouts <spice.sqlite>");
+        std::process::exit(2);
+    }
+    let path = PathBuf::from(&args[1]);
+    let conn = Connection::open(&path)?;
+
+    // 1. Build crew GUID -> (kind_tag, fqn) lookup.
+    //    kind_tag is "tal" or "abl" so we can classify matches.
+    let mut crew: HashMap<String, (&'static str, String)> = HashMap::new();
+    {
+        let mut stmt = conn.prepare(
+            "SELECT guid, fqn FROM objects \
+             WHERE fqn LIKE 'tal.spvp.crew.%' OR fqn LIKE 'abl.spvp.crew.%'",
+        )?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+        for row in rows.filter_map(|r| r.ok()) {
+            let (guid, fqn) = row;
+            let kind = if fqn.starts_with("tal.") {
+                "tal"
+            } else {
+                "abl"
+            };
+            crew.insert(guid.to_uppercase(), (kind, fqn));
+        }
+    }
+    println!("crew object GUIDs loaded: {}", crew.len());
+
+    // 2. Walk every npc.companion.spvp.* payload AND header.
+    //    Header layout known: bytes 0-7 = content GUID, 16-23 = template GUID.
+    //    Bytes 8-15 and 24-41 are unparsed -- prime candidates for embedded
+    //    GUID refs (e.g. crew talents/abilities).
+    let mut stmt = conn.prepare(
+        "SELECT fqn, \
+                json_extract(json, '$.payload_b64'), \
+                json_extract(json, '$.header_hex') \
+         FROM objects WHERE fqn LIKE 'npc.companion.spvp.%' \
+         ORDER BY fqn",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    })?;
+
+    let mut summary_cf_hits: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
+    let mut summary_window_hits: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
+    let mut crew_object_hit_count: HashMap<String, usize> = HashMap::new();
+
+    type HeaderHit = (Vec<String>, Vec<String>, Vec<(usize, String)>);
+    let mut summary_header_hits: BTreeMap<String, HeaderHit> = BTreeMap::new();
+
+    for row in rows.filter_map(|r| r.ok()) {
+        let (fqn, payload_b64, header_hex) = row;
+        let payload = BASE64.decode(payload_b64.as_bytes())?;
+        let header = hex::decode(&header_hex).unwrap_or_default();
+
+        // Header scan: brute-force every overlapping 8-byte window over the
+        // unparsed regions (8-15 and 24-end). Print the offset of any hit so
+        // we can confirm a fixed slot.
+        let mut hdr_tals = Vec::new();
+        let mut hdr_abls = Vec::new();
+        let mut hdr_offsets: Vec<(usize, String)> = Vec::new();
+        if header.len() >= 8 {
+            for start in 0..=header.len() - 8 {
+                // Skip the known content-GUID slot (0..8) and template-GUID slot (16..24).
+                if start == 0 {
+                    continue;
+                }
+                if (16..24).contains(&start) {
+                    continue;
+                }
+                let bytes: [u8; 8] = header[start..start + 8].try_into().unwrap();
+                let guid_le = format!("{:016X}", u64::from_le_bytes(bytes));
+                let guid_be = format!("{:016X}", u64::from_be_bytes(bytes));
+                for guid in [&guid_le, &guid_be] {
+                    if let Some((kind, target_fqn)) = crew.get(guid) {
+                        let entry = format!("{} -> {} (offset {})", guid, target_fqn, start);
+                        if *kind == "tal" {
+                            hdr_tals.push(entry.clone());
+                        } else {
+                            hdr_abls.push(entry.clone());
+                        }
+                        hdr_offsets.push((start, target_fqn.clone()));
+                    }
+                }
+            }
+        }
+        summary_header_hits.insert(fqn.clone(), (hdr_tals, hdr_abls, hdr_offsets));
+
+        // a. cf-marker GUIDs.
+        let mut cf_guids: BTreeSet<String> = BTreeSet::new();
+        let mut i = 0;
+        while i + 9 <= payload.len() {
+            if payload[i] == 0xCF {
+                let bytes: [u8; 8] = payload[i + 1..i + 9].try_into().unwrap();
+                let guid = format!("{:016X}", u64::from_le_bytes(bytes));
+                cf_guids.insert(guid);
+                i += 9;
+            } else {
+                i += 1;
+            }
+        }
+
+        // b. Brute-force every 8-byte window (overlapping).
+        let mut window_guids: BTreeSet<String> = BTreeSet::new();
+        if payload.len() >= 8 {
+            for start in 0..=payload.len() - 8 {
+                let bytes: [u8; 8] = payload[start..start + 8].try_into().unwrap();
+                let guid = format!("{:016X}", u64::from_le_bytes(bytes));
+                if crew.contains_key(&guid) {
+                    window_guids.insert(guid);
+                }
+            }
+        }
+
+        let mut cf_tals = Vec::new();
+        let mut cf_abls = Vec::new();
+        for g in &cf_guids {
+            if let Some((kind, target_fqn)) = crew.get(g) {
+                let entry = format!("{} -> {}", g, target_fqn);
+                if *kind == "tal" {
+                    cf_tals.push(entry);
+                } else {
+                    cf_abls.push(entry);
+                }
+                *crew_object_hit_count.entry(target_fqn.clone()).or_default() += 1;
+            }
+        }
+
+        let mut win_tals = Vec::new();
+        let mut win_abls = Vec::new();
+        for g in &window_guids {
+            if let Some((kind, target_fqn)) = crew.get(g) {
+                let entry = format!("{} -> {}", g, target_fqn);
+                if *kind == "tal" {
+                    win_tals.push(entry);
+                } else {
+                    win_abls.push(entry);
+                }
+            }
+        }
+
+        summary_cf_hits.insert(fqn.clone(), (cf_tals, cf_abls));
+        summary_window_hits.insert(fqn, (win_tals, win_abls));
+    }
+
+    // 3. Report.
+    println!("\n=== per-companion: cf-marker matches ===");
+    for (fqn, (tals, abls)) in &summary_cf_hits {
+        println!("\n{}", fqn);
+        println!("  tal.spvp.crew matches ({})", tals.len());
+        for t in tals {
+            println!("    {}", t);
+        }
+        println!("  abl.spvp.crew matches ({})", abls.len());
+        for a in abls {
+            println!("    {}", a);
+        }
+    }
+
+    println!("\n=== per-companion: brute-force 8-byte window matches ===");
+    println!("(use this if cf-marker count looks wrong)");
+    for (fqn, (tals, abls)) in &summary_window_hits {
+        let total = tals.len() + abls.len();
+        if total == 0 {
+            println!("\n{}  -- NO WINDOW HITS", fqn);
+        } else {
+            println!("\n{}  ({} tal + {} abl)", fqn, tals.len(), abls.len());
+            for t in tals {
+                println!("    {}", t);
+            }
+            for a in abls {
+                println!("    {}", a);
+            }
+        }
+    }
+
+    println!("\n=== per-companion: HEADER scan (bytes 8-15, 24-41) ===");
+    for (fqn, (tals, abls, offsets)) in &summary_header_hits {
+        let total = tals.len() + abls.len();
+        if total == 0 {
+            println!("\n{}  -- NO HEADER HITS", fqn);
+        } else {
+            println!("\n{}  ({} tal + {} abl)", fqn, tals.len(), abls.len());
+            for t in tals {
+                println!("    {}", t);
+            }
+            for a in abls {
+                println!("    {}", a);
+            }
+            let _ = offsets;
+        }
+    }
+
+    println!("\n=== raw header dumps (so we can eyeball unparsed regions) ===");
+    let mut stmt = conn.prepare(
+        "SELECT fqn, json_extract(json, '$.header_hex') FROM objects \
+         WHERE fqn LIKE 'npc.companion.spvp.%' ORDER BY fqn",
+    )?;
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+    for row in rows.filter_map(|r| r.ok()) {
+        let (fqn, header_hex) = row;
+        println!("\n  {}", fqn);
+        println!("    full   : {}", header_hex);
+        let bytes = hex::decode(&header_hex).unwrap_or_default();
+        if bytes.len() >= 8 {
+            println!(
+                "    [00-07]: {} (content GUID, LE u64)",
+                hex::encode_upper(&bytes[0..8])
+            );
+        }
+        if bytes.len() >= 16 {
+            println!(
+                "    [08-15]: {} (UNPARSED)",
+                hex::encode_upper(&bytes[8..16])
+            );
+        }
+        if bytes.len() >= 24 {
+            println!(
+                "    [16-23]: {} (template GUID)",
+                hex::encode_upper(&bytes[16..24])
+            );
+        }
+        if bytes.len() > 24 {
+            println!(
+                "    [24-{:02}]: {} (UNPARSED)",
+                bytes.len() - 1,
+                hex::encode_upper(&bytes[24..])
+            );
+        }
+    }
+
+    println!("\n=== summary ===");
+    let total = summary_cf_hits.len();
+    let with_2tal_1abl_cf = summary_cf_hits
+        .values()
+        .filter(|(t, a)| t.len() == 2 && a.len() == 1)
+        .count();
+    let with_2tal_1abl_win = summary_window_hits
+        .values()
+        .filter(|(t, a)| t.len() == 2 && a.len() == 1)
+        .count();
+    println!("companions probed: {}", total);
+    println!(
+        "companions with exactly 2 tal + 1 abl crew refs (cf marker): {}/{}",
+        with_2tal_1abl_cf, total
+    );
+    println!(
+        "companions with exactly 2 tal + 1 abl crew refs (window):    {}/{}",
+        with_2tal_1abl_win, total
+    );
+
+    println!("\ntop crew objects referenced (cf marker, by hit count):");
+    let mut hit_counts: Vec<_> = crew_object_hit_count.iter().collect();
+    hit_counts.sort_by(|a, b| b.1.cmp(a.1));
+    for (fqn, count) in hit_counts.iter().take(20) {
+        println!("  {:3}x  {}", count, fqn);
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,7 +709,7 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
         // mechanics. Story-arc content lives under epp.exp.*.
         let is_encounter_or_companion = matches!(
             second,
-            "companion" | "flashpoint" | "operation" | "qtr" | "daily_area" | "exp"
+            "companion" | "flashpoint" | "operation" | "qtr" | "daily_area" | "exp" | "spvp"
         );
         if !(is_player_class || is_shared_flurry || is_encounter_or_companion) {
             return false;


### PR DESCRIPTION
## Summary
- Add `'spvp'` to the epp encounter/companion namespace whitelist in `src/main.rs::should_extract_object`. Brings 170 new `epp.spvp.*` records into extraction (drone summons, mine detonates, missile warheads, shield activations, plus 15 `epp.spvp.crew.*.activate` audio dispatches).
- Land three probe binaries alongside the existing `verify_gsf_*` tools as documentation of how the GSF crew-loadout investigation was carried out: `probe_gsf_companion_loadouts`, `probe_evasion_byteref`, `probe_companion_byteref`.

## Findings
All three probes return zero hits across 310,791 objects -- the per-companion crew loadout map (which 2 stat modifiers + 1 active ability each spvp companion grants) is **not present** in any byte kessel extracts from the .tor archives. The link lives in client UI definition files outside the asset surface. Reflection: 019de734-f54e-7813-b5ee-d68bc4159602.

## Test plan
- [x] cargo fmt clean
- [x] cargo clippy --release --bins -- -D warnings clean
- [x] cargo test --release --lib (93 passed)
- [ ] Re-extract on Sean's SWTOR install and confirm SELECT COUNT(*) FROM objects WHERE fqn LIKE 'epp.spvp%' returns ~170