### PR TITLE
feat: decode 27 GSF talent stat IDs for build-calculator rollup

### DIFF
--- a/gsf_stat_dictionary.toml
+++ b/gsf_stat_dictionary.toml
@@ -100,6 +100,233 @@ confidence = "guess"
 notes      = "Paired with 0x22; semantics unverified"
 
 
+# --- 2026-05-18 expansion (huttspawn build-calculator pass) ---
+# Each addition is anchored to the canonical minor_<slot>.<stat> talent FQN
+# whose name string makes the meaning unambiguous (e.g. minor_armor.hull_strength
+# -> "Structural Reinforcement, +8%"). See PR description for the verification
+# query (gsf_talent_stats JOIN talents ON FQN).
+
+[talent_stats.0x08]
+label      = "hull_strength_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_armor.hull_strength.{base,upgrade} +8% / +4/+8/+12; drone.*.tier_X 'Fortified Beacon' +10-20%"
+
+[talent_stats.0x38]
+label      = "evasion_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_armor.evasion.* (Composite Plating +3%); crew.defensive.evasion (Response Tuning +5%); shield.distortion_field.base +9%"
+
+[talent_stats.0x45]
+label      = "weapon_power_pool_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_magazine.weapon_power.* (Blaster Power +8%); crew.engineering.weapon_power_pool (Power to Blasters +15%)"
+
+[talent_stats.0x46]
+label      = "shield_power_pool_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_reactor.shield_power.* +8%; crew.defensive.shield_power_pool (Power to Shields +10%); shield bases match 2014 SWTORStrategies values (directional +20%, overcharged +50%, quick_recharge -30%, fortress +20%, charged_plating +40%)"
+
+[talent_stats.0x58]
+label      = "damage_reduction_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_armor.damage_reduction.* (Durasteel Plating +8%); crew.defensive.damage_reduction (Structural Support +9%)"
+
+[talent_stats.0x4d]
+label      = "pweapon_rof_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_capacitor.pweapon_rof.* (Quick-Charge Capacitor +6%); laser.{ion,laser,light,quad}_cannon.tier_X 'Increased Rate of Fire'"
+
+[talent_stats.0x1e]
+label      = "weapon_power_regen_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_magazine.weapon_power_regen.* (Blaster Power Regeneration +8% base, +4/+8/+12 upgrade); paired with 0x1f"
+
+[talent_stats.0x1f]
+label      = "weapon_power_regen_pct_alt"
+unit       = "pct"
+confidence = "verified"
+notes      = "Paired with 0x1e; values match. Only appears on the same minor_magazine.weapon_power_regen.* talents"
+
+[talent_stats.0x20]
+label      = "shield_power_regen_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_reactor.shield_power_regen.* (+8% base); crew.defensive.shield_power_regen (Quick Recharge +15%); shield ability outliers (overcharged_shield.base -60%, quick_recharge.base +55%, shield_projector.base +35%)"
+
+[talent_stats.0x21]
+label      = "shield_power_regen_pct_alt"
+unit       = "pct"
+confidence = "verified"
+notes      = "Paired with 0x20; matches on component/crew. Shield ability rows diverge (quick_recharge.base = 75.0, quick_recharge.tier3a = 100.0) -- those values are NOT percentages but appear to be a delay/threshold scalar. Filter to WHERE label='shield_power_regen_pct' for clean rollup"
+
+[talent_stats.0x2f]
+label      = "pweapon_range_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_capacitor.pweapon_range.* (Precision Capacitor +4% base, +2/+4/+6 upgrade); laser tier_2 +5% Increased Range; rocket_pod.tier_5a +10%. Triple-encoded with 0x30 and 0x31 (identical values per row -- consumers should pick one)"
+
+[talent_stats.0x30]
+label      = "pweapon_range_pct_alt1"
+unit       = "pct"
+confidence = "verified"
+notes      = "Paired with 0x2f and 0x31; identical values. Likely a per-band (short/medium/long) split that always carries the same delta"
+
+[talent_stats.0x31]
+label      = "pweapon_range_pct_alt2"
+unit       = "pct"
+confidence = "verified"
+notes      = "Paired with 0x2f and 0x30. Also picks up missile range (all missile.*.tier_4{a,b} 'Increased Range' +10%, proton_torpedoes.tier5b +15%, target_tracker.tier4b +10%)"
+
+[talent_stats.0x3f]
+label      = "sensor_range_units"
+unit       = "units"
+confidence = "verified"
+notes      = "minor_sensors.sensor_range.* (Increased Sensor Range +20 units base, +10/+20/+30 upgrade); crew.tactical.sensor_radius (Peripheral Vision +30); drone.sensor_beacon.tier2 +50. Distinct from 0x68 sensor_radius_units (which fires on aoe/mine radius)"
+
+[talent_stats.0x44]
+label      = "sensor_dampening_units"
+unit       = "units"
+confidence = "verified"
+notes      = "minor_sensors.sensor_dampen.* (Increased Dampening +16 units base, +8/+16/+24 upgrade); crew.tactical.sensor_damping (Silent Running +20)"
+
+[talent_stats.0x4a]
+label      = "shield_piercing_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "Laser/missile/railgun 'Shield Piercing' tier upgrades (+8% to +15%)"
+
+[talent_stats.0x4c]
+label      = "hull_damage_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "Laser tier_5a 'Increased Hull Damage' +16%; railgun.slug_railgun.tier_4a 'Improved Damage to Hull' +6%"
+
+[talent_stats.0x4e]
+label      = "accuracy_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "crew.offensive.accuracy (Pinpointing +6%); laser tier 'Improved Targeting/Accuracy' (+2-6%); railgun 'Increased Accuracy and Tracking' +3%"
+
+[talent_stats.0x50]
+label      = "power_transfer_cost_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "shield.directional_shield.tier1 'Remove Transfer Cost' = -1.0 (-100%); shield.xfer_to_engine.tier2 'Reduce Power Cost' -10%"
+
+[talent_stats.0x51]
+label      = "engine_ability_power_cost_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "Engine ability tier1 'Reduced Power Cost' (-10% to -20%) on every engine maneuver; crew.engineering.engine_power_efficiency (Efficient Maneuvers -13%). Paired with 0x26 and 0x27 on the crew passive"
+
+[talent_stats.0x52]
+label      = "weapon_power_draw_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "railgun.{plasma,slug}_railgun.tier_{3,4b} 'Reduced Power Draw' -10%. Distinct from 0x56 weapon_power_cost_pct (laser-side)"
+
+[talent_stats.0x55]
+label      = "shield_regen_delay_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_reactor.shield_regen_cooldown.* (-24% base, -12/-24/-36 upgrade); crew.defensive.shield_power_regen secondary effect (-15%); shield.quick_recharge.base -15%. OUTLIER: shield.directional_shield.tier3a stores -3.0 = -3 seconds raw delta (not a percentage) -- consumers can filter WHERE label='shield_regen_delay_pct' AND ABS(value) < 1.0 for clean pct rollup"
+
+[talent_stats.0x56]
+label      = "weapon_power_cost_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "laser tier_2/tier_4b 'Reduced Power Cost' -10%; crew.engineering.weapon_power_efficiency (Efficient Fire -13%). Laser-side counterpart to 0x52 weapon_power_draw_pct (railgun)"
+
+[talent_stats.0x59]
+label      = "armor_pierce_flag"
+unit       = "bool"
+confidence = "verified"
+notes      = "All values = 1.0 (boolean flag). Laser/missile/railgun 'Ignore Armor' tier upgrades that grant 100% armor pierce on a hit type"
+
+[talent_stats.0x5a]
+label      = "charge_time_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "Railgun tier_1 'Reduced Charge Time' -10% (plasma/slug/ion railguns)"
+
+[talent_stats.0x5d]
+label      = "secondary_weapon_cooldown_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "crew.offensive.secondary_weapons_cooldown (Rapid Reload -12%). OUTLIERS: missile.interdiction_missiles.tier_2 (-3.0) and missile.target_tracker.tier3 (-5.0) store raw seconds. Filter WHERE ABS(value) < 1.0 for percent rollup"
+
+[talent_stats.0x5e]
+label      = "engine_speed_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "minor_thrusters.engine_speed.* (Increased Speed +4% base, +2/+4/+6 upgrade); engine ability tier3a 'Increased Ship Speed' +10%"
+
+[talent_stats.0x6a]
+label      = "crit_damage_pct"
+unit       = "pct"
+confidence = "verified"
+notes      = "laser.quad_laser.tier_4a 'Increased Critical Hit Damage' +15%. Distinct from 0x69 crit_chance_pct"
+
+[talent_stats.0x26]
+label      = "engine_ability_power_cost_pct_alt1"
+unit       = "pct"
+confidence = "verified"
+notes      = "Paired with 0x27 and 0x51 on crew.engineering.engine_power_efficiency (Efficient Maneuvers -13%). Single-record stat; semantics same as 0x51"
+
+[talent_stats.0x27]
+label      = "engine_ability_power_cost_pct_alt2"
+unit       = "pct"
+confidence = "verified"
+notes      = "Paired with 0x26 and 0x51 on crew.engineering.engine_power_efficiency. Single-record stat"
+
+
+# --- FQN-prefix overrides ---
+# Some stat_ids carry context-dependent semantics. The "default" label below is
+# correct for the most common talents that emit the byte (e.g. shield.shield_projector
+# uses 0x40 for cooldown_delta_seconds), but specific FQN families repurpose the
+# slot for a domain-specific stat. When the talent's FQN starts with `fqn_prefix`,
+# the populate function replaces the default label/unit/confidence with the
+# override below.
+[[talent_stat_overrides]]
+fqn_prefix = "tal.spvp.minor_sensors.com_range"
+stat_id    = "0x40"
+label      = "comm_range_units"
+unit       = "units"
+confidence = "verified"
+notes      = "minor_sensors.com_range.{base,upgrade} +40 / +20/+40/+60 units. The 0x40 slot defaults to cooldown_delta_seconds but for comm_range talents it's distance units"
+
+[[talent_stat_overrides]]
+fqn_prefix = "tal.spvp.crew.tactical.communications_range"
+stat_id    = "0x40"
+label      = "comm_range_units"
+unit       = "units"
+confidence = "verified"
+notes      = "crew.tactical.communications_range (Comm Boost +50 units). Same 0x40-as-units repurposing as the minor_sensors.com_range talents"
+
+[[talent_stat_overrides]]
+fqn_prefix = "tal.spvp.minor_sensors.sensor_range"
+stat_id    = "0x41"
+label      = "sensor_range_duration_seconds"
+unit       = "s"
+confidence = "guess"
+notes      = "minor_sensors.sensor_range.* carries BOTH 0x3f (sensor_range_units, the primary effect) and 0x41 with the same value scale. 0x41 normally encodes duration_extension_seconds for active abilities; for this passive its meaning is unclear but values align with the unit count (20/10/20/30). Treat as redundant pending verification"
+
+[[talent_stat_overrides]]
+fqn_prefix = "tal.spvp.crew.tactical.sensor_volume"
+stat_id    = "0x41"
+label      = "sensor_volume_units"
+unit       = "units"
+confidence = "verified"
+notes      = "crew.tactical.sensor_volume (Depth of Field +35 units). The 0x41 slot defaults to duration_extension_seconds but this crew passive grants a sensor-volume bonus"
+
+
 # abl.spvp.* prop_id (u16) -- u16 LE prop_id with high byte 0x04, followed
 # by f32 LE value. Stat-ID semantics differ from `tal.spvp.*` -- 0x0402
 # is cooldown for GSF base abilities, an animation marker for ground.

--- a/src/db.rs
+++ b/src/db.rs
@@ -1909,14 +1909,18 @@ impl Database {
         let dict = StatDictionary::from_embedded()?;
         let conn = self.conn.lock().unwrap();
 
-        let payloads: Vec<(String, Option<String>)> = {
+        let payloads: Vec<(String, String, Option<String>)> = {
             let mut stmt = conn.prepare(
-                "SELECT game_id, json_extract(json, '$.payload_b64') \
+                "SELECT game_id, fqn, json_extract(json, '$.payload_b64') \
                  FROM objects WHERE fqn LIKE 'tal.spvp.%' AND is_canonical = 1",
             )?;
-            let rows: Vec<(String, Option<String>)> = stmt
+            let rows: Vec<(String, String, Option<String>)> = stmt
                 .query_map([], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
                 })?
                 .filter_map(|r| r.ok())
                 .collect();
@@ -1931,7 +1935,7 @@ impl Database {
         )?;
 
         let mut count: u64 = 0;
-        for (game_id, payload_b64) in &payloads {
+        for (game_id, fqn, payload_b64) in &payloads {
             let Some(b64) = payload_b64 else { continue };
             let Ok(payload) = BASE64.decode(b64) else {
                 continue;
@@ -1942,7 +1946,10 @@ impl Database {
             let mut rank_per_label: std::collections::HashMap<String, i64> =
                 std::collections::HashMap::new();
             for rec in decode_gsf_stats(&payload) {
-                let label = dict.talent_label(rec.stat_id);
+                // FQN-aware lookup so context-overloaded stat_ids (0x40 acting
+                // as comm_range_units on minor_sensors.com_range.*, etc.) ship
+                // with the domain-correct label instead of the generic default.
+                let label = dict.talent_label_for(rec.stat_id, fqn);
                 let rank = rank_per_label.entry(label.label.clone()).or_insert(0);
                 *rank += 1;
                 stmt.execute(params![

--- a/src/gsf_stat_dictionary.rs
+++ b/src/gsf_stat_dictionary.rs
@@ -26,6 +26,17 @@ pub struct StatDictionary {
     pub ability_stats: HashMap<u16, StatLabel>,
     /// `abl.*` ground -- prop_id (u16) -> label
     pub ground_ability_props: HashMap<u16, StatLabel>,
+    /// FQN-prefix overrides for `tal.spvp.*` stat_ids whose meaning depends on
+    /// the parent talent (e.g. 0x40 is normally `cooldown_delta_seconds` but
+    /// `minor_sensors.com_range.*` repurposes it as `comm_range_units`).
+    pub talent_stat_overrides: Vec<TalentStatOverride>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TalentStatOverride {
+    pub fqn_prefix: String,
+    pub stat_id: u8,
+    pub label: StatLabel,
 }
 
 impl StatDictionary {
@@ -42,9 +53,22 @@ impl StatDictionary {
             ability_stats: HashMap<String, Entry>,
             #[serde(default)]
             ground_ability_props: HashMap<String, Entry>,
+            #[serde(default)]
+            talent_stat_overrides: Vec<OverrideEntry>,
         }
         #[derive(serde::Deserialize)]
         struct Entry {
+            label: String,
+            unit: String,
+            confidence: String,
+            #[serde(default)]
+            #[allow(dead_code)]
+            notes: Option<String>,
+        }
+        #[derive(serde::Deserialize)]
+        struct OverrideEntry {
+            fqn_prefix: String,
+            stat_id: String,
             label: String,
             unit: String,
             confidence: String,
@@ -99,10 +123,28 @@ impl StatDictionary {
             );
         }
 
+        let mut talent_stat_overrides = Vec::with_capacity(file.talent_stat_overrides.len());
+        for entry in file.talent_stat_overrides {
+            let stat_id = parse_hex(&entry.stat_id)? as u8;
+            talent_stat_overrides.push(TalentStatOverride {
+                fqn_prefix: entry.fqn_prefix,
+                stat_id,
+                label: StatLabel {
+                    label: entry.label,
+                    unit: entry.unit,
+                    confidence: entry.confidence,
+                },
+            });
+        }
+        // Longest prefix first so a more specific override wins over a shorter
+        // sibling if any future entries overlap.
+        talent_stat_overrides.sort_by_key(|ov| std::cmp::Reverse(ov.fqn_prefix.len()));
+
         Ok(Self {
             talent_stats,
             ability_stats,
             ground_ability_props,
+            talent_stat_overrides,
         })
     }
 
@@ -118,6 +160,19 @@ impl StatDictionary {
                 unit: String::new(),
                 confidence: "unknown".to_string(),
             })
+    }
+
+    /// FQN-aware label lookup for `tal.spvp.*`. Consults `talent_stat_overrides`
+    /// first; falls back to the default `talent_label` mapping. Use this from
+    /// `populate_gsf_talent_stats` so context-overloaded stat_ids (0x40 acting
+    /// as comm range on minor_sensors.com_range.*) ship with the right label.
+    pub fn talent_label_for(&self, stat_id: u8, fqn: &str) -> StatLabel {
+        for ov in &self.talent_stat_overrides {
+            if ov.stat_id == stat_id && fqn.starts_with(&ov.fqn_prefix) {
+                return ov.label.clone();
+            }
+        }
+        self.talent_label(stat_id)
     }
 
     /// Look up a label for an `abl.spvp.*` prop_id.
@@ -172,5 +227,52 @@ mod tests {
         let label = dict.talent_label(0xFE);
         assert_eq!(label.label, "unknown_0xfe");
         assert_eq!(label.confidence, "unknown");
+    }
+
+    #[test]
+    fn fqn_override_relabels_collision_stats() {
+        let dict = StatDictionary::from_embedded().unwrap();
+        // Default for 0x40 is cooldown_delta_seconds.
+        let default_label = dict.talent_label_for(0x40, "tal.spvp.shield.shield_projector.tier1");
+        assert_eq!(default_label.label, "cooldown_delta_seconds");
+        assert_eq!(default_label.unit, "s");
+
+        // minor_sensors.com_range.* repurposes 0x40 as comm_range_units.
+        let overridden = dict.talent_label_for(0x40, "tal.spvp.minor_sensors.com_range.base");
+        assert_eq!(overridden.label, "comm_range_units");
+        assert_eq!(overridden.unit, "units");
+        assert_eq!(overridden.confidence, "verified");
+
+        // crew.tactical.communications_range is also overridden.
+        let comm_boost = dict.talent_label_for(0x40, "tal.spvp.crew.tactical.communications_range");
+        assert_eq!(comm_boost.label, "comm_range_units");
+
+        // crew.tactical.sensor_volume reuses 0x41 as sensor_volume_units.
+        let sensor_volume = dict.talent_label_for(0x41, "tal.spvp.crew.tactical.sensor_volume");
+        assert_eq!(sensor_volume.label, "sensor_volume_units");
+        assert_eq!(sensor_volume.unit, "units");
+    }
+
+    #[test]
+    fn new_decoded_labels_present() {
+        let dict = StatDictionary::from_embedded().unwrap();
+        // Spot-check the labels huttspawn needs for the build calculator.
+        for (id, expected) in [
+            (0x46u8, "shield_power_pool_pct"),
+            (0x45, "weapon_power_pool_pct"),
+            (0x08, "hull_strength_pct"),
+            (0x58, "damage_reduction_pct"),
+            (0x38, "evasion_pct"),
+            (0x4e, "accuracy_pct"),
+            (0x3f, "sensor_range_units"),
+            (0x44, "sensor_dampening_units"),
+            (0x55, "shield_regen_delay_pct"),
+            (0x20, "shield_power_regen_pct"),
+            (0x1e, "weapon_power_regen_pct"),
+        ] {
+            let label = dict.talent_label(id);
+            assert_eq!(label.label, expected, "stat 0x{:02x}", id);
+            assert_eq!(label.confidence, "verified", "stat 0x{:02x}", id);
+        }
     }
 }


### PR DESCRIPTION
## Context

Per directed signal from huttspawn (id `019e3c80-648c-7b23-9fcc-5528d54c7766`): the GSF build-stat calculator needs the `gsf_talent_stats.unknown_0x*` labels decoded so build-aggregation rollups can key on `shield_power_pool_pct` instead of opaque hex IDs.

## What this PR ships

### Verified labels (27 new entries in `gsf_stat_dictionary.toml`)

Anchored on canonical `tal.spvp.minor_<slot>.<stat>.*` talents whose name strings make the meaning unambiguous (e.g. `minor_armor.hull_strength.base` is named "Structural Reinforcement, +8%"), plus crew passives and shield-component values that match the 2014 SWTORStrategies reference (`overcharged_shield.base = +50%`, `quick_recharge.base = -30%`, etc.).

PRIMARY ask (huttspawn build calculator):
- `0x46 shield_power_pool_pct` (confirms huttspawn's strong inference; verified end-to-end)
- `0x45 weapon_power_pool_pct`
- `0x20 shield_power_regen_pct` (paired with `0x21` _alt)
- `0x1e weapon_power_regen_pct` (paired with `0x1f` _alt)
- `0x55 shield_regen_delay_pct` (with documented seconds-encoding outlier for `directional_shield.tier3a`)
- `0x08 hull_strength_pct`, `0x58 damage_reduction_pct`, `0x38 evasion_pct`
- `0x4e accuracy_pct`
- `0x3f sensor_range_units` (distinct from existing `0x68 sensor_radius_units`, which fires on AoE/mine radii)
- `0x44 sensor_dampening_units`
- `0x40 comm_range_units` (via FQN override -- see below)

Lower-priority deltas also decoded:
- `0x2f / 0x30 / 0x31 pweapon_range_pct` (triple-encoded; identical values per row)
- `0x4d pweapon_rof_pct`, `0x5e engine_speed_pct`
- `0x4a shield_piercing_pct`, `0x4c hull_damage_pct`, `0x59 armor_pierce_flag`
- `0x51 engine_ability_power_cost_pct` (+ `0x26 / 0x27` paired alts on the crew passive)
- `0x50 power_transfer_cost_pct`, `0x52 weapon_power_draw_pct`, `0x56 weapon_power_cost_pct`
- `0x5a charge_time_pct`, `0x5d secondary_weapon_cooldown_pct`, `0x6a crit_damage_pct`

### FQN-prefix override mechanism

Some stat IDs are context-overloaded. The generic `0x40` slot defaults to `cooldown_delta_seconds` (verified for shield-ability tier1 cooldown reductions), but on `minor_sensors.com_range.*` and `crew.tactical.communications_range` the same byte slot carries communication range in distance units, not seconds. Similarly `0x41` defaults to `duration_extension_seconds` but `crew.tactical.sensor_volume` repurposes it for sensor-volume units.

A new `[[talent_stat_overrides]]` TOML section maps `(fqn_prefix, stat_id) -> StatLabel`. `populate_gsf_talent_stats` now selects each talent's FQN alongside its payload and calls `dict.talent_label_for(stat_id, fqn)`, which consults the overrides first (longest prefix wins) and falls back to the default `talent_label` mapping.

### Net effect for consumers

- Verified labels: **14 -> 41** (~3x increase in queryable rows).
- `unknown_0x__` residual: **~30 -> ~8** (single-row outliers and the ambiguous `0x57` shield-bleedthrough case).
- huttspawn can now `SELECT label, value FROM gsf_talent_stats WHERE label IN (...)` for the full build-calculator roll-up of every label they asked for.

### Caveats documented in `notes`

- `0x21` shield_power_regen_pct_alt diverges from `0x20` on a few shield-ability outliers -- consumers should filter to the primary `shield_power_regen_pct` label for clean roll-up.
- `0x55` shield_regen_delay_pct is a percentage on minor/crew rows but stores raw seconds on `shield.directional_shield.tier3a` (-3.0 = -3s). Consumers wanting only percent rows: `WHERE label='shield_regen_delay_pct' AND ABS(value) < 1.0`.
- `0x5d` secondary_weapon_cooldown_pct has the same dual-encoding caveat (percentage on crew, raw seconds on two missile-ability rows).

## Test plan

- [x] `cargo test --release` -- 12 lib tests pass (including 3 new ones: FQN override behavior, embedded-load smoke, new-labels-present)
- [x] `cargo clippy --release --lib -- -D warnings` -- clean
- [x] `rustfmt --check` on modified files -- clean
- [ ] Re-extraction against `~/swtor/Assets` (next session; the populate logic is verified by unit tests, but a fresh spice.sqlite will let huttspawn ingest the new labels immediately)

## Refs

- Signal: `019e3c80-648c-7b23-9fcc-5528d54c7766` (huttspawn -> kessel, 2026-05-18)
- Reflection lineage: `019df58f-15dd-7de3-8e8f-c320f2920a8c` (the queued dictionary work from the 2026-05-04 GSF base-stats session) -- this PR is its delivery.