### PR TITLE
feat(singletons): PBUK singleton extraction pipeline (closes #171)

### DIFF
--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -14,6 +14,26 @@ use crate::stb::StbEntry;
 /// Quest class type_hi32 from client.gom (decoded by Agent D, legion 019e4d75).
 const QUEST_CLASS_TYPE_HI32: u32 = 0x2ADE_C3D2;
 
+/// Count non-overlapping occurrences of a byte pattern in a payload.
+/// Used by singleton extraction to record cheap shape hints (CF E0 marker
+/// count, CF 40 marker count) without committing to a full decoder pass.
+fn count_byte_pattern(payload: &[u8], pattern: &[u8]) -> usize {
+    if pattern.is_empty() || payload.len() < pattern.len() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut i = 0;
+    while i + pattern.len() <= payload.len() {
+        if &payload[i..i + pattern.len()] == pattern {
+            count += 1;
+            i += pattern.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
+}
+
 /// Per-kind row counts inserted by `populate_conversation_refs`.
 #[derive(Default, Debug)]
 pub struct ConversationRefCounts {
@@ -1035,6 +1055,23 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_talent_effects_stat ON talent_effects(stat);
 
+            -- PBUK singleton prototypes (#171): one row per zero-dot PBUK
+            -- object. These are master tables / config blobs the game references
+            -- by FQN (tagTablePrototype, colCollectionItemsPrototype,
+            -- cnqConquestInfoPrototype, etc -- ~370 in current corpus).
+            -- Foundation for per-singleton decoders (#172 + future).
+            CREATE TABLE IF NOT EXISTS singletons (
+                fqn            TEXT PRIMARY KEY,
+                payload_size   INTEGER NOT NULL,
+                payload_b64    TEXT NOT NULL,
+                string_count   INTEGER NOT NULL,
+                cf_e0_count    INTEGER NOT NULL,
+                cf_40_count    INTEGER NOT NULL,
+                header_hex     TEXT NOT NULL,
+                extracted_at   INTEGER NOT NULL DEFAULT (unixepoch())
+            );
+            CREATE INDEX IF NOT EXISTS idx_singletons_size ON singletons(payload_size DESC);
+
             -- Extraction metadata
             CREATE TABLE IF NOT EXISTS meta (
                 key TEXT PRIMARY KEY,
@@ -1141,6 +1178,43 @@ impl Database {
                 conn.execute(&sql, [])?;
             }
         }
+        Ok(())
+    }
+
+    /// Insert one PBUK singleton prototype (#171). Singletons are zero-dot
+    /// PBUK objects (master tables / config blobs) like tagTablePrototype,
+    /// colCollectionItemsPrototype, cnqConquestInfoPrototype. They sit
+    /// outside the `objects` table because their shape doesn't match the
+    /// per-instance GameObject model (no per-instance GUID semantics, no
+    /// kind label, no string_id linkage). The raw payload + a few cheap
+    /// shape hints land in `singletons` for per-singleton decoders to
+    /// consume in follow-on issues.
+    pub fn insert_singleton(&self, obj: &crate::pbuk::GomObject) -> Result<()> {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let strings = obj.extract_strings();
+        let string_count = strings.len() as i64;
+        let cf_e0_count = count_byte_pattern(&obj.payload, &[0xCF, 0xE0, 0x00]) as i64;
+        let cf_40_count = count_byte_pattern(&obj.payload, &[0xCF, 0x40, 0x00, 0x00]) as i64;
+        let payload_b64 = BASE64.encode(&obj.payload);
+        let header_hex = hex::encode(&obj.header);
+
+        // extracted_at uses the table's DEFAULT (unixepoch()) by omitting the column.
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO singletons \
+               (fqn, payload_size, payload_b64, string_count, cf_e0_count, cf_40_count, header_hex) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                obj.fqn,
+                obj.payload.len() as i64,
+                payload_b64,
+                string_count,
+                cf_e0_count,
+                cf_40_count,
+                header_hex,
+            ],
+        )?;
         Ok(())
     }
 

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -259,6 +259,12 @@ fn main() -> Result<()> {
                                     continue;
                                 };
                                 obj.fqn = fqn.clone();
+                                if is_singleton_fqn(&fqn) {
+                                    if db.insert_singleton(&obj).is_ok() {
+                                        total_objects += 1;
+                                    }
+                                    continue;
+                                }
                                 let game_obj = schema::GameObject::from_gom_with_overrides(
                                     &obj,
                                     icon_overrides.as_ref(),
@@ -294,6 +300,12 @@ fn main() -> Result<()> {
                                 continue;
                             };
                             obj.fqn = fqn.clone();
+                            if is_singleton_fqn(&fqn) {
+                                if db.insert_singleton(&obj).is_ok() {
+                                    total_objects += 1;
+                                }
+                                continue;
+                            }
                             let game_obj = schema::GameObject::from_gom_with_overrides(
                                 &obj,
                                 icon_overrides.as_ref(),
@@ -950,6 +962,14 @@ fn should_extract_object(fqn: &str, unfiltered: bool) -> bool {
     true
 }
 
+/// True for FQNs that are PBUK singleton prototypes (zero-dot PascalCase /
+/// camelCase identifiers like `tagTablePrototype`, `colCollectionItemsPrototype`).
+/// These bypass `should_extract_object`'s prefix whitelist and route to the
+/// `singletons` table instead of `objects`.
+fn is_singleton_fqn(fqn: &str) -> bool {
+    !fqn.is_empty() && !fqn.contains('.') && !fqn.contains('/')
+}
+
 fn process_pbuk(
     data: &[u8],
     db: &db::Database,
@@ -965,6 +985,16 @@ fn process_pbuk(
             continue;
         };
         obj.fqn = fqn.clone();
+
+        // Singletons (zero-dot PBUK objects) route to their own table.
+        // Per kessel issue #171: they're master tables / config blobs whose
+        // shape doesn't match the per-instance GameObject model.
+        if is_singleton_fqn(&fqn) {
+            db.insert_singleton(&obj)?;
+            count += 1;
+            continue;
+        }
+
         let game_obj = schema::GameObject::from_gom_with_overrides(&obj, overrides);
         if !accept_variant(versioned_seen, &fqn, &game_obj) {
             continue;
@@ -1049,6 +1079,23 @@ mod tests {
         // The /N/M suffix gate is unchanged; versioned FQNs still get
         // normalized at a different layer.
         assert!(!should_extract_object("abl.foo.bar/7/0", false));
+    }
+
+    #[test]
+    fn is_singleton_fqn_classifies_correctly() {
+        // Per kessel issue #171: zero-dot, non-slash, non-empty FQNs are
+        // singleton prototypes (master tables / config blobs).
+        assert!(is_singleton_fqn("tagTablePrototype"));
+        assert!(is_singleton_fqn("colCollectionItemsPrototype"));
+        assert!(is_singleton_fqn("Suburb"));
+        assert!(is_singleton_fqn("cnqConquestInfoPrototype"));
+        // Per-instance objects (dotted) are NOT singletons.
+        assert!(!is_singleton_fqn("abl.sith_warrior.ravage"));
+        assert!(!is_singleton_fqn("dis.powertech.firebug"));
+        // Versioned variants are filtered before this check fires, but
+        // defensively the slash-containing case is rejected.
+        assert!(!is_singleton_fqn("abl.foo.bar/7/0"));
+        assert!(!is_singleton_fqn(""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #171. Generic extractor for zero-dot PBUK objects into a new `singletons` table. Foundation for per-singleton decoders — `scFFComponentUpgradesCostPrototype` (closes #115 underlying need) lands in singletons; per-singleton decode is #172.

## Schema

New table `singletons`:
```sql
fqn            TEXT PRIMARY KEY,
payload_size   INTEGER NOT NULL,
payload_b64    TEXT NOT NULL,
string_count   INTEGER NOT NULL,
cf_e0_count    INTEGER NOT NULL,
cf_40_count    INTEGER NOT NULL,
header_hex     TEXT NOT NULL,
extracted_at   INTEGER NOT NULL DEFAULT (unixepoch())
```

Cheap shape hints (CF E0 / CF 40 marker counts via new `count_byte_pattern` helper) let future per-singleton decoders pick targets without re-parsing payloads.

## Routing

New `is_singleton_fqn` predicate in main.rs (zero-dot, non-slash, non-empty FQN). Applied at all 3 PBUK extraction sites:
- `process_pbuk` (main PBUK fast path)
- Bucket-DBLB inline path (~line 256)
- Loose-DBLB inline path (~line 297)

Zero-dot objects route to `singletons`; dotted objects continue through the existing GameObject pipeline unchanged.

## Verification (live ~/swtor/Assets extraction)

- **366 singletons** (within ~1% of `catalog_singletons` survey of ~370)
- `tagTablePrototype`: 449,917 bytes ✓
- `colCollectionItemsPrototype`: 2,290,795 bytes ✓
- `cnqConquestInfoPrototype`: 141,169 bytes ✓
- Existing `objects` table count unchanged (no per-instance regressions)

## Tests

- `is_singleton_fqn` classifies tagTablePrototype, colCollection*, dotted FQNs, versioned FQNs, and empty strings correctly
- Full lib + bin suite passes (199 lib + 189 bin)

## Test plan

- [x] `cargo test -p kessel`: 199 lib + 189 bin pass
- [x] `cargo clippy -p kessel -- -D warnings` passes
- [x] `cargo fmt -p kessel --check` passes
- [x] /legion-simplify: clean
- [x] Live extraction: 366 singletons, all 3 spot-checks match expected sizes

## Doctrine

PR #4 of the 16-issue sequence. Strictly serial — opened only after #186 merged. #172 (gsf_requisition_costs, closes #115) opens only after this merges.

Generated with Claude Code