### PR TITLE
feat(appearance): .epp UTF-16 XML parser (closes #128)

### DIFF
--- a/kessel/src/lib.rs
+++ b/kessel/src/lib.rs
@@ -15,3 +15,4 @@ pub mod quest;
 pub mod schema;
 pub mod stb;
 pub mod xml_parser;
+pub mod xml_utf16;

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -19,6 +19,7 @@ mod quest;
 mod schema;
 mod stb;
 mod unknowns;
+mod xml_utf16;
 
 #[derive(Parser, Debug)]
 #[command(name = "kessel")]

--- a/kessel/src/schema/appearance.rs
+++ b/kessel/src/schema/appearance.rs
@@ -1,0 +1,285 @@
+//! `.epp` Appearance Prototype parser.
+//!
+//! Files at `/resources/gamedata/epp/<numeric_id>.epp` are UTF-16-LE BOM
+//! XML documents declaring per-object visual appearance data: FX bindings,
+//! material slots, bone references, etc. 20,515 entries in v7.x archives
+//! per sub-agent E (legion `019e4d74`).
+//!
+//! This parser handles the BOM via `kessel::xml_utf16::decode_xml_bom` and
+//! uses `quick-xml`'s event reader to avoid allocating a full DOM. Unknown
+//! elements and attributes are ignored so future game patches add fields
+//! without breaking extraction.
+
+use crate::hash::HashDictionary;
+use crate::myp::Archive;
+use crate::xml_utf16::decode_xml_bom;
+use anyhow::{anyhow, bail, Context, Result};
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use serde::Serialize;
+use std::collections::HashSet;
+
+/// One parsed `.epp` appearance prototype.
+#[derive(Debug, Clone, Serialize, Default)]
+#[allow(dead_code)]
+pub struct Appearance {
+    pub fqn: String,
+    pub guid: String,
+    pub asset_version: u32,
+    pub creation_time_stamp: String,
+    pub fx_actions: Vec<FxAction>,
+}
+
+/// One `<AppearanceAction>` child describing an FX trigger.
+#[derive(Debug, Clone, Serialize, Default)]
+#[allow(dead_code)]
+pub struct FxAction {
+    pub kind: String,
+    pub fx_spec_string: Option<String>,
+    pub caster_target_type: Option<String>,
+    pub target_bone: Option<String>,
+    pub is_looping: Option<bool>,
+    pub fx_priority: Option<String>,
+    pub fx_channel: Option<String>,
+}
+
+/// Parse an `.epp` file's bytes into an `Appearance` record.
+#[allow(dead_code)]
+pub fn parse(bytes: &[u8]) -> Result<Appearance> {
+    let xml = decode_xml_bom(bytes).context("epp BOM decode")?;
+    let mut reader = Reader::from_str(&xml);
+    reader.trim_text(true);
+
+    let mut appearance = Appearance::default();
+    let mut buf = Vec::new();
+    let mut current_fx: Option<FxAction> = None;
+    let mut saw_root = false;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
+                let name_owned = e.name().as_ref().to_vec();
+                let name = std::str::from_utf8(&name_owned).unwrap_or("");
+                match name {
+                    "Appearance" => {
+                        saw_root = true;
+                        for attr in e.attributes().with_checks(false).flatten() {
+                            let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
+                            let val = attr.unescape_value().unwrap_or_default().to_string();
+                            match key {
+                                "fqn" => appearance.fqn = val,
+                                "GUID" => appearance.guid = normalize_guid(&val),
+                                "assetVersion" => {
+                                    appearance.asset_version = val.parse().unwrap_or(0)
+                                }
+                                "CreationTimeStamp" => appearance.creation_time_stamp = val,
+                                _ => {}
+                            }
+                        }
+                    }
+                    "AppearanceAction" => {
+                        let mut action = FxAction::default();
+                        for attr in e.attributes().with_checks(false).flatten() {
+                            if attr.key.as_ref() == b"type" {
+                                action.kind = attr.unescape_value().unwrap_or_default().to_string();
+                            }
+                        }
+                        current_fx = Some(action);
+                    }
+                    other => {
+                        if let Some(action) = current_fx.as_mut() {
+                            let value = collect_text_attr(&e, &mut reader)?;
+                            assign_fx_field(action, other, &value);
+                        }
+                    }
+                }
+            }
+            Ok(Event::End(e)) if e.name().as_ref() == b"AppearanceAction" => {
+                if let Some(action) = current_fx.take() {
+                    appearance.fx_actions.push(action);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(err) => return Err(anyhow!("epp xml parse: {err}")),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    if !saw_root {
+        bail!("missing <Appearance> root element");
+    }
+    if appearance.fqn.is_empty() {
+        bail!("missing fqn attribute on <Appearance>");
+    }
+    Ok(appearance)
+}
+
+/// Walk every `.epp` entry in the archive and parse each.
+///
+/// Per-file errors are silently skipped -- the goal is "all parseable
+/// appearances" for downstream extractors. Callers that want failure
+/// detail should call `parse` directly on the bytes.
+#[allow(dead_code)]
+pub fn walk_archive_appearances(
+    archive: &mut Archive,
+    hash_dict: &HashDictionary,
+) -> Result<Vec<Appearance>> {
+    let epp_hashes: HashSet<u64> = hash_dict
+        .paths_matching("/resources/gamedata/epp/")
+        .into_iter()
+        .filter(|(_, path)| path.ends_with(".epp"))
+        .map(|(h, _)| h)
+        .collect();
+    let entries: Vec<_> = archive.entries()?.cloned().collect();
+
+    let mut out = Vec::with_capacity(epp_hashes.len());
+    for entry in entries {
+        if !epp_hashes.contains(&entry.filename_hash) {
+            continue;
+        }
+        let bytes = match archive.read_entry(&entry) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if let Ok(rec) = parse(&bytes) {
+            out.push(rec);
+        }
+    }
+    Ok(out)
+}
+
+fn normalize_guid(raw: &str) -> String {
+    let stripped: String = raw.chars().filter(|c| !c.is_whitespace()).collect();
+    let no_prefix = stripped.strip_prefix("0x").unwrap_or(&stripped);
+    no_prefix.to_uppercase()
+}
+
+fn collect_text_attr<R: std::io::BufRead>(
+    e: &quick_xml::events::BytesStart<'_>,
+    reader: &mut Reader<R>,
+) -> Result<String> {
+    for attr in e.attributes().with_checks(false).flatten() {
+        if attr.key.as_ref() == b"value" {
+            return Ok(attr.unescape_value().unwrap_or_default().to_string());
+        }
+    }
+    let mut inner_buf = Vec::new();
+    let mut text = String::new();
+    loop {
+        match reader.read_event_into(&mut inner_buf) {
+            Ok(Event::Text(t)) => {
+                text.push_str(&t.unescape().unwrap_or_default());
+            }
+            Ok(Event::End(end)) if end.name() == e.name() => break,
+            Ok(Event::Eof) => break,
+            Err(err) => return Err(anyhow!("epp inner text: {err}")),
+            _ => {}
+        }
+        inner_buf.clear();
+    }
+    Ok(text)
+}
+
+fn assign_fx_field(action: &mut FxAction, name: &str, value: &str) {
+    let v = value.to_string();
+    match name {
+        "FxSpecString" => action.fx_spec_string = Some(v),
+        "CasterTargetType" => action.caster_target_type = Some(v),
+        "TargetBone" => action.target_bone = Some(v),
+        "IsLooping" => action.is_looping = Some(matches!(v.as_str(), "true" | "1" | "True")),
+        "FxPriority" => action.fx_priority = Some(v),
+        "FxChannel" => action.fx_channel = Some(v),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_epp(xml: &str) -> Vec<u8> {
+        let mut out = vec![0xFF, 0xFE];
+        for c in xml.encode_utf16() {
+            out.extend_from_slice(&c.to_le_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn parses_minimal_appearance() {
+        let xml = r#"<?xml version="1.0" encoding="utf-16"?>
+<Appearance fqn="epp.test.foo" GUID="0xDEADBEEFCAFEBABE" assetVersion="3" CreationTimeStamp="2026-01-01"/>"#;
+        let bytes = build_epp(xml);
+        let app = parse(&bytes).expect("parse");
+        assert_eq!(app.fqn, "epp.test.foo");
+        assert_eq!(app.guid, "DEADBEEFCAFEBABE");
+        assert_eq!(app.asset_version, 3);
+        assert_eq!(app.creation_time_stamp, "2026-01-01");
+        assert!(app.fx_actions.is_empty());
+    }
+
+    #[test]
+    fn parses_appearance_with_fx_actions() {
+        let xml = r#"<?xml version="1.0" encoding="utf-16"?>
+<Appearance fqn="epp.test.bar" GUID="01" assetVersion="1" CreationTimeStamp="now">
+  <AppearanceAction type="PlayFXAppFunctionType">
+    <FxSpecString value="fx.spec.example"/>
+    <CasterTargetType value="SINGLENODE"/>
+    <TargetBone value="head"/>
+    <IsLooping value="true"/>
+    <FxPriority value="HIGH"/>
+    <FxChannel value="VISUAL"/>
+  </AppearanceAction>
+</Appearance>"#;
+        let bytes = build_epp(xml);
+        let app = parse(&bytes).expect("parse");
+        assert_eq!(app.fx_actions.len(), 1);
+        let fx = &app.fx_actions[0];
+        assert_eq!(fx.kind, "PlayFXAppFunctionType");
+        assert_eq!(fx.fx_spec_string.as_deref(), Some("fx.spec.example"));
+        assert_eq!(fx.caster_target_type.as_deref(), Some("SINGLENODE"));
+        assert_eq!(fx.target_bone.as_deref(), Some("head"));
+        assert_eq!(fx.is_looping, Some(true));
+        assert_eq!(fx.fx_priority.as_deref(), Some("HIGH"));
+        assert_eq!(fx.fx_channel.as_deref(), Some("VISUAL"));
+    }
+
+    #[test]
+    fn ignores_unknown_attributes_and_elements() {
+        let xml = r#"<?xml version="1.0" encoding="utf-16"?>
+<Appearance fqn="epp.unknown" GUID="00" assetVersion="1" CreationTimeStamp="0" unknown_attr="x">
+  <UnknownChild ignore="me"/>
+  <AppearanceAction type="PlayFXAppFunctionType">
+    <UnknownField value="z"/>
+  </AppearanceAction>
+</Appearance>"#;
+        let bytes = build_epp(xml);
+        let app = parse(&bytes).expect("parse");
+        assert_eq!(app.fx_actions.len(), 1);
+        assert_eq!(app.fx_actions[0].kind, "PlayFXAppFunctionType");
+    }
+
+    #[test]
+    fn rejects_missing_root() {
+        let xml = r#"<NotAppearance/>"#;
+        let bytes = build_epp(xml);
+        let err = parse(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("missing <Appearance>"));
+    }
+
+    #[test]
+    fn rejects_missing_fqn() {
+        let xml = r#"<Appearance GUID="00" assetVersion="1" CreationTimeStamp="0"/>"#;
+        let bytes = build_epp(xml);
+        let err = parse(&bytes).unwrap_err();
+        assert!(format!("{err}").contains("missing fqn"));
+    }
+
+    #[test]
+    fn normalizes_guid_to_uppercase_no_prefix() {
+        assert_eq!(normalize_guid("0xdeadbeef"), "DEADBEEF");
+        assert_eq!(normalize_guid(" 01ab "), "01AB");
+        assert_eq!(normalize_guid("ABCDEF"), "ABCDEF");
+    }
+}

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -1,5 +1,6 @@
 //! Schema definitions for SWTOR game objects
 
+pub mod appearance;
 pub mod gsf_ability;
 pub mod gsf_talent;
 pub mod item;

--- a/kessel/src/xml_utf16.rs
+++ b/kessel/src/xml_utf16.rs
@@ -1,0 +1,160 @@
+//! Shared UTF-16-LE BOM-detecting XML loader.
+//!
+//! Eight SWTOR archive file extensions use UTF-16-LE BOM-prefixed XML
+//! (`FF FE 3C 00 ...`): `.epp`, `.svy`, `.tbl`, `.fxspec`, `.emt`, `.fxa`,
+//! `.fxe`, plus UTF-8 XML siblings (`.mat`, `.tex`, `.xml`, `.rul`, etc).
+//!
+//! This module provides one BOM-detecting reader so each per-extension parser
+//! doesn't reimplement UTF-16-to-UTF-8 transcoding plus quick_xml plumbing.
+//!
+//! BOM detection:
+//!   - `FF FE`     -> UTF-16-LE
+//!   - `FE FF`     -> UTF-16-BE
+//!   - `EF BB BF`  -> UTF-8 (BOM stripped)
+//!   - none        -> UTF-8 (assumed)
+
+use anyhow::{bail, Result};
+
+/// Detect a UTF-16 or UTF-8 BOM at the start of `bytes` and return an owned
+/// UTF-8 String of the XML content. Strips BOM. Trims trailing nulls.
+#[allow(dead_code)]
+pub fn decode_xml_bom(bytes: &[u8]) -> Result<String> {
+    if bytes.len() < 2 {
+        bail!("input too short for BOM detection ({} bytes)", bytes.len());
+    }
+
+    let (kind, payload) = match (bytes[0], bytes[1]) {
+        (0xFF, 0xFE) => (Encoding::Utf16Le, &bytes[2..]),
+        (0xFE, 0xFF) => (Encoding::Utf16Be, &bytes[2..]),
+        (0xEF, 0xBB) if bytes.len() >= 3 && bytes[2] == 0xBF => (Encoding::Utf8, &bytes[3..]),
+        _ => (Encoding::Utf8, bytes),
+    };
+
+    let text = match kind {
+        Encoding::Utf8 => std::str::from_utf8(payload)
+            .map_err(|e| anyhow::anyhow!("invalid UTF-8: {e}"))?
+            .to_string(),
+        Encoding::Utf16Le => decode_utf16(payload, true)?,
+        Encoding::Utf16Be => decode_utf16(payload, false)?,
+    };
+
+    Ok(text.trim_end_matches('\u{0}').to_string())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Encoding {
+    Utf8,
+    Utf16Le,
+    Utf16Be,
+}
+
+fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String> {
+    if !bytes.len().is_multiple_of(2) {
+        bail!("UTF-16 input has odd byte length: {}", bytes.len());
+    }
+
+    let u16_iter = bytes.chunks_exact(2).map(|chunk| {
+        let pair = [chunk[0], chunk[1]];
+        if little_endian {
+            u16::from_le_bytes(pair)
+        } else {
+            u16::from_be_bytes(pair)
+        }
+    });
+
+    let units: Vec<u16> = u16_iter.collect();
+    char::decode_utf16(units)
+        .collect::<std::result::Result<String, _>>()
+        .map_err(|e| anyhow::anyhow!("invalid UTF-16 surrogate pair: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_utf16_le(text: &str) -> Vec<u8> {
+        let mut out = vec![0xFF, 0xFE];
+        for ch in text.chars() {
+            let mut buf = [0u16; 2];
+            let slice = ch.encode_utf16(&mut buf);
+            for unit in slice {
+                out.extend_from_slice(&unit.to_le_bytes());
+            }
+        }
+        out
+    }
+
+    fn encode_utf16_be(text: &str) -> Vec<u8> {
+        let mut out = vec![0xFE, 0xFF];
+        for ch in text.chars() {
+            let mut buf = [0u16; 2];
+            let slice = ch.encode_utf16(&mut buf);
+            for unit in slice {
+                out.extend_from_slice(&unit.to_be_bytes());
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn decodes_utf16_le_xml() {
+        let bytes = encode_utf16_le("<Hello/>");
+        let s = decode_xml_bom(&bytes).expect("decode");
+        assert_eq!(s, "<Hello/>");
+    }
+
+    #[test]
+    fn decodes_utf16_be_xml() {
+        let bytes = encode_utf16_be("<World/>");
+        let s = decode_xml_bom(&bytes).expect("decode");
+        assert_eq!(s, "<World/>");
+    }
+
+    #[test]
+    fn decodes_utf8_with_bom() {
+        let mut bytes = vec![0xEF, 0xBB, 0xBF];
+        bytes.extend_from_slice(b"<Hello/>");
+        assert_eq!(decode_xml_bom(&bytes).expect("decode"), "<Hello/>");
+    }
+
+    #[test]
+    fn decodes_utf8_without_bom() {
+        let bytes = b"<Hello/>";
+        assert_eq!(decode_xml_bom(bytes).expect("decode"), "<Hello/>");
+    }
+
+    #[test]
+    fn rejects_too_short_input() {
+        assert!(decode_xml_bom(b"").is_err());
+        assert!(decode_xml_bom(b"X").is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_utf16_surrogate() {
+        // BOM + an unpaired high surrogate
+        let bytes = [0xFF, 0xFE, 0x00, 0xD8];
+        assert!(decode_xml_bom(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_odd_length_utf16() {
+        let bytes = [0xFF, 0xFE, 0x3C, 0x00, 0x00]; // BOM + 2 valid + 1 stray
+        assert!(decode_xml_bom(&bytes).is_err());
+    }
+
+    #[test]
+    fn trims_trailing_nulls() {
+        let mut bytes = encode_utf16_le("<Hello/>");
+        bytes.extend_from_slice(&[0x00, 0x00]); // extra null pair at end
+        let s = decode_xml_bom(&bytes).expect("decode");
+        assert!(!s.ends_with('\u{0}'), "trailing null not stripped: {s:?}");
+    }
+
+    #[test]
+    fn handles_unicode_codepoints() {
+        // Multi-byte UTF-16: U+1F600 (Grinning Face emoji) becomes a surrogate pair
+        let bytes = encode_utf16_le("<Hi>\u{1F600}</Hi>");
+        let s = decode_xml_bom(&bytes).expect("decode");
+        assert_eq!(s, "<Hi>\u{1F600}</Hi>");
+    }
+}


### PR DESCRIPTION
## Summary
- New `kessel::schema::appearance` module parses `.epp` UTF-16 XML files at `/resources/gamedata/epp/<id>.epp`.
- 20,515 entries per sub-agent E catalog (legion `019e4d74`).
- Surface: `Appearance` + `FxAction` structs, `parse(bytes)` for single file, `walk_archive_appearances(archive, hash_dict)` for batch.
- Forward-compatible: unknown elements/attributes are ignored.

## Implementation notes
- Uses `kessel::xml_utf16::decode_xml_bom` (from #123) for BOM handling.
- `quick-xml` event reader -- no full DOM allocation.
- Per-file errors in walker are silently skipped (goal: "all parseable appearances").

## Stack

Stacked on #149 (#123 xml_utf16). Merge order: #145 -> #149 -> this PR.

## Test plan
- [x] `cargo test -p kessel --lib` -- 129 tests pass (6 new in `schema::appearance::tests`)
- [x] `cargo clippy -p kessel --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p kessel` clean
- [x] legion-simplify gate: clean