### PR TITLE
feat(hash): hashlittle2 + swtor_filename_hash (closes #120)

### DIFF
--- a/kessel/src/hash.rs
+++ b/kessel/src/hash.rs
@@ -137,3 +137,248 @@ impl Default for HashDictionary {
         Self::new()
     }
 }
+
+// ----- Bob Jenkins lookup3 hashlittle2 ---------------------------------------
+//
+// SWTOR's MYP archive filename hash is Bob Jenkins' `hashlittle2` from
+// https://burtleburtle.net/bob/c/lookup3.c
+// (verified 2026-05-21 against `~/swtor/data/hashes_filename.txt`).
+//
+// EasyMYP format stores `PH#SH#path` where:
+//   PH = hashlittle2(path).primary
+//   SH = hashlittle2(path).secondary
+//
+// `swtor_filename_hash(path) -> u64` combines them as `(SH << 32) | PH`.
+//
+// Case-preserving, UTF-8, no null terminator. Pure-Rust translation; no FFI.
+
+#[inline(always)]
+#[allow(dead_code)]
+fn rot(x: u32, k: u32) -> u32 {
+    x.rotate_left(k)
+}
+
+#[inline(always)]
+#[allow(dead_code)]
+fn mix(mut a: u32, mut b: u32, mut c: u32) -> (u32, u32, u32) {
+    a = a.wrapping_sub(c);
+    a ^= rot(c, 4);
+    c = c.wrapping_add(b);
+    b = b.wrapping_sub(a);
+    b ^= rot(a, 6);
+    a = a.wrapping_add(c);
+    c = c.wrapping_sub(b);
+    c ^= rot(b, 8);
+    b = b.wrapping_add(a);
+    a = a.wrapping_sub(c);
+    a ^= rot(c, 16);
+    c = c.wrapping_add(b);
+    b = b.wrapping_sub(a);
+    b ^= rot(a, 19);
+    a = a.wrapping_add(c);
+    c = c.wrapping_sub(b);
+    c ^= rot(b, 4);
+    b = b.wrapping_add(a);
+    (a, b, c)
+}
+
+#[inline(always)]
+#[allow(dead_code)]
+fn final_mix(mut a: u32, mut b: u32, mut c: u32) -> (u32, u32, u32) {
+    c ^= b;
+    c = c.wrapping_sub(rot(b, 14));
+    a ^= c;
+    a = a.wrapping_sub(rot(c, 11));
+    b ^= a;
+    b = b.wrapping_sub(rot(a, 25));
+    c ^= b;
+    c = c.wrapping_sub(rot(b, 16));
+    a ^= c;
+    a = a.wrapping_sub(rot(c, 4));
+    b ^= a;
+    b = b.wrapping_sub(rot(a, 14));
+    c ^= b;
+    c = c.wrapping_sub(rot(b, 24));
+    (a, b, c)
+}
+
+#[inline(always)]
+#[allow(dead_code)]
+fn load_u32_le(buf: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        buf[offset],
+        buf[offset + 1],
+        buf[offset + 2],
+        buf[offset + 3],
+    ])
+}
+
+/// Bob Jenkins lookup3 `hashlittle2`. Returns the `(b, c)` output pair as
+/// `(primary, secondary)` u32s.
+///
+/// `initval` seeds the primary half, `initval2` the secondary half. Most
+/// callers use `(0, 0)`.
+#[allow(dead_code)]
+pub fn hashlittle2(key: &[u8], initval: u32, initval2: u32) -> (u32, u32) {
+    let length = key.len() as u32;
+    let mut a = 0xdeadbeef_u32.wrapping_add(length).wrapping_add(initval);
+    let mut b = a;
+    let mut c = a.wrapping_add(initval2);
+
+    let mut offset = 0;
+    let mut remaining = key.len();
+
+    // Process full 12-byte chunks
+    while remaining > 12 {
+        a = a.wrapping_add(load_u32_le(key, offset));
+        b = b.wrapping_add(load_u32_le(key, offset + 4));
+        c = c.wrapping_add(load_u32_le(key, offset + 8));
+        let r = mix(a, b, c);
+        a = r.0;
+        b = r.1;
+        c = r.2;
+        offset += 12;
+        remaining -= 12;
+    }
+
+    // Handle the last 0..12 bytes
+    match remaining {
+        12 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(load_u32_le(key, offset + 4));
+            c = c.wrapping_add(load_u32_le(key, offset + 8));
+        }
+        11 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(load_u32_le(key, offset + 4));
+            c = c.wrapping_add(
+                (key[offset + 8] as u32)
+                    | ((key[offset + 9] as u32) << 8)
+                    | ((key[offset + 10] as u32) << 16),
+            );
+        }
+        10 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(load_u32_le(key, offset + 4));
+            c = c.wrapping_add((key[offset + 8] as u32) | ((key[offset + 9] as u32) << 8));
+        }
+        9 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(load_u32_le(key, offset + 4));
+            c = c.wrapping_add(key[offset + 8] as u32);
+        }
+        8 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(load_u32_le(key, offset + 4));
+        }
+        7 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(
+                (key[offset + 4] as u32)
+                    | ((key[offset + 5] as u32) << 8)
+                    | ((key[offset + 6] as u32) << 16),
+            );
+        }
+        6 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add((key[offset + 4] as u32) | ((key[offset + 5] as u32) << 8));
+        }
+        5 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+            b = b.wrapping_add(key[offset + 4] as u32);
+        }
+        4 => {
+            a = a.wrapping_add(load_u32_le(key, offset));
+        }
+        3 => {
+            a = a.wrapping_add(
+                (key[offset] as u32)
+                    | ((key[offset + 1] as u32) << 8)
+                    | ((key[offset + 2] as u32) << 16),
+            );
+        }
+        2 => {
+            a = a.wrapping_add((key[offset] as u32) | ((key[offset + 1] as u32) << 8));
+        }
+        1 => {
+            a = a.wrapping_add(key[offset] as u32);
+        }
+        0 => return (b, c),
+        _ => unreachable!(),
+    }
+
+    let r = final_mix(a, b, c);
+    (r.1, r.2)
+}
+
+/// Compute SWTOR's 64-bit MYP archive filename hash for a path.
+///
+/// `swtor_filename_hash(path) == (SH << 32) | PH` where `(PH, SH) =
+/// hashlittle2(path, 0, 0)`. Matches the `PH#SH#path` entries in
+/// `hashes_filename.txt`.
+#[allow(dead_code)]
+pub fn swtor_filename_hash(path: &str) -> u64 {
+    let (ph, sh) = hashlittle2(path.as_bytes(), 0, 0);
+    ((sh as u64) << 32) | (ph as u64)
+}
+
+#[cfg(test)]
+mod hashlittle2_tests {
+    use super::*;
+
+    /// Verified against `~/swtor/data/hashes_filename.txt` real entries.
+    /// Format from the dictionary: `PH#SH#path#CRC`.
+    #[test]
+    fn matches_real_archive_paths() {
+        // Real PH/SH pairs taken from hashes_filename.txt.
+        let cases: &[(&str, u32, u32)] = &[
+            // /resources/en-us/str/abl.stb
+            ("/resources/en-us/str/abl.stb", 0x8154956D, 0x54305B3B),
+            // /resources/systemgenerated/client.gom
+            (
+                "/resources/systemgenerated/client.gom",
+                0x6107069D,
+                0xB7C70D58,
+            ),
+        ];
+        for (path, exp_ph, exp_sh) in cases {
+            let (ph, sh) = hashlittle2(path.as_bytes(), 0, 0);
+            assert_eq!(
+                ph, *exp_ph,
+                "primary hash mismatch for {path}: got {ph:08X}, want {exp_ph:08X}"
+            );
+            assert_eq!(
+                sh, *exp_sh,
+                "secondary hash mismatch for {path}: got {sh:08X}, want {exp_sh:08X}"
+            );
+            let combined = swtor_filename_hash(path);
+            assert_eq!(combined, ((*exp_sh as u64) << 32) | (*exp_ph as u64));
+        }
+    }
+
+    #[test]
+    fn empty_input() {
+        // For empty input the function returns (initval, initval2 + initval).
+        // With (0, 0) seeds, that's just (0xdeadbeef, 0xdeadbeef).
+        let (ph, sh) = hashlittle2(b"", 0, 0);
+        assert_eq!(ph, 0xdeadbeef);
+        assert_eq!(sh, 0xdeadbeef);
+    }
+
+    #[test]
+    fn case_preserving() {
+        let lower = swtor_filename_hash("/resources/en-us/str/abl.stb");
+        let upper = swtor_filename_hash("/resources/EN-US/STR/abl.stb");
+        assert_ne!(
+            lower, upper,
+            "case-preserving -- different case must hash differently"
+        );
+    }
+
+    #[test]
+    fn deterministic() {
+        let a = swtor_filename_hash("/resources/systemgenerated/client.gom");
+        let b = swtor_filename_hash("/resources/systemgenerated/client.gom");
+        assert_eq!(a, b);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1, issue 1 of 4 from the systemgenerated/ integration plan.

Adds Bob Jenkins' lookup3 `hashlittle2` to `kessel::hash` as `swtor_filename_hash(path)` — kessel can now compute MYP archive filename hashes for any path, not just lookups against the public dictionary.

## Test plan

- [x] `cargo test -p kessel --lib hashlittle2` passes (4 tests)
- [x] Real hashes from `~/swtor/data/hashes_filename.txt` verified:
   - `/resources/en-us/str/abl.stb` -> `8154956D 54305B3B` ✓
   - `/resources/systemgenerated/client.gom` -> `6107069D B7C70D58` ✓
- [x] Empty input: `(0xdeadbeef, 0xdeadbeef)` ✓
- [x] Case-preserving (different case hashes differently) ✓
- [x] `cargo clippy -p kessel -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] No `unsafe`, no `unwrap()`

## Depends on

- #119 (workspace refactor) — branched off its branch; will rebase to main once #119 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)