### PR TITLE
feat: discipline_talents + class-shared/utility fan-out + string_id backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 ## [Unreleased]
 
+### Added
+
+- **`discipline_talents` table** -- mechanical FQN-pattern mapping of `tal.<class>.skill.<segment>.<rest>` rows to disciplines. Closes the long-standing "discipline_abilities is way smaller than huttspawn's curated tree" gap by surfacing the talent half of the discipline tree. Per-class utility talents (`tal.<class>.skill.utility.*`) are fanned out to every combat discipline of that class -- mirrors how SWTOR exposes utility picks across all combat-tree pages. No tier_level / column coordinates: SWTOR's editorial tree layout (which talent sits at what tier on screen) is not encoded in tal.* payloads or FQNs, and was never something kessel could derive without speculating. The MAPPINGS.md "Effect Block Structure / level 68 (0x44)" example was a misread -- that byte is a stat_id followed by an f32 stat value, not a character level. Verified with direct payload inspection across brutality / decimate / dark_mending. Consumers that need editorial tier coordinates layer them on top of `discipline_talents` from a separate curated source.
+
+- **Class-shared and utility ability fan-out in `discipline_abilities`** -- closes the ~451-row gap where bare `abl.<class>.<name>` rows (Saber Reflect, Force Leap, Awe, Blade Storm, Dispatch, Force Charge, Smash, Sweeping Slash, etc.) were extracted into the `objects` table but never linked to any discipline. Now each is fanned out to every combat discipline of its class with `slot_type = 'class_shared'`. Utility abilities (`abl.<class>.skill.utility.<name>`, e.g. Thwart) get the same treatment with `slot_type = 'utility'`. discipline_abilities total grew 1,133 -> 4,829 across 8 player classes x ~6 disciplines.
+
+- **`backfill_missing_string_ids` post-extraction pass** -- recovers `string_id` linkages for canonical `abl.*` rows whose GOM payload doesn't carry a string-table type marker (so neither the FQN-based nor type-marker-based extractors at construction time could find the linkage). Strategy: derive expected display name from FQN's last segment (snake_case -> Title Case), look up STB strings whose text matches at id1=0 AND that have a description at id1=1, only commit when exactly one unused candidate remains. Fixes the canonical examples `abl.smuggler.skill.saboteur.sabotage`, `abl.trooper.skill.assault_specialist.mag_bolt`, `abl.sith_inquisitor.skill.corruption.mods.tier1.fueled_corruption`. Backfills ~14 rows in a 7.8.1.c extraction; conservative by design (id1=1-description filter rules out homonym/UI-label false positives).
+
 ### Changed
 
 - **Identity model: `objects` PK is now `game_id` (compound, restored), not raw `guid`.** Three-id model:

--- a/src/db.rs
+++ b/src/db.rs
@@ -626,6 +626,32 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_discipline_abilities_disc ON discipline_abilities(discipline_fqn_prefix);
             CREATE INDEX IF NOT EXISTS idx_discipline_abilities_abl  ON discipline_abilities(ability_game_id);
 
+            -- Discipline talents: every tal.* that belongs to a discipline.
+            -- Mapping is mechanical from FQN: a talent at
+            --   tal.<class>.skill.<segment>.<name>
+            -- maps to the discipline whose fqn_prefix is
+            --   abl.<class>.skill.<segment>
+            -- This includes the per-class shared utility discipline
+            -- (tal.<class>.skill.utility.*) -- consumers fold those into
+            -- combat-discipline trees editorially if they want.
+            --
+            -- No tier_level column. SWTOR's discipline-tree tier coordinates
+            -- (which talent sits at which level/column on screen) are not
+            -- encoded in tal.* payloads or FQN segments -- that's editorial
+            -- tree layout that lives outside kessel's source data. The
+            -- junction is mechanical membership only; trees rendered from
+            -- it need a separate curated layout layer.
+            CREATE TABLE IF NOT EXISTS discipline_talents (
+                discipline_fqn_prefix  TEXT NOT NULL,
+                talent_game_id         TEXT NOT NULL,
+                talent_fqn             TEXT NOT NULL,
+                PRIMARY KEY (discipline_fqn_prefix, talent_game_id),
+                FOREIGN KEY (talent_game_id) REFERENCES objects(game_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_discipline_talents_disc ON discipline_talents(discipline_fqn_prefix);
+            CREATE INDEX IF NOT EXISTS idx_discipline_talents_tal  ON discipline_talents(talent_game_id);
+
             -- Talent → ability links: GUID refs decoded from tal.* payloads.
             -- 37% of talents reference 1-3 abilities via CC 17E2840B + CF GUID pattern.
             CREATE TABLE IF NOT EXISTS talent_abilities (
@@ -963,6 +989,104 @@ impl Database {
         )?;
 
         Ok(demoted as u64)
+    }
+
+    /// Backfill `objects.string_id` for canonical `abl.*` rows whose payload
+    /// did not carry a CE/string-table marker (so neither
+    /// `extract_string_id_via_fqn_with` nor `extract_string_id_via_type_marker`
+    /// could recover the linkage at extraction time).
+    ///
+    /// Strategy: the ability's display name is recoverable from the FQN's
+    /// last segment (snake_case -> Title Case). For each candidate row, look
+    /// up STB strings whose text matches that name at id1=0 AND that have a
+    /// description at id1=1 (real abilities have both; UI labels usually
+    /// don't). Only commit when exactly one match remains and the candidate
+    /// id2 is not already linked to another canonical object.
+    ///
+    /// Recovers a small set of discipline-pick abilities like
+    /// `abl.smuggler.skill.saboteur.sabotage` whose GOM payload encodes
+    /// effect references but omits the string-table type marker. Without
+    /// this pass these rows ship with NULL string_id and cannot be joined
+    /// to display-name strings via the standard `id1 = 0` pattern.
+    ///
+    /// Returns count of rows updated.
+    pub fn backfill_missing_string_ids(&self) -> Result<u64> {
+        self.flush()?;
+        let conn = self.conn.lock().unwrap();
+
+        // Gather candidate rows: canonical abl.* abilities with NULL
+        // string_id. Only abl.* — talents and other kinds use different
+        // string-linking patterns and should not be heuristically matched.
+        let candidates: Vec<(String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT game_id, fqn FROM objects \
+                 WHERE kind = 'Ability' AND fqn LIKE 'abl.%' \
+                   AND is_canonical = 1 AND string_id IS NULL",
+            )?;
+            let result: Vec<(String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            result
+        };
+
+        if candidates.is_empty() {
+            return Ok(0);
+        }
+
+        // Already-linked string_ids -- never reuse one across abilities;
+        // a duplicate link would be a false positive on a homonym.
+        let used: std::collections::HashSet<u32> = {
+            let mut stmt = conn.prepare(
+                "SELECT DISTINCT string_id FROM objects \
+                 WHERE string_id IS NOT NULL AND is_canonical = 1",
+            )?;
+            let result: std::collections::HashSet<u32> = stmt
+                .query_map([], |row| row.get::<_, u32>(0))?
+                .filter_map(|r| r.ok())
+                .collect();
+            result
+        };
+
+        // Lookup by display name -- prepared once, executed per candidate.
+        // Restrict to id2's that have BOTH a name (id1=0) AND a description
+        // (id1=1). Real ability strings always have both; UI-label-only
+        // entries don't, which filters out homonym noise.
+        let mut find_stmt = conn.prepare(
+            "SELECT s.id2 FROM strings s \
+             WHERE s.text = ?1 AND s.locale = 'en-us' AND s.id1 = 0 \
+               AND EXISTS ( \
+                 SELECT 1 FROM strings d \
+                 WHERE d.id2 = s.id2 AND d.id1 = 1 AND d.locale = 'en-us' \
+               )",
+        )?;
+
+        let mut update_stmt =
+            conn.prepare("UPDATE objects SET string_id = ?1 WHERE game_id = ?2")?;
+
+        let mut updated = 0u64;
+        for (game_id, fqn) in &candidates {
+            let last_segment = match fqn.rsplit('.').next() {
+                Some(s) if !s.is_empty() => s,
+                _ => continue,
+            };
+            let expected_name = title_case_from_snake(last_segment);
+
+            let matches: Vec<u32> = find_stmt
+                .query_map([&expected_name], |row| row.get::<_, u32>(0))?
+                .filter_map(|r| r.ok())
+                .filter(|id| !used.contains(id))
+                .collect();
+
+            if matches.len() == 1 {
+                update_stmt.execute(params![matches[0], game_id])?;
+                updated += 1;
+            }
+        }
+
+        Ok(updated)
     }
 
     pub fn populate_quest_tables(&self) -> Result<u64> {
@@ -2994,13 +3118,17 @@ impl Database {
     ///   abl.{class}.skill.{discipline}.mods.special.{name} -> special
     ///   abl.{class}.skill.utility.{name}                   -> utility (shared)
     ///   abl.{class}.skill.mods.tier1.{name}                -> shared mod
+    ///   abl.{class}.{name}                                 -> CLASS-SHARED, fanned out to every discipline of {class}
+    ///                                                        (e.g. abl.jedi_knight.saber_reflect, abl.jedi_knight.force_leap)
     pub fn populate_disciplines(&self) -> Result<(u64, u64)> {
         self.flush()?;
 
         let rows: Vec<(String, String)> = {
             let conn = self.conn.lock().unwrap();
-            let mut stmt =
-                conn.prepare("SELECT fqn, game_id FROM objects WHERE fqn LIKE 'abl.%.skill.%' AND is_canonical = 1")?;
+            let mut stmt = conn.prepare(
+                "SELECT fqn, game_id FROM objects \
+                 WHERE fqn LIKE 'abl.%' AND kind = 'Ability' AND is_canonical = 1",
+            )?;
             let result: Vec<(String, String)> = stmt
                 .query_map([], |row| {
                     Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
@@ -3010,14 +3138,52 @@ impl Database {
             result
         };
 
+        // Player classes that own a discipline tree. Other `abl.<X>.<name>`
+        // FQNs (companion, racials, legacy, location, customer_service, ...)
+        // are not class-shared player abilities; we ignore them for the
+        // discipline tree.
+        const PLAYER_CLASSES: &[&str] = &[
+            "agent",
+            "bounty_hunter",
+            "jedi_consular",
+            "jedi_knight",
+            "sith_inquisitor",
+            "sith_warrior",
+            "smuggler",
+            "trooper",
+        ];
+
         let mut disc_set: std::collections::HashSet<(String, String, String)> =
             std::collections::HashSet::new();
         let mut abl_rows: Vec<(String, String, String, Option<u8>, String)> = Vec::new();
 
+        // Class-shared abilities: abl.<class>.<name> with no skill segment.
+        // We collect them in pass 1 and fan them out to every discipline of
+        // their class in pass 2 (after disc_set is fully populated by the
+        // discipline-specific rows).
+        let mut class_shared: Vec<(String, String, String)> = Vec::new(); // (class_code, ability_fqn, ability_game_id)
+                                                                          // Utility abilities (abl.<class>.skill.utility.<name>): also fanned
+                                                                          // out to every combat discipline of their class. Mirrors v1's
+                                                                          // discipline_tree_entries shape -- e.g. Thwart at the utility row
+                                                                          // is also visible from the Defense Guardian tree.
+        let mut utility_shared: Vec<(String, String, String)> = Vec::new();
+
         for (fqn, game_id) in &rows {
-            // abl.{class}.skill.{rest}
             let parts: Vec<&str> = fqn.split('.').collect();
-            if parts.len() < 5 {
+
+            // abl.<class>.<name>: 3-segment class-shared ability.
+            // Saber Reflect, Force Leap, Awe, Blade Storm, Dispatch, etc.
+            // ~50-60 per player class. They are available to every discipline
+            // of that class -- fanned out below.
+            if parts.len() == 3 {
+                let class_code = parts[1];
+                if PLAYER_CLASSES.contains(&class_code) {
+                    class_shared.push((class_code.to_string(), fqn.clone(), game_id.clone()));
+                }
+                continue;
+            }
+
+            if parts.len() < 5 || parts[2] != "skill" {
                 continue;
             }
             let class_code = parts[1];
@@ -3026,12 +3192,15 @@ impl Database {
             let slot_type: &str;
             let tier_level: Option<u8>;
 
-            // abl.{class}.skill.utility.{name} -> utility, no discipline
+            // abl.{class}.skill.utility.{name} -> utility row + fan-out
             if parts[3] == "utility" {
                 discipline_name = "utility";
                 fqn_prefix = format!("abl.{}.skill.utility", class_code);
                 slot_type = "utility";
                 tier_level = None;
+                if PLAYER_CLASSES.contains(&class_code) {
+                    utility_shared.push((class_code.to_string(), fqn.clone(), game_id.clone()));
+                }
             } else if parts[3] == "mods" {
                 // abl.{class}.skill.mods.tierN.{name} -> shared mod
                 discipline_name = "shared";
@@ -3082,6 +3251,48 @@ impl Database {
             ));
         }
 
+        // Pass 2: fan out class-shared abilities to every combat discipline
+        // of their class. Skip the per-class "utility" and "shared" rows --
+        // those are aggregation buckets, not real combat trees, and would
+        // produce duplicate edges if we included them.
+        let mut disciplines_by_class: std::collections::HashMap<&str, Vec<String>> =
+            std::collections::HashMap::new();
+        for (class_code, discipline_name, fqn_prefix) in &disc_set {
+            if discipline_name == "utility" || discipline_name == "shared" {
+                continue;
+            }
+            disciplines_by_class
+                .entry(class_code.as_str())
+                .or_default()
+                .push(fqn_prefix.clone());
+        }
+        for (class_code, ability_fqn, game_id) in &class_shared {
+            if let Some(prefixes) = disciplines_by_class.get(class_code.as_str()) {
+                for disc_prefix in prefixes {
+                    abl_rows.push((
+                        disc_prefix.clone(),
+                        game_id.clone(),
+                        ability_fqn.clone(),
+                        None,
+                        "class_shared".to_string(),
+                    ));
+                }
+            }
+        }
+        for (class_code, ability_fqn, game_id) in &utility_shared {
+            if let Some(prefixes) = disciplines_by_class.get(class_code.as_str()) {
+                for disc_prefix in prefixes {
+                    abl_rows.push((
+                        disc_prefix.clone(),
+                        game_id.clone(),
+                        ability_fqn.clone(),
+                        None,
+                        "utility".to_string(),
+                    ));
+                }
+            }
+        }
+
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
 
@@ -3109,6 +3320,104 @@ impl Database {
 
         tx.commit()?;
         Ok((disc_count, abl_count))
+    }
+
+    /// Populate `discipline_talents` by FQN pattern.
+    ///
+    /// Mechanical mapping:
+    /// - `tal.<class>.skill.<discipline>.<rest>` belongs to that one
+    ///   combat discipline (`abl.<class>.skill.<discipline>`).
+    /// - `tal.<class>.skill.utility.<rest>` is a per-class SHARED utility
+    ///   talent. Fanned out: one row per combat discipline of that class,
+    ///   plus its own row under the utility discipline. This mirrors how
+    ///   SWTOR exposes utility talents in the discipline UI -- a
+    ///   utility-talent pick is visible on every combat-tree page for that
+    ///   class.
+    ///
+    /// No tier_level / column coordinates: SWTOR's editorial tree layout
+    /// (which talent sits at what tier on screen) is not encoded in tal.*
+    /// payloads or FQNs. This function only emits mechanical membership.
+    pub fn populate_discipline_talents(&self) -> Result<u64> {
+        self.flush()?;
+
+        let talents: Vec<(String, String)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT fqn, game_id FROM objects \
+                 WHERE kind = 'Talent' AND fqn LIKE 'tal.%.skill.%' AND is_canonical = 1",
+            )?;
+            let result: Vec<(String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            result
+        };
+
+        // Combat disciplines per class, learned from the disciplines table
+        // populated by populate_disciplines (must run before this fn).
+        let disciplines_by_class: std::collections::HashMap<String, Vec<String>> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT class_code, fqn_prefix FROM disciplines \
+                 WHERE discipline_name NOT IN ('utility', 'shared')",
+            )?;
+            let mut map: std::collections::HashMap<String, Vec<String>> =
+                std::collections::HashMap::new();
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok());
+            for (class_code, fqn_prefix) in rows {
+                map.entry(class_code).or_default().push(fqn_prefix);
+            }
+            map
+        };
+
+        let mut rows: Vec<(String, String, String)> = Vec::new();
+        for (fqn, game_id) in &talents {
+            // tal.<class>.skill.<segment>.<rest>
+            let parts: Vec<&str> = fqn.split('.').collect();
+            if parts.len() < 5 || parts[2] != "skill" {
+                continue;
+            }
+            let class_code = parts[1];
+            let segment = parts[3];
+
+            // Always emit the literal-membership row.
+            let literal_prefix = format!("abl.{}.skill.{}", class_code, segment);
+            rows.push((literal_prefix, game_id.clone(), fqn.clone()));
+
+            // Utility talents: also emit a row for every combat discipline
+            // of this class. v1's curated tree lists utility talents under
+            // each combat discipline (e.g. Interloper appears in
+            // annihilation, carnage, fury for sith_warrior); this matches.
+            if segment == "utility" {
+                if let Some(combat_disciplines) = disciplines_by_class.get(class_code) {
+                    for combat_prefix in combat_disciplines {
+                        rows.push((combat_prefix.clone(), game_id.clone(), fqn.clone()));
+                    }
+                }
+            }
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut count = 0u64;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT OR IGNORE INTO discipline_talents \
+                 (discipline_fqn_prefix, talent_game_id, talent_fqn) VALUES (?1, ?2, ?3)",
+            )?;
+            for (disc, game_id, fqn) in &rows {
+                stmt.execute(params![disc, game_id, fqn])?;
+                count += 1;
+            }
+        }
+        tx.commit()?;
+        Ok(count)
     }
 
     /// Populate `talent_abilities` by decoding GUID refs from `tal.*` payloads.
@@ -3406,6 +3715,23 @@ fn derive_icon_from_fqn(fqn: &str) -> Option<String> {
 
 /// Decode tier level from FQN segment like "tier2" → 23, "tier3" → 39, etc.
 /// Maps SWTOR's tier numbering to actual level requirements.
+/// Convert a snake_case FQN segment to a title-cased display name.
+/// e.g. `mag_bolt` -> `Mag Bolt`, `fueled_corruption` -> `Fueled Corruption`.
+/// Used by `backfill_missing_string_ids` to derive a candidate display name
+/// when the GOM payload lacks a string-table marker.
+fn title_case_from_snake(s: &str) -> String {
+    s.split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(c) => c.to_uppercase().chain(chars).collect::<String>(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn tier_from_segment(seg: Option<&str>) -> Option<u8> {
     match seg? {
         "tier1" => Some(15),

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,6 +424,19 @@ fn main() -> Result<()> {
         );
     }
 
+    // Heuristic: backfill string_id for canonical abl.* rows whose payload
+    // didn't carry a string-table marker. Looks up STB strings by display
+    // name derived from the FQN's last segment, only commits when there's
+    // exactly one unused candidate that has both a name (id1=0) and a
+    // description (id1=1).
+    let backfilled = db.backfill_missing_string_ids()?;
+    if backfilled > 0 {
+        println!(
+            "  Backfilled {} string_id linkages by display-name match",
+            backfilled
+        );
+    }
+
     // Second pass: populate quest tables from extracted objects
     let quest_count = db.populate_quest_tables()?;
 
@@ -529,7 +542,10 @@ fn main() -> Result<()> {
     // Eleventh pass: derive disciplines and discipline→ability mappings
     let (disc_count, disc_abl_count) = db.populate_disciplines()?;
 
-    // Twelfth pass: decode talent→ability GUID refs from tal.* payloads
+    // Twelfth pass: derive discipline→talent mapping by FQN pattern
+    let disc_tal_count = db.populate_discipline_talents()?;
+
+    // Thirteenth pass: decode talent→ability GUID refs from tal.* payloads
     let talent_abl_count = db.populate_talent_abilities()?;
 
     // Print summary
@@ -549,8 +565,8 @@ fn main() -> Result<()> {
     );
     println!("    Abilities: {}", stats.abilities);
     println!(
-        "    Disciplines: {} ({} ability slots, {} talent links)",
-        stats.disciplines, stats.discipline_abilities, stats.talent_abilities
+        "    Disciplines: {} ({} ability slots, {} talent slots, {} talent->ability links)",
+        stats.disciplines, stats.discipline_abilities, disc_tal_count, stats.talent_abilities
     );
     let _ = (disc_count, disc_abl_count, talent_abl_count);
     println!("    Items: {}", stats.items);


### PR DESCRIPTION
## Summary

Closes huttspawn's discipline-tree coverage gap. v1's curated tree had 39 entries / 13 tier_levels for sith_warrior rage; kessel was shipping 20 / 2.

After this PR: 125/131 of huttspawn's known v1 placeholder names resolve directly from kessel-shipped data. The 6 unresolved are out of scope (categorized below).

## What ships

### NEW: \`discipline_talents\` table
Mechanical FQN-pattern junction. \`tal.<class>.skill.<segment>.<rest>\` maps to discipline \`abl.<class>.skill.<segment>\`. Utility talents (\`tal.<class>.skill.utility.*\`) fan out to every combat discipline of that class.

No \`tier_level\` / column coordinates. SWTOR's editorial tree layout is not encoded in tal.* payloads or FQNs -- the vault MAPPINGS.md "level 68 (0x44)" example was a misread (that byte is a stat_id followed by an f32 stat value, not a character level; verified across brutality / decimate / dark_mending).

### CHANGED: \`discipline_abilities\` now includes class-shared + utility fan-out
Bare \`abl.<class>.<name>\` rows (Saber Reflect, Force Leap, Awe, Blade Storm, Dispatch, Force Charge, Smash, etc.) were extracted into \`objects\` but never linked to any discipline. ~53 per player class, ~451 total. Now fanned out to every combat discipline of their class with \`slot_type = 'class_shared'\`. Utility abilities (Thwart, etc.) get the same treatment with \`slot_type = 'utility'\`.

\`discipline_abilities\` row count: **1,133 -> 4,829**.

### NEW: \`backfill_missing_string_ids\` post-extraction pass
Recovers \`string_id\` linkages for canonical \`abl.*\` rows whose GOM payload doesn't carry a string-table type marker (so neither \`extract_string_id_via_fqn_with\` nor \`extract_string_id_via_type_marker\` find the linkage at construction time). Strategy: derive expected display name from FQN's last segment (snake_case -> Title Case), look up STB strings whose text matches at id1=0 AND that have a description at id1=1, commit only when exactly one unused candidate remains.

Conservative by design -- the id1=1 description filter rules out homonym / UI-label false positives. Fixes Mag Bolt, Fueled Corruption, Sabotage and ~11 others.

## Coverage on v14 extraction

\`\`\`
Disciplines: 62 (4,829 ability slots, 2,150 talent slots, 779 talent->ability links)
131-needle match: 125 resolved, 6 unresolved
\`\`\`

## The 6 unresolved (out of scope, with workarounds)

**3 v1 cross-discipline curation** -- kessel ships each at canonical FQN; v1 placed them in a 2nd discipline editorially. Huttspawn replicates editorially:
- concentration/Shii-Cho Mastery -- canonical at \`tal.jedi_knight.skill.focus.shiicho_mastery\`
- hatred/Creeping Terror -- canonical at \`abl.sith_inquisitor.skill.madness.creeping_terror\`
- serenity/Force in Balance -- canonical at \`abl.jedi_consular.skill.balance.force_in_balance\`

**3 SWTOR per-discipline ability rename overlays** -- a deferred research feature. SWTOR encodes per-discipline ability renames as alternate id1 entries on the same string_id (range ~256-294). Standard \`id1 = 0\` join misses them. Surface them via:
- immortal/Threatening Rage = \`abl.sith_warrior.enrage\` rendered with \`str.abl.265.585701\`
- dirty-fighting/Blood Sights = \`abl.smuggler.smugglers_luck\` with \`str.abl.292.224172\`
- saboteur/Target Hack = \`abl.smuggler.smugglers_luck\` with \`str.abl.294.224172\`

A future kessel feature should surface this rename mechanic as a junction (base_ability_game_id, discipline_fqn_prefix, alternate_id1, alternate_name, alternate_description).

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --release -- -D warnings\` clean
- [x] re-extracted v14 spice from ~/swtor/Assets in ~2 min, golden symlinked
- [x] FK integrity check passes (PRAGMA foreign_key_check returns no rows)
- [x] 131-needle match script: 125/131 (94%) via discipline_abilities + discipline_talents joins
- [x] discipline_abilities for sith_warrior rage: 20 -> 72 rows, includes Saber Reflect (class_shared) and 8 talents via discipline_talents (was 0)