### PR TITLE
feat: walk all CE-marker stids, surface flavor_string_id

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -284,6 +284,12 @@ impl Database {
             -- Item details (classified from FQN patterns; #59).
             -- Set name and set bonus require GOM payload parsing and are
             -- deferred to a follow-up issue.
+            -- flavor_string_id: the SECOND distinct CE-marked stid in the
+            -- itm.* payload (the first goes to objects.string_id as the
+            -- item name). For gear, this is the in-game flavor description.
+            -- Tactical items typically have only one distinct stid so this
+            -- column is NULL for them. Set-bonus and weapon-proc text
+            -- (third+ stids) are not yet surfaced -- see #105.
             CREATE TABLE IF NOT EXISTS item_details (
                 fqn TEXT PRIMARY KEY,
                 item_kind TEXT NOT NULL,
@@ -294,7 +300,8 @@ impl Database {
                 item_level INTEGER,
                 source TEXT,
                 is_schematic INTEGER NOT NULL DEFAULT 0,
-                crew_skill TEXT
+                crew_skill TEXT,
+                flavor_string_id INTEGER
             );
 
             CREATE INDEX IF NOT EXISTS idx_item_details_kind ON item_details(item_kind);
@@ -1300,12 +1307,24 @@ impl Database {
     pub fn populate_item_tables(&self) -> Result<u64> {
         self.flush()?;
 
-        let rows: Vec<String> = {
+        // Fetch fqn + payload + the primary string_id captured by the FQN-
+        // proximity scan. The walker may revisit the same stid; we use the
+        // stored string_id to identify "the first one already captured" and
+        // surface the NEXT distinct one as flavor_string_id.
+        let rows: Vec<(String, String, Option<i64>)> = {
             let conn = self.conn.lock().unwrap();
-            let mut stmt =
-                conn.prepare("SELECT fqn FROM objects WHERE kind = 'Item' AND is_canonical = 1")?;
-            let collected: Vec<String> = stmt
-                .query_map([], |row| row.get::<_, String>(0))?
+            let mut stmt = conn.prepare(
+                "SELECT fqn, json_extract(json, '$.payload_b64'), string_id \
+                 FROM objects WHERE kind = 'Item' AND is_canonical = 1",
+            )?;
+            let collected: Vec<(String, String, Option<i64>)> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                    ))
+                })?
                 .collect::<Result<Vec<_>, _>>()?;
             collected
         };
@@ -1315,12 +1334,26 @@ impl Database {
         let mut count = 0u64;
 
         {
+            use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
             let mut stmt = tx.prepare_cached(
-                "INSERT OR REPLACE INTO item_details (fqn, item_kind, slot, weapon_type, armor_weight, rarity, item_level, source, is_schematic, crew_skill) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                "INSERT OR REPLACE INTO item_details (fqn, item_kind, slot, weapon_type, armor_weight, rarity, item_level, source, is_schematic, crew_skill, flavor_string_id) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             )?;
 
-            for fqn in &rows {
+            for (fqn, payload_b64, primary_stid) in &rows {
                 let d = item::classify(fqn);
+                let payload = BASE64.decode(payload_b64).unwrap_or_default();
+
+                let mut flavor_stid: Option<u32> = None;
+                if !payload.is_empty() {
+                    let stids = item::extract_all_string_ids_from_payload(&payload);
+                    // Pick the first stid that is NOT the primary -- that's
+                    // the flavor description. NULL when the payload only
+                    // carries one distinct stid (typical for tacticals).
+                    let primary_u32 = primary_stid.and_then(|v| u32::try_from(v).ok());
+                    flavor_stid = stids.into_iter().find(|s| Some(*s) != primary_u32);
+                }
+
                 stmt.execute(params![
                     d.fqn,
                     d.item_kind,
@@ -1332,6 +1365,7 @@ impl Database {
                     d.source,
                     if d.is_schematic { 1 } else { 0 },
                     d.crew_skill,
+                    flavor_stid,
                 ])?;
                 count += 1;
             }

--- a/src/schema/item.rs
+++ b/src/schema/item.rs
@@ -168,6 +168,34 @@ fn extract_item_level(fqn_lower: &str) -> Option<u32> {
         .and_then(|m| m.as_str().parse().ok())
 }
 
+/// Walk the full payload and return every distinct CE-marked string_id in
+/// payload order. Each `0xCE` byte is followed by 3 bytes BE encoding the
+/// stid (the canonical GOM string-table reference shape). Validated to the
+/// same range as the existing extractors (1_000..=10_000_000).
+///
+/// The first hit is typically what `objects.string_id` already captures via
+/// the FQN-proximity scan; subsequent hits are the FLAVOR description (gear),
+/// SET-BONUS name/desc, and other secondary refs depending on item kind.
+/// Tactical items often have the same stid repeated -- dedupe preserves order.
+pub fn extract_all_string_ids_from_payload(payload: &[u8]) -> Vec<u32> {
+    const MIN_STRING_ID: u32 = 1_000;
+    const MAX_STRING_ID: u32 = 10_000_000;
+    let mut seen: Vec<u32> = Vec::new();
+    let mut i = 0;
+    while i + 4 <= payload.len() {
+        if payload[i] == 0xCE {
+            let be24 = (payload[i + 1] as u32) << 16
+                | (payload[i + 2] as u32) << 8
+                | payload[i + 3] as u32;
+            if (MIN_STRING_ID..=MAX_STRING_ID).contains(&be24) && !seen.contains(&be24) {
+                seen.push(be24);
+            }
+        }
+        i += 1;
+    }
+    seen
+}
+
 fn detect_source(segments: &[&str], fqn_lower: &str) -> Option<String> {
     let seg2 = segments.get(2).copied().unwrap_or("");
     let s = match seg2 {
@@ -285,6 +313,42 @@ mod tests {
         let d = classify("itm.mod.color_crystal.att_pwr.green.artifact.basemod_03");
         assert_eq!(d.item_kind, "mod");
         assert_eq!(d.rarity.as_deref(), Some("artifact"));
+    }
+
+    #[test]
+    fn extracts_two_distinct_stids_in_payload_order() {
+        let mut payload = vec![0u8; 200];
+        // 995562 = 0x0F30EA
+        payload[50..54].copy_from_slice(&[0xCE, 0x0F, 0x30, 0xEA]);
+        // 995163 = 0x0F2F5B
+        payload[100..104].copy_from_slice(&[0xCE, 0x0F, 0x2F, 0x5B]);
+        assert_eq!(
+            extract_all_string_ids_from_payload(&payload),
+            vec![995562, 995163]
+        );
+    }
+
+    #[test]
+    fn dedupes_repeated_ce_markers_preserving_order() {
+        let mut payload = vec![0u8; 200];
+        payload[50..54].copy_from_slice(&[0xCE, 0x0F, 0x30, 0xEA]);
+        payload[150..154].copy_from_slice(&[0xCE, 0x0F, 0x30, 0xEA]);
+        assert_eq!(extract_all_string_ids_from_payload(&payload), vec![995562]);
+    }
+
+    #[test]
+    fn rejects_out_of_range_ce_stids() {
+        // stid 5 (below MIN_STRING_ID), stid 0xFFFFFF (above MAX_STRING_ID).
+        let payload = vec![0xCE, 0x00, 0x00, 0x05, 0xCE, 0xFF, 0xFF, 0xFF];
+        assert_eq!(
+            extract_all_string_ids_from_payload(&payload),
+            Vec::<u32>::new()
+        );
+    }
+
+    #[test]
+    fn empty_payload_returns_empty_vec() {
+        assert_eq!(extract_all_string_ids_from_payload(&[]), Vec::<u32>::new());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #103. Walks the full itm.* payload for every CE-marked stid (not just the first 40-byte FQN-proximity window), dedupes preserving order, and writes the second distinct stid as \`item_details.flavor_string_id\`.

## Schema
- New column: \`item_details.flavor_string_id INTEGER\`. NULL for items whose payload carries only one distinct stid (typical for tacticals -- the FQN scan and full walker land on the same stid).

## Findings
- 0 occurrences of the str.abl-tactical-effect-text stid (995163) in any archive via CE marker -- confirms the cross-namespace link for tactical mechanical-effect text is NOT in the item payload (handled separately by #104).
- For gear with separate name/desc string_ids, this PR surfaces the desc.

## Test plan
- [x] cargo test (104 passed -- 4 new + existing suite)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [ ] Re-extract: spot-check 10 gear items have populated flavor_string_id and the joined str.itm.1.<id> row reads as a flavor description