### PR TITLE
feat(node): PROT (.node) prototype parser (closes #126)

### DIFF
--- a/kessel/src/lib.rs
+++ b/kessel/src/lib.rs
@@ -11,6 +11,7 @@ pub mod hash;
 pub mod icon_overrides;
 pub mod myp;
 pub mod pbuk;
+pub mod prototypes_info;
 pub mod quest;
 pub mod schema;
 pub mod stb;

--- a/kessel/src/lib.rs
+++ b/kessel/src/lib.rs
@@ -10,6 +10,7 @@ pub mod gsf_stat_dictionary;
 pub mod hash;
 pub mod icon_overrides;
 pub mod myp;
+pub mod node;
 pub mod pbuk;
 pub mod prototypes_info;
 pub mod quest;

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -15,6 +15,7 @@ mod hash;
 mod icon_overrides;
 mod myp;
 mod pbuk;
+mod prototypes_info;
 mod quest;
 mod schema;
 mod stb;

--- a/kessel/src/node.rs
+++ b/kessel/src/node.rs
@@ -1,0 +1,230 @@
+//! PROT (.node) prototype file parser.
+//!
+//! Files at `/resources/systemgenerated/prototypes/<numeric_id>.node` use the
+//! PROT format:
+//!
+//! | offset | bytes | meaning                                          |
+//! |--------|-------|--------------------------------------------------|
+//! | 0      | 4     | `PROT` magic (50 52 4F 54)                       |
+//! | 4      | 4     | version (`02 00 05 00` LE on v7.x archives)      |
+//! | 8      | 8     | content GUID (u64 LE)                            |
+//! | 16     | 4     | FQN length (u32 LE) -- includes trailing NUL     |
+//! | 20     | N     | FQN UTF-8 bytes (may end in NUL)                 |
+//! | 20+N   | ...   | binary GOM payload (same shape as PBUK payloads) |
+//!
+//! Empirically verified across 10,735 NODE entries in v7.x archives -- all
+//! observed FQNs begin with `cnv.` (conversation prototypes). The format is
+//! generic, so creature/stage/ability prototypes would parse identically if
+//! they appear in future patches. The downstream GOM payload is handed off to
+//! `kessel::pbuk` consumers (e.g. `extract_strings_from_payload`).
+//!
+//! Discovery reflection: legion `019dd668-d09c-7a20-b835-791e29f8e511`.
+
+use crate::hash::HashDictionary;
+use crate::myp::Archive;
+use crate::prototypes_info::PrototypeInfo;
+use anyhow::{anyhow, bail, Result};
+use std::collections::{HashMap, HashSet};
+
+const PROT_MAGIC: [u8; 4] = [b'P', b'R', b'O', b'T'];
+const HEADER_LEN: usize = 20;
+
+/// One PROT-format node file's parsed contents.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct NodeRecord {
+    /// Numeric id matching the `.node` filename.
+    pub numeric_id: u64,
+    /// In-payload FQN (e.g. `cnv.<area>.<scene>`).
+    pub fqn: String,
+    /// PINF kind flag for downstream schema routing.
+    pub kind_flag: u8,
+    /// Raw GOM payload following the FQN -- ready for the pbuk decoder.
+    pub payload: Vec<u8>,
+    /// 16-char hex of the 8-byte content GUID at offset 8, matching the
+    /// `objects` table format.
+    pub template_guid: String,
+}
+
+/// Parse a single `.node` file's bytes into a `NodeRecord`.
+#[allow(dead_code)]
+pub fn parse(bytes: &[u8], numeric_id: u64, kind_flag: u8) -> Result<NodeRecord> {
+    if bytes.len() < HEADER_LEN {
+        bail!(
+            "truncated PROT header: got {} bytes, need at least {}",
+            bytes.len(),
+            HEADER_LEN
+        );
+    }
+    if bytes[..4] != PROT_MAGIC {
+        bail!("invalid PROT magic: {:02X?}", &bytes[..4]);
+    }
+
+    let guid_bytes: [u8; 8] = bytes[8..16].try_into().expect("8..16 in 20-byte header");
+    let template_guid = format!("{:016X}", u64::from_le_bytes(guid_bytes));
+
+    let len_bytes: [u8; 4] = bytes[16..20].try_into().expect("16..20 in 20-byte header");
+    let fqn_len = u32::from_le_bytes(len_bytes) as usize;
+    let fqn_end = HEADER_LEN
+        .checked_add(fqn_len)
+        .filter(|end| *end <= bytes.len())
+        .ok_or_else(|| {
+            anyhow!(
+                "invalid FQN length: {} (file size {})",
+                fqn_len,
+                bytes.len()
+            )
+        })?;
+
+    let mut fqn_slice = &bytes[HEADER_LEN..fqn_end];
+    while let Some(&0) = fqn_slice.last() {
+        fqn_slice = &fqn_slice[..fqn_slice.len() - 1];
+    }
+    let fqn = std::str::from_utf8(fqn_slice)
+        .map_err(|e| anyhow!("non-UTF8 FQN: {e}"))?
+        .to_string();
+
+    let payload = bytes[fqn_end..].to_vec();
+    Ok(NodeRecord {
+        numeric_id,
+        fqn,
+        kind_flag,
+        payload,
+        template_guid,
+    })
+}
+
+/// Discover every `.node` file in the archive and parse each one.
+///
+/// `kind_flag` is sourced from `prototypes.info`; entries without a PINF row
+/// receive flag `0`. Malformed PROT entries are skipped rather than failing the
+/// whole walk -- the goal is "all parseable nodes" for downstream extractors.
+#[allow(dead_code)]
+pub fn walk_archive_nodes(
+    archive: &mut Archive,
+    hash_dict: &HashDictionary,
+    pinf: &[PrototypeInfo],
+) -> Result<Vec<NodeRecord>> {
+    let flag_by_id: HashMap<u64, u8> = pinf.iter().map(|p| (p.numeric_id, p.flag)).collect();
+    let proto_hashes: HashSet<u64> = hash_dict
+        .paths_matching("/resources/systemgenerated/prototypes/")
+        .into_iter()
+        .map(|(h, _)| h)
+        .collect();
+    let entries: Vec<_> = archive.entries()?.cloned().collect();
+
+    let mut out = Vec::with_capacity(entries.len() / 16);
+    for entry in entries {
+        if !proto_hashes.contains(&entry.filename_hash) {
+            continue;
+        }
+        let path = match hash_dict.get(entry.filename_hash) {
+            Some(p) => p,
+            None => continue,
+        };
+        let numeric_id = path
+            .rsplit('/')
+            .next()
+            .and_then(|f| f.strip_suffix(".node"))
+            .and_then(|s| s.parse::<u64>().ok());
+        let Some(numeric_id) = numeric_id else {
+            continue;
+        };
+        let kind_flag = flag_by_id.get(&numeric_id).copied().unwrap_or(0);
+        let bytes = match archive.read_entry(&entry) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if let Ok(rec) = parse(&bytes, numeric_id, kind_flag) {
+            out.push(rec);
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_prot(fqn: &str, guid: u64, payload: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(HEADER_LEN + fqn.len() + 1 + payload.len());
+        buf.extend_from_slice(&PROT_MAGIC);
+        buf.extend_from_slice(&[0x02, 0x00, 0x05, 0x00]); // version
+        buf.extend_from_slice(&guid.to_le_bytes());
+        let len = (fqn.len() + 1) as u32; // include NUL terminator
+        buf.extend_from_slice(&len.to_le_bytes());
+        buf.extend_from_slice(fqn.as_bytes());
+        buf.push(0);
+        buf.extend_from_slice(payload);
+        buf
+    }
+
+    #[test]
+    fn parses_minimal_cnv_prot() {
+        let payload = vec![0xAA, 0xBB, 0xCC];
+        let bytes = build_prot("cnv.test.scene_a", 0x1122_3344_5566_7788, &payload);
+        let rec = parse(&bytes, 42, 1).expect("parse");
+        assert_eq!(rec.numeric_id, 42);
+        assert_eq!(rec.kind_flag, 1);
+        assert_eq!(rec.fqn, "cnv.test.scene_a");
+        assert_eq!(rec.template_guid, "1122334455667788");
+        assert_eq!(rec.payload, payload);
+    }
+
+    #[test]
+    fn rejects_invalid_magic() {
+        let mut bytes = build_prot("cnv.x", 0, &[]);
+        bytes[0] = b'X';
+        let err = parse(&bytes, 0, 0).unwrap_err();
+        assert!(format!("{err}").contains("invalid PROT magic"));
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        let bytes = b"PROT\x02\x00\x05\x00\x00\x00";
+        let err = parse(bytes, 0, 0).unwrap_err();
+        assert!(format!("{err}").contains("truncated PROT header"));
+    }
+
+    #[test]
+    fn rejects_fqn_length_past_eof() {
+        let mut bytes = build_prot("cnv.short", 0, &[]);
+        // overwrite length to point past file end
+        bytes[16..20].copy_from_slice(&9_999u32.to_le_bytes());
+        let err = parse(&bytes, 0, 0).unwrap_err();
+        assert!(format!("{err}").contains("invalid FQN length"));
+    }
+
+    #[test]
+    fn rejects_non_utf8_fqn() {
+        let mut bytes = build_prot("cnv.placeholder", 0, &[]);
+        // overwrite the first FQN byte with an invalid UTF-8 sequence start
+        bytes[HEADER_LEN] = 0xFF;
+        bytes[HEADER_LEN + 1] = 0xFE;
+        let err = parse(&bytes, 0, 0).unwrap_err();
+        assert!(format!("{err}").contains("non-UTF8"));
+    }
+
+    #[test]
+    fn fqn_without_trailing_null_still_parses() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&PROT_MAGIC);
+        buf.extend_from_slice(&[0x02, 0x00, 0x05, 0x00]);
+        buf.extend_from_slice(&0u64.to_le_bytes());
+        let fqn = "cnv.no_terminator";
+        buf.extend_from_slice(&(fqn.len() as u32).to_le_bytes());
+        buf.extend_from_slice(fqn.as_bytes());
+        buf.extend_from_slice(&[0x11, 0x22]);
+        let rec = parse(&buf, 7, 1).expect("parse");
+        assert_eq!(rec.fqn, "cnv.no_terminator");
+        assert_eq!(rec.payload, vec![0x11, 0x22]);
+    }
+
+    #[test]
+    fn payload_is_slice_after_fqn() {
+        let payload: Vec<u8> = (0..32).collect();
+        let bytes = build_prot("cnv.payload_test", 1, &payload);
+        let rec = parse(&bytes, 1, 0).expect("parse");
+        assert_eq!(rec.payload, payload);
+    }
+}

--- a/kessel/src/prototypes_info.rs
+++ b/kessel/src/prototypes_info.rs
@@ -1,0 +1,158 @@
+//! Parser for `/resources/systemgenerated/prototypes.info` (PINF format).
+//!
+//! PINF is a metadata table mapping each `.node` PROT prototype's numeric ID
+//! to a flag byte. The flag routes the .node file to its correct schema
+//! converter (conversation vs creature vs stage vs player ability) without
+//! parsing each file's header speculatively.
+//!
+//! Format (per sub-agent investigation, legion `019e4d74`):
+//! - 11-byte header: `PINF` magic + version (`01 00 05 00`) + 3 unknown bytes
+//! - Records: 10 bytes each = u64 BE numeric_id + u8 flag + 1 unknown byte
+//! - Trailing end-of-stream marker
+//!
+//! Current archive: 723,690 records, 10,735 flag=1 (matches the cnv.* files
+//! present in the .node corpus).
+
+use anyhow::{bail, Result};
+use std::collections::HashMap;
+
+const PINF_MAGIC: &[u8; 4] = b"PINF";
+const HEADER_LEN: usize = 11;
+const RECORD_LEN: usize = 10;
+
+/// One PINF record: numeric_id (matches the .node filename) and flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrototypeInfo {
+    pub numeric_id: u64,
+    pub flag: u8,
+}
+
+/// Parse the binary PINF file. Returns all records in file order.
+#[allow(dead_code)]
+pub fn parse(bytes: &[u8]) -> Result<Vec<PrototypeInfo>> {
+    if bytes.len() < HEADER_LEN {
+        bail!("PINF too short for header: {} bytes", bytes.len());
+    }
+    if &bytes[..4] != PINF_MAGIC {
+        bail!(
+            "invalid PINF magic: {:02X?} (expected {:02X?})",
+            &bytes[..4],
+            PINF_MAGIC
+        );
+    }
+
+    let payload = &bytes[HEADER_LEN..];
+    let usable_len = (payload.len() / RECORD_LEN) * RECORD_LEN;
+    let mut records = Vec::with_capacity(usable_len / RECORD_LEN);
+
+    let mut i = 0;
+    while i + RECORD_LEN <= usable_len {
+        let chunk = &payload[i..i + RECORD_LEN];
+        let id_bytes: [u8; 8] = chunk[0..8].try_into().unwrap();
+        let numeric_id = u64::from_be_bytes(id_bytes);
+        let flag = chunk[8];
+        // chunk[9] is currently unknown -- carry along separately if/when meaning
+        // is identified.
+        records.push(PrototypeInfo { numeric_id, flag });
+        i += RECORD_LEN;
+    }
+
+    Ok(records)
+}
+
+/// Build a numeric_id -> flag lookup map from a parsed record list.
+#[allow(dead_code)]
+pub fn build_id_to_flag_map(records: &[PrototypeInfo]) -> HashMap<u64, u8> {
+    let mut map = HashMap::with_capacity(records.len());
+    for record in records {
+        map.insert(record.numeric_id, record.flag);
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_record(id: u64, flag: u8) -> [u8; RECORD_LEN] {
+        let mut out = [0u8; RECORD_LEN];
+        out[..8].copy_from_slice(&id.to_be_bytes());
+        out[8] = flag;
+        out
+    }
+
+    fn build_pinf(records: &[(u64, u8)]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(HEADER_LEN + records.len() * RECORD_LEN);
+        bytes.extend_from_slice(PINF_MAGIC);
+        bytes.extend_from_slice(&[0x01, 0x00, 0x05, 0x00]); // version
+        bytes.extend_from_slice(&[0xAA, 0xAA, 0xAA]); // unknown header tail
+        for (id, flag) in records {
+            bytes.extend_from_slice(&build_record(*id, *flag));
+        }
+        bytes
+    }
+
+    #[test]
+    fn parses_minimal_pinf() {
+        let bytes = build_pinf(&[(0x12345678, 1)]);
+        let records = parse(&bytes).expect("parse failed");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].numeric_id, 0x12345678);
+        assert_eq!(records[0].flag, 1);
+    }
+
+    #[test]
+    fn parses_multiple_records() {
+        let bytes = build_pinf(&[
+            (14988260499516371179, 1),
+            (14988260499516371180, 0),
+            (14988260499516371181, 1),
+        ]);
+        let records = parse(&bytes).expect("parse failed");
+        assert_eq!(records.len(), 3);
+        let flag1 = records.iter().filter(|r| r.flag == 1).count();
+        assert_eq!(flag1, 2);
+    }
+
+    #[test]
+    fn rejects_invalid_magic() {
+        let mut bytes = vec![b'N', b'O', b'P', b'E'];
+        bytes.extend_from_slice(&[0u8; HEADER_LEN]);
+        assert!(parse(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_too_short() {
+        let bytes = b"PINF\x01\x00";
+        assert!(parse(bytes).is_err());
+    }
+
+    #[test]
+    fn empty_records_section_ok() {
+        let bytes = build_pinf(&[]);
+        let records = parse(&bytes).expect("parse failed");
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn build_id_to_flag_map_dedupes() {
+        let records = vec![
+            PrototypeInfo {
+                numeric_id: 1,
+                flag: 0,
+            },
+            PrototypeInfo {
+                numeric_id: 2,
+                flag: 1,
+            },
+            PrototypeInfo {
+                numeric_id: 1,
+                flag: 1,
+            }, // later entry wins
+        ];
+        let map = build_id_to_flag_map(&records);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&1), Some(&1));
+        assert_eq!(map.get(&2), Some(&1));
+    }
+}


### PR DESCRIPTION
## Summary
- New `kessel::node` module parses PROT-format `.node` files at `/resources/systemgenerated/prototypes/<id>.node`.
- `parse(bytes, numeric_id, kind_flag) -> Result<NodeRecord>` for one file; `walk_archive_nodes(archive, hash_dict, pinf) -> Result<Vec<NodeRecord>>` for batch discovery via PINF routing (issue #121).
- Closes the long-standing "NODE files not yet parsed" gap in CLAUDE.md Known Gaps.
- Unlocks Phase 5: #133 (creatures), #134 (stages), #135 (cnv ingest).

## Format

| offset | bytes | meaning                                          |
|--------|-------|--------------------------------------------------|
| 0      | 4     | `PROT` magic                                     |
| 4      | 4     | version                                          |
| 8      | 8     | content GUID (u64 LE)                            |
| 16     | 4     | FQN length (u32 LE)                              |
| 20     | N     | FQN UTF-8 (NUL-trimmed)                          |
| 20+N   | ...   | binary GOM payload (consumed by pbuk decoders)   |

Source: legion reflection `019dd668` (Agent E discovery).

## Stack

Stacked on #147 (#121 PINF parser). Merge order: #145 -> #146 -> #147 -> this PR. Will auto-retarget to main once #147 lands.

## Test plan
- [x] `cargo test -p kessel --lib` -- 127 tests pass (7 new in `node::tests`)
- [x] `cargo clippy -p kessel --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p kessel` clean
- [x] legion-simplify gate: clean (0 findings)
- [ ] Real-archive walk verifying >=10,000 cnv.* (deferred -- archive-dependent, run locally before merge)