### PR TITLE
feat(scpt): promote SCPT decoder to library module (closes #127)

### DIFF
--- a/kessel-discovery/src/bin/decrypt_scpt.rs
+++ b/kessel-discovery/src/bin/decrypt_scpt.rs
@@ -1,115 +1,13 @@
-//! Decrypt SCPT compiled-script files from /resources/systemgenerated/compilednative/.
+//! CLI wrapper around `kessel::scpt::parse_and_decrypt`.
 //!
-//! ## SCPT Format (reverse-engineered)
-//!
-//! All files in `swtor_main_global_1.tor` under `/resources/systemgenerated/compilednative/`
-//! share this format:
-//!
-//! ### Header (37 bytes, plaintext)
-//!
-//! Offset  Size  Field           Description
-//! ------  ----  -----           -----------
-//! 0x00    4     magic           "SCPT" (0x53 0x43 0x50 0x54)
-//! 0x04    4     version         0x06000500 (version 6.5)
-//! 0x08    8     section_count?  Constant 0x0000000000000001
-//! 0x10    8     guid_le         Per-file u64 LE = the numeric filename
-//! 0x18    8     constant        0x0000000000000201
-//! 0x20    1     pad             0x00
-//! 0x21    3     body_size_le    u24 LE: bytes following the header
-//! 0x24    1     pad             0x00
-//!
-//! ### Body (body_size bytes, encrypted)
-//!
-//! XOR stream cipher with the deterministic keystream:
-//!
-//!     plaintext[i] = cipher[i] XOR ((0x43 + 11*i) mod 256)
-//!
-//! The cipher key is **constant across all 1,196 files** -- no per-file derivation,
-//! no GUID dependency. Confirmed via 149 stub files whose decrypted plaintext is
-//! identical (30 bytes of mostly-zero data with structural tag bytes).
-//!
-//! ### Plaintext layout (after decryption)
-//!
-//! The decrypted body is a SWTOR-internal compiled-script container holding
-//! native x86-64 machine code, not Pawn bytecode. 1046/1047 non-stub files
-//! contain identifiable x86-64 function prologues (`55 48 89 E5`, `41 57 41 56`,
-//! etc). The body opens with a metadata section that uses tag bytes:
-//!
-//!   0xCB = string-reference / external symbol id (5-byte record: CB + 4 bytes)
-//!   0xC9 = native-code blob marker
-//!   0xD1 = literal-int open, 0xD3 = literal-int close
-//!
-//! followed by the raw x86-64 function code. This is JIT-style precompiled
-//! UI/scripting code, NOT gameplay-formula data.
-//!
-//! ## Important: SCPT files are UI/client logic, not gameplay math
-//!
-//! Identifiable script purposes (extracted from embedded string tables):
-//! - `displayDialog`, `scrollPagePanel`, `OnSliderFieldValueChange`
-//! - `cmdValidateIsPositiveNumber`, `HE_getWindow` (HTML-Engine UI widgets)
-//! - `Play_spvp_targetlock_beep`, `onSetMissileLockIndicatorState`
-//! - `displayGalacticStarfighterUpsellWindow`
-//!
-//! No GSF damage formulas, no per-component damage constants, no combat
-//! arithmetic was found in any of the 1,196 SCPT files. The "damage" strings
-//! that DO appear are UI event hooks (`onChangedPlayerDamageStat`) and
-//! animation labels (`damage_01`..`damage_05`).
-//!
-//! Conclusion: SCPT is the wrong format for GSF damage extraction. Combat
-//! formulas must live elsewhere -- likely in client EXE/DLL code that consumes
-//! these scripts but performs the math itself.
+//! Walks every SCPT entry in the provided `.tor` archives, decrypts the body,
+//! and writes the plaintext to `<output_dir>/<numeric_id>.scpt.dec`. See the
+//! `kessel::scpt` module docs for format details.
 
 use anyhow::Result;
 use kessel::myp::Archive;
+use kessel::scpt;
 use std::path::PathBuf;
-
-const SCPT_MAGIC: [u8; 4] = *b"SCPT";
-const SCPT_HEADER_SIZE: usize = 37;
-const CIPHER_START: u8 = 0x43;
-const CIPHER_STEP: u8 = 11;
-
-/// Decrypt an SCPT file body in-place.
-///
-/// `body` is the bytes AFTER the 37-byte header. Returns the plaintext
-/// (same length as input).
-pub fn decrypt_body(body: &[u8]) -> Vec<u8> {
-    body.iter()
-        .enumerate()
-        .map(|(i, &b)| {
-            let key = CIPHER_START.wrapping_add(CIPHER_STEP.wrapping_mul(i as u8));
-            b ^ key
-        })
-        .collect()
-}
-
-#[derive(Debug)]
-pub struct ScptHeader {
-    pub version: u32,
-    pub section_count: u64,
-    pub guid: u64,
-    pub constant_18: u64,
-    pub body_size: u32,
-}
-
-impl ScptHeader {
-    pub fn parse(data: &[u8]) -> Result<Self> {
-        if data.len() < SCPT_HEADER_SIZE {
-            anyhow::bail!("SCPT data too small: {} < {}", data.len(), SCPT_HEADER_SIZE);
-        }
-        if data[0..4] != SCPT_MAGIC {
-            anyhow::bail!("bad SCPT magic: {:?}", &data[0..4]);
-        }
-        // body_size is a u24 LE at offset 0x21
-        let body_size = u32::from_le_bytes([data[0x21], data[0x22], data[0x23], 0]);
-        Ok(Self {
-            version: u32::from_le_bytes(data[4..8].try_into()?),
-            section_count: u64::from_le_bytes(data[8..16].try_into()?),
-            guid: u64::from_le_bytes(data[16..24].try_into()?),
-            constant_18: u64::from_le_bytes(data[24..32].try_into()?),
-            body_size,
-        })
-    }
-}
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -157,21 +55,17 @@ fn main() -> Result<()> {
                 Ok(d) => d,
                 Err(_) => continue,
             };
-            if data.len() < SCPT_HEADER_SIZE || data[0..4] != SCPT_MAGIC {
+            if data.len() < 4 || &data[..4] != b"SCPT" {
                 continue;
             }
-            let header = ScptHeader::parse(&data)?;
-            let body = &data[SCPT_HEADER_SIZE..];
-            if body.len() != header.body_size as usize {
-                eprintln!(
-                    "warn: body size mismatch for {}: hdr={} actual={}",
-                    header.guid,
-                    header.body_size,
-                    body.len()
-                );
-            }
-            let plaintext = decrypt_body(body);
-            let out_path = output_dir.join(format!("{}.scpt.dec", header.guid));
+            let (header, plaintext) = match scpt::parse_and_decrypt(&data) {
+                Ok(out) => out,
+                Err(e) => {
+                    eprintln!("warn: {} -- {e}", entry.filename_hash);
+                    continue;
+                }
+            };
+            let out_path = output_dir.join(format!("{}.scpt.dec", header.numeric_id));
             std::fs::write(&out_path, &plaintext)?;
             total += 1;
         }

--- a/kessel/src/lib.rs
+++ b/kessel/src/lib.rs
@@ -13,5 +13,6 @@ pub mod myp;
 pub mod pbuk;
 pub mod quest;
 pub mod schema;
+pub mod scpt;
 pub mod stb;
 pub mod xml_parser;

--- a/kessel/src/scpt.rs
+++ b/kessel/src/scpt.rs
@@ -1,0 +1,211 @@
+//! SCPT compiled-script file format.
+//!
+//! Files at `/resources/systemgenerated/compilednative/<numeric_id>.scpt` use
+//! a constant-key XOR stream cipher over a 37-byte plaintext header. Verified
+//! by sub-agent B across all 1,196 SCPT entries in v7.x archives (legion
+//! reflection `019e4d62`).
+//!
+//! ## Header (37 bytes, plaintext)
+//!
+//! | offset | size | field          | meaning                           |
+//! |-------:|-----:|----------------|-----------------------------------|
+//! | 0x00   | 4    | magic          | `SCPT`                            |
+//! | 0x04   | 4    | version        | `06 00 05 00` (LE) on v7.x        |
+//! | 0x08   | 8    | section_count  | constant `1`                      |
+//! | 0x10   | 8    | numeric_id     | u64 LE -- matches filename        |
+//! | 0x18   | 8    | constant_marker| always `0x0000_0000_0000_0201`    |
+//! | 0x20   | 1    | pad            | `0x00`                            |
+//! | 0x21   | 3    | body_size      | u24 LE                            |
+//! | 0x24   | 1    | pad            | `0x00`                            |
+//!
+//! ## Body cipher
+//!
+//! Constant XOR keystream, no per-file derivation:
+//! `plaintext[i] = ciphertext[i] XOR ((0x43 + 11 * i) % 256)`
+//!
+//! ## What this is NOT
+//!
+//! SCPT bodies decrypt to native x86-64 UI/SFX code, not gameplay-formula data
+//! or Pawn bytecode. Decoder ships as a utility for future UI-string scans
+//! (cnv/qst/mpn cross-references); no spice table consumes SCPT bodies today.
+
+use anyhow::{bail, Result};
+
+const SCPT_MAGIC: [u8; 4] = *b"SCPT";
+const SCPT_HEADER_SIZE: usize = 37;
+const CIPHER_START: u8 = 0x43;
+const CIPHER_STEP: u8 = 11;
+
+/// SCPT plaintext header (37 bytes, uniform across all known files).
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct ScptHeader {
+    pub version: u32,
+    pub section_count: u64,
+    pub numeric_id: u64,
+    pub constant_marker: u64,
+    pub body_size: u32,
+}
+
+impl ScptHeader {
+    /// Parse the 37-byte SCPT header from the start of `bytes`.
+    pub fn parse(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < SCPT_HEADER_SIZE {
+            bail!(
+                "SCPT header truncated: got {} bytes, need {}",
+                bytes.len(),
+                SCPT_HEADER_SIZE
+            );
+        }
+        if bytes[..4] != SCPT_MAGIC {
+            bail!("invalid SCPT magic: {:02X?}", &bytes[..4]);
+        }
+        let body_size = u32::from_le_bytes([bytes[0x21], bytes[0x22], bytes[0x23], 0]);
+        Ok(Self {
+            version: u32::from_le_bytes(bytes[4..8].try_into().expect("4..8")),
+            section_count: u64::from_le_bytes(bytes[8..16].try_into().expect("8..16")),
+            numeric_id: u64::from_le_bytes(bytes[16..24].try_into().expect("16..24")),
+            constant_marker: u64::from_le_bytes(bytes[24..32].try_into().expect("24..32")),
+            body_size,
+        })
+    }
+}
+
+/// Decrypt an SCPT body using the verified XOR keystream.
+///
+/// `ciphertext` is the bytes following the 37-byte header. Output has the
+/// same length.
+#[allow(dead_code)]
+pub fn decrypt_body(ciphertext: &[u8]) -> Vec<u8> {
+    ciphertext
+        .iter()
+        .enumerate()
+        .map(|(i, &b)| {
+            let key = CIPHER_START.wrapping_add(CIPHER_STEP.wrapping_mul(i as u8));
+            b ^ key
+        })
+        .collect()
+}
+
+/// Parse the header and decrypt the body in one call.
+///
+/// Returns an error if the body size in the header does not match
+/// `file_bytes.len() - 37`.
+#[allow(dead_code)]
+pub fn parse_and_decrypt(file_bytes: &[u8]) -> Result<(ScptHeader, Vec<u8>)> {
+    let header = ScptHeader::parse(file_bytes)?;
+    let body = &file_bytes[SCPT_HEADER_SIZE..];
+    if body.len() != header.body_size as usize {
+        bail!(
+            "body size mismatch: header says {}, file has {}",
+            header.body_size,
+            body.len()
+        );
+    }
+    Ok((header, decrypt_body(body)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_scpt(numeric_id: u64, body: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(SCPT_HEADER_SIZE + body.len());
+        buf.extend_from_slice(&SCPT_MAGIC);
+        buf.extend_from_slice(&0x0006_0005u32.to_le_bytes());
+        buf.extend_from_slice(&1u64.to_le_bytes());
+        buf.extend_from_slice(&numeric_id.to_le_bytes());
+        buf.extend_from_slice(&0x0000_0000_0000_0201u64.to_le_bytes());
+        buf.push(0x00);
+        let size_bytes = (body.len() as u32).to_le_bytes();
+        buf.extend_from_slice(&size_bytes[..3]);
+        buf.push(0x00);
+        // Encrypt the body so decrypt round-trips correctly
+        for (i, &b) in body.iter().enumerate() {
+            let key = CIPHER_START.wrapping_add(CIPHER_STEP.wrapping_mul(i as u8));
+            buf.push(b ^ key);
+        }
+        buf
+    }
+
+    #[test]
+    fn parses_header_fields() {
+        let bytes = build_scpt(0xDEAD_BEEF_CAFE_BABE, b"hello");
+        let header = ScptHeader::parse(&bytes).expect("parse");
+        assert_eq!(header.numeric_id, 0xDEAD_BEEF_CAFE_BABE);
+        assert_eq!(header.section_count, 1);
+        assert_eq!(header.constant_marker, 0x0000_0000_0000_0201);
+        assert_eq!(header.body_size, 5);
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut bytes = build_scpt(0, b"x");
+        bytes[0] = b'X';
+        let err = ScptHeader::parse(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("invalid SCPT magic"));
+    }
+
+    #[test]
+    fn rejects_truncated_header() {
+        let bytes = b"SCPT\x06\x00\x05\x00";
+        let err = ScptHeader::parse(bytes).unwrap_err();
+        assert!(format!("{err}").contains("truncated"));
+    }
+
+    #[test]
+    fn decrypt_round_trips_for_first_bytes() {
+        // Verify against the hand-computed keystream for i=0..3.
+        // i=0: key = 0x43
+        // i=1: key = 0x43 + 11 = 0x4E
+        // i=2: key = 0x43 + 22 = 0x59
+        // i=3: key = 0x43 + 33 = 0x64
+        let plain = [0xAA, 0xBB, 0xCC, 0xDD];
+        let cipher: Vec<u8> = plain
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| {
+                let key = CIPHER_START.wrapping_add(CIPHER_STEP.wrapping_mul(i as u8));
+                b ^ key
+            })
+            .collect();
+        assert_eq!(
+            cipher,
+            vec![0xAA ^ 0x43, 0xBB ^ 0x4E, 0xCC ^ 0x59, 0xDD ^ 0x64]
+        );
+        let recovered = decrypt_body(&cipher);
+        assert_eq!(recovered, plain);
+    }
+
+    #[test]
+    fn parse_and_decrypt_returns_plaintext_body() {
+        let plain = b"hello world!";
+        let bytes = build_scpt(42, plain);
+        let (header, body) = parse_and_decrypt(&bytes).expect("parse_and_decrypt");
+        assert_eq!(header.numeric_id, 42);
+        assert_eq!(body, plain);
+    }
+
+    #[test]
+    fn body_size_mismatch_errors() {
+        let mut bytes = build_scpt(0, b"abcd");
+        // Lie about the body size in the header
+        bytes[0x21] = 99;
+        let err = parse_and_decrypt(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("body size mismatch"));
+    }
+
+    #[test]
+    fn decrypt_empty_body_is_empty() {
+        assert!(decrypt_body(&[]).is_empty());
+    }
+
+    #[test]
+    fn keystream_wraps_at_256_bytes() {
+        // i=23 -> 0x43 + 23*11 = 0x43 + 0xFD = 0x140 -> u8 wraps to 0x40
+        let key_23 = CIPHER_START.wrapping_add(CIPHER_STEP.wrapping_mul(23));
+        assert_eq!(key_23, 0x40);
+        // i=255 -> further wrapping must not panic
+        let _ = CIPHER_START.wrapping_add(CIPHER_STEP.wrapping_mul(255));
+    }
+}


### PR DESCRIPTION
## Summary
- New `kessel::scpt` module with `ScptHeader::parse`, `decrypt_body`, `parse_and_decrypt`.
- Constant-key XOR keystream `(0x43 + 11*i) % 256` verified by sub-agent B across all 1,196 SCPT entries (legion reflection `019e4d62`).
- `kessel-discovery/src/bin/decrypt_scpt.rs` refactored into a thin CLI wrapper around the new library function -- no logic duplication.
- Utility-only this PR. SCPT bodies are native x86-64 UI/SFX code; no spice consumer wired. Library function is now available for follow-on UI-string scans.

## Stack

Stacked on #145 (#119 workspace refactor). No earlier-PR dependencies.

## Test plan
- [x] `cargo test -p kessel --lib` -- 122 tests pass (8 new in `scpt::tests`)
- [x] `cargo build -p kessel-discovery --bin decrypt_scpt` succeeds
- [x] `cargo clippy -p kessel --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p kessel` clean
- [x] legion-simplify gate: clean