### PR TITLE
feat: extract abl.itm.tactical / setbonus / legendary (effect text wiring)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -789,6 +789,27 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
     // Skip internal abilities
     if prefix == "abl" && parts.len() >= 2 {
         let second = parts[1];
+
+        // Allowlist `abl.itm.tactical.*`, `abl.itm.setbonus.*`, and
+        // `abl.itm.legendary.*` BEFORE the generic `abl.itm.*` blocklist.
+        // These three carry the mechanical-effect strings Jedipedia exposes
+        // on tactical / set-bonus / legendary-implant pages. The item's
+        // payload references this abl.* by GUID; the abl.* row's string_id
+        // holds the effect description text in str.abl.1.<id>. Without this
+        // allowlist the abl.itm generic blocklist below drops them and the
+        // wiring is invisible (see #111).
+        //
+        // Source-canon segment names verified against Jedipedia ability URLs:
+        //   abl.itm.tactical.<source>.<class_group>.<style_group>.<modifier_id>
+        //   abl.itm.setbonus.<source>.<class_group>.<bonus_id>_NN  (NN = tier rank)
+        //   abl.itm.legendary.<source>.<class_group>.<modifier_id>
+        if second == "itm" && parts.len() >= 3 {
+            let third = parts[2];
+            if matches!(third, "tactical" | "setbonus" | "legendary") {
+                return true;
+            }
+        }
+
         if matches!(
             second,
             "npc"


### PR DESCRIPTION
## Summary
Allowlists \`abl.itm.tactical.*\`, \`abl.itm.setbonus.*\`, and \`abl.itm.legendary.*\` BEFORE the generic \`abl.itm.*\` blocklist in \`should_extract_object\`. These three sub-namespaces hold the mechanical-effect ability that backs every tactical item, set-bonus tier, and legendary implant proc. Closes the chain of issues that were filed as 'client-only / unresolvable' (#111 and similar) -- the data was always extractable, just being silently dropped.

## End-to-end verification (Grit Teeth)

\`\`\`
itm.tactical.sow.juggernaut.grit_teeth
  payload @ 0x6F: CF E00044A60CB26E7D  (the unique CF GUID I previously called 'unresolved')
                              v
abl.itm.tactical.sow.war_kni.jug_guar.utl_def_02
  string_id = 995163
                              v
str.abl.1.995163 = "The active cooldown of Saber Ward is reduced by 2 seconds when you are attacked..."
\`\`\`

## Post-fix extraction (v18b)
| sub-prefix | count |
|---|---|
| \`abl.itm.tactical.*\` | 154 |
| \`abl.itm.setbonus.*\` | 521 |
| \`abl.itm.legendary.*\` | 47 |

521 set-bonus rows = 2/4/6-piece tiers across all current sets. Berserker, Trishin's Retort, Saber Master, etc. all resolve.

## Jedipedia cross-reference
Discovered during investigation: Jedipedia's "Global ID" decimal IS the content GUID in hex. Their "Combat Log ID" is a packed \`(string_id.id1 << 32 | string_id.id2)\`. Both useful for cross-checking extraction correctness.

## Test plan
- [x] cargo test (100 passed)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] Re-extracted v18b -- 154 tactical / 521 setbonus / 47 legendary objects, all with string_ids that resolve to mechanical-effect text in str.abl.1.<id>

## Process lesson
Before declaring any GUID 'unresolvable' / 'client-only', audit \`should_extract_object\`'s blocklist for a sub-prefix that would have dropped the matching object. Same audit applies to:
- #86 (GSF tier residual) -- likely \`abl.itm.legendary.spvp.*\` or similar
- #57 (Saber Strike) -- check \`abl.player.*\` / \`abl.flurry.*\` / \`abl.generic.*\` blocklist
- GSF crew loadouts -- \`npc.companion.spvp.*\` GUIDs probably target filtered abl.spvp.<sub>
- Quest objective text -- \`abl.qst.*\` still blocklisted

Reflection: \`legion recall --repo kessel --context 'should_extract_object blocklist'\`

## Next step
Build a \`item_effects\` populator that joins items to their abl.itm.* siblings via CF GUID (tacticals/legendary -- direct ref) or FQN pattern (setbonus -- editorial join). Surface the effect text in item_details for the search UI.