### PR TITLE
feat: extract abl.flurry.* (closes #57 -- Saber Strike + base-class basic attacks)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -849,7 +849,12 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
                 | "ventures"
                 | "creature_default"
                 | "droid"
-                | "flurry"
+                // Removed `"flurry"` from this blocklist (was here pre-2026-05-04).
+                // Jedipedia shows player base-class abilities like Saber Strike
+                // (string_id 220604) live at abl.flurry.npc.<class>_stance_flurry --
+                // dropping all of abl.flurry.* hides those fundamentals (tracked
+                // historically by #57). The companion epp side already uses
+                // is_shared_flurry above to allow epp.flurry.melee/ranged.
                 | "generic"
         ) {
             return false;


### PR DESCRIPTION
## Summary
Removes \`\"flurry\"\` from the abl-blocklist. Jedipedia trace confirmed Saber Strike (string_id 220604, #57's literal acceptance criterion) lives at \`abl.flurry.jedi_consular.saber_strike_optimize\` — kessel was filtering it.

Same audit pattern as PR #112 (abl.itm fix). Total: 106 new abl.* objects, abl.* string_id coverage 99.0% → 99.4%.

## Closes #57
Original hypothesis was 'parse .node prototype files to recover Saber Strike'. Wrong namespace -- Saber Strike isn't a node prototype, it's an abl object filtered by the blocklist.

| FQN | stid | Display |
|---|---|---|
| abl.flurry.jedi_consular.saber_strike_optimize | 220604 | Saber Strike ← #57 acceptance |
| abl.flurry.sith_inquisitor.saber_strike_optimize | 220606 | Saber Strike |
| abl.flurry.jedi_knight.strike_optimize | 220575 | Strike |
| abl.flurry.sith_warrior.assault_optimize | 209222 | Assault |
| abl.flurry.npc.inquisitor_stance_flurry | 852869 | Saber Strike (NPC) |
| abl.flurry.npc.warrior_stance_flurry | 852996 | Assault (NPC) |
| abl.flurry.droid.* | (92 rows) | Droid basic attacks |
| abl.flurry.creature.* | (31 rows) | Bestiary basic attacks |

## Why now
Today's blocklist-audit lesson: 'before declaring data unrecoverable, check should_extract_object's blocklist for a sub-prefix that would have dropped the matching object.' Same one-line fix shape as PR #112.

## Test plan
- [x] cargo test (112 passed)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo fmt --check (clean)
- [x] Re-extracted v19-test: \`SELECT fqn FROM objects WHERE string_id=220604 AND is_canonical=1 AND fqn LIKE 'abl.%'\` returns \`abl.flurry.jedi_consular.saber_strike_optimize\` ✓
- [ ] After merge: re-extract spice, promote symlink, ping huttspawn

## Related
- #112 (abl.itm fix) -- same root cause, same audit pattern
- Reflection 019df482 -- the audit template