### PR TITLE
feat(gsf_costs): GSF requisition cost decoder (closes #172, closes #115)

### DIFF
--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -1055,6 +1055,25 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_talent_effects_stat ON talent_effects(stat);
 
+            -- GSF requisition costs (#115 / #172). Decoded from the
+            -- scFFComponentsCostPrototype + scFFComponentUpgradesCostPrototype
+            -- singletons. (target_guid, cost_kind, tier) is the natural key;
+            -- a single component appears once with cost_kind = 'component_unlock'
+            -- and tier = 0, then five times with cost_kind = 'tier_upgrade' and
+            -- tier = 1..5. target_game_id resolves the GUID into kessel's
+            -- objects table (NULL when the component's content GUID isn't in
+            -- the extracted set).
+            CREATE TABLE IF NOT EXISTS gsf_requisition_costs (
+                target_guid       TEXT NOT NULL,
+                cost_kind         TEXT NOT NULL CHECK (cost_kind IN ('component_unlock', 'tier_upgrade')),
+                tier              INTEGER NOT NULL,
+                cost              INTEGER NOT NULL,
+                target_game_id    TEXT,
+                target_fqn        TEXT,
+                PRIMARY KEY (target_guid, cost_kind, tier)
+            );
+            CREATE INDEX IF NOT EXISTS idx_gsf_req_costs_target ON gsf_requisition_costs(target_game_id);
+
             -- PBUK singleton prototypes (#171): one row per zero-dot PBUK
             -- object. These are master tables / config blobs the game references
             -- by FQN (tagTablePrototype, colCollectionItemsPrototype,
@@ -4311,6 +4330,93 @@ impl Database {
         }
         tx.commit()?;
         Ok((disc_count, mod_count))
+    }
+
+    /// Populate `gsf_requisition_costs` from the GSF cost singletons
+    /// (`scFFComponentsCostPrototype` for unlock costs and
+    /// `scFFComponentUpgradesCostPrototype` for per-tier upgrade costs).
+    /// Closes #115; first per-singleton decoder on top of the #171
+    /// singleton pipeline.
+    ///
+    /// Returns (component_unlock_rows, tier_upgrade_rows).
+    pub fn populate_gsf_requisition_costs(&self) -> Result<(u64, u64)> {
+        use crate::schema::gsf_costs::{decode_component_upgrades_cost, decode_components_cost};
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        // Load the two singleton payloads from the singletons table.
+        let payloads: std::collections::HashMap<String, Vec<u8>> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT fqn, payload_b64 FROM singletons \
+                 WHERE fqn IN ('scFFComponentsCostPrototype', 'scFFComponentUpgradesCostPrototype')",
+            )?;
+            let rows: std::collections::HashMap<String, Vec<u8>> = stmt
+                .query_map([], |row| {
+                    let fqn: String = row.get(0)?;
+                    let b64: String = row.get(1)?;
+                    Ok((fqn, b64))
+                })?
+                .filter_map(|r| r.ok())
+                .filter_map(|(fqn, b64)| BASE64.decode(&b64).ok().map(|b| (fqn, b)))
+                .collect();
+            rows
+        };
+
+        // Resolve target GUIDs to game_ids + fqns up front (avoid per-row SQL
+        // in the hot loop).
+        let guid_to_object: std::collections::HashMap<String, (String, String)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt =
+                conn.prepare("SELECT guid, game_id, fqn FROM objects WHERE guid IS NOT NULL")?;
+            let rows: std::collections::HashMap<String, (String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        (row.get::<_, String>(1)?, row.get::<_, String>(2)?),
+                    ))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        let mut component_rows = 0u64;
+        let mut tier_rows = 0u64;
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        {
+            let mut insert = tx.prepare_cached(
+                "INSERT OR REPLACE INTO gsf_requisition_costs \
+                   (target_guid, cost_kind, tier, cost, target_game_id, target_fqn) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )?;
+            let mut insert_costs =
+                |costs: Vec<crate::schema::gsf_costs::GsfCost>, counter: &mut u64| -> Result<()> {
+                    for cost in costs {
+                        let resolved = guid_to_object.get(&cost.target_guid);
+                        insert.execute(params![
+                            cost.target_guid,
+                            cost.kind.as_sql(),
+                            cost.tier,
+                            cost.cost,
+                            resolved.map(|(gid, _)| gid.as_str()),
+                            resolved.map(|(_, fqn)| fqn.as_str()),
+                        ])?;
+                        *counter += 1;
+                    }
+                    Ok(())
+                };
+
+            if let Some(payload) = payloads.get("scFFComponentsCostPrototype") {
+                insert_costs(decode_components_cost(payload)?, &mut component_rows)?;
+            }
+            if let Some(payload) = payloads.get("scFFComponentUpgradesCostPrototype") {
+                insert_costs(decode_component_upgrades_cost(payload)?, &mut tier_rows)?;
+            }
+        }
+        tx.commit()?;
+        Ok((component_rows, tier_rows))
     }
 
     /// Populate `discipline_talents` by FQN pattern.

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -607,6 +607,11 @@ fn main() -> Result<()> {
     // docs/probes/dis-payload-format.md.
     let (dis_disc_count, dis_mod_count) = db.populate_disciplines_from_dis()?;
 
+    // Twelfth-and-three-quarters pass: GSF requisition costs from the two
+    // sc...Cost singletons (issue #172, closes #115). First per-singleton
+    // decoder on top of the #171 singleton pipeline.
+    let (gsf_component_costs, gsf_tier_costs) = db.populate_gsf_requisition_costs()?;
+
     // Thirteenth pass: derive discipline→talent + class_utility_talents.
     // Per-origin utility talents fan to both combat styles; combat-discipline
     // talents stay scoped to their own discipline (no fan-out).
@@ -638,6 +643,10 @@ fn main() -> Result<()> {
     println!(
         "    Disciplines (dis.*): {} enriched, {} mods",
         dis_disc_count, dis_mod_count
+    );
+    println!(
+        "    GSF requisition costs: {} components + {} tier upgrades",
+        gsf_component_costs, gsf_tier_costs
     );
     println!(
         "    Combat-style shared: {} abilities, {} utility talents",

--- a/kessel/src/schema/gsf_costs.rs
+++ b/kessel/src/schema/gsf_costs.rs
@@ -1,0 +1,231 @@
+//! Decoders for the two GSF requisition-cost singleton prototypes
+//! (`scFFComponentsCostPrototype`, `scFFComponentUpgradesCostPrototype`).
+//!
+//! Both payloads are arrays of records keyed by component content_guid.
+//! Components carry one unlock-cost per component; Upgrades carry five
+//! tier-cost values per component (standard GSF progression
+//! 500 / 1250 / 2500 / 5000 / 7500 requisition).
+//!
+//! Wire format (verified against firebug-era live extraction 2026-05-24):
+//!
+//!   `scFFComponentsCostPrototype`:
+//!     <CF E0 00 + 8-byte content GUID>
+//!     04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01
+//!     02 C9 <cost u16 BE>
+//!     CB 01 BF 63 42 02 C0 01
+//!
+//!   `scFFComponentUpgradesCostPrototype`:
+//!     <CF E0 00 + 8-byte content GUID>
+//!     02 09 05 05                          (5-tier array header)
+//!     <tier_idx u8 (01..05)>
+//!     04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01
+//!     02 C9 <cost u16 BE>
+//!     CB 01 BF 63 42 02 C0 01
+//!     (... repeat 5 times for each component)
+//!
+//! Issue: #115 / #172. Singleton bytes pulled from `singletons` table per
+//! issue #171's pipeline.
+
+use anyhow::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CostKind {
+    /// Unlock cost for a GSF component (one per component_guid).
+    ComponentUnlock,
+    /// Per-tier upgrade cost for a GSF component (five tiers per component).
+    TierUpgrade,
+}
+
+impl CostKind {
+    pub fn as_sql(self) -> &'static str {
+        match self {
+            CostKind::ComponentUnlock => "component_unlock",
+            CostKind::TierUpgrade => "tier_upgrade",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GsfCost {
+    /// 16-char hex GUID of the target component / talent.
+    pub target_guid: String,
+    /// Cost in requisition.
+    pub cost: u32,
+    /// `ComponentUnlock` for the components payload; `TierUpgrade` for the
+    /// upgrades payload. Tier index 1..5 distinguishes tier rows within a
+    /// component; ComponentUnlock rows always have `tier = 0`.
+    pub tier: u8,
+    pub kind: CostKind,
+}
+
+/// Format the 8 bytes immediately after a `CF E0 00` marker as the standard
+/// 16-char uppercase hex GUID (BE order, matching the convention used by
+/// objects.guid).
+fn guid_hex(bytes: &[u8]) -> String {
+    hex::encode_upper(bytes)
+}
+
+/// Decode the components-unlock payload. One cost per `CF E0 00 <guid>`.
+pub fn decode_components_cost(payload: &[u8]) -> Result<Vec<GsfCost>> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 11 <= payload.len() {
+        if payload[i] != 0xCF || payload[i + 1] != 0xE0 || payload[i + 2] != 0x00 {
+            i += 1;
+            continue;
+        }
+        let guid_end = i + 11;
+        let target_guid = guid_hex(&payload[i + 3..guid_end]);
+        // Walk forward up to 30 bytes looking for the first `02 C9 XX YY`
+        // cost record. The record is preceded by the CF40 template + a few
+        // wrapper bytes (consistent shape per docstring).
+        let mut j = guid_end;
+        let scan_end = (guid_end + 30).min(payload.len());
+        let mut cost: Option<u32> = None;
+        while j + 4 <= scan_end {
+            if payload[j] == 0x02 && payload[j + 1] == 0xC9 {
+                cost = Some(u16::from_be_bytes([payload[j + 2], payload[j + 3]]) as u32);
+                break;
+            }
+            j += 1;
+        }
+        if let Some(c) = cost {
+            out.push(GsfCost {
+                target_guid,
+                cost: c,
+                tier: 0,
+                kind: CostKind::ComponentUnlock,
+            });
+        }
+        i = guid_end;
+    }
+    Ok(out)
+}
+
+/// Decode the upgrades payload. Five tier costs per `CF E0 00 <guid>`.
+pub fn decode_component_upgrades_cost(payload: &[u8]) -> Result<Vec<GsfCost>> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i + 11 <= payload.len() {
+        if payload[i] != 0xCF || payload[i + 1] != 0xE0 || payload[i + 2] != 0x00 {
+            i += 1;
+            continue;
+        }
+        let guid_end = i + 11;
+        let target_guid = guid_hex(&payload[i + 3..guid_end]);
+        // Walk forward through the 5-tier array, collecting `02 C9 XX YY`
+        // cost records in order. Stop at the next `CF E0` marker or after 5
+        // costs collected.
+        let mut j = guid_end;
+        let mut tier: u8 = 0;
+        while j + 4 <= payload.len() && tier < 5 {
+            // Stop at next component marker
+            if j + 3 <= payload.len()
+                && payload[j] == 0xCF
+                && payload[j + 1] == 0xE0
+                && payload[j + 2] == 0x00
+            {
+                break;
+            }
+            if payload[j] == 0x02 && payload[j + 1] == 0xC9 {
+                tier += 1;
+                let cost = u16::from_be_bytes([payload[j + 2], payload[j + 3]]) as u32;
+                out.push(GsfCost {
+                    target_guid: target_guid.clone(),
+                    cost,
+                    tier,
+                    kind: CostKind::TierUpgrade,
+                });
+                j += 4;
+                continue;
+            }
+            j += 1;
+        }
+        i = j;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real first-component slice of scFFComponentsCostPrototype (verified
+    /// against live spice extract 2026-05-24). One component, cost 1000.
+    fn components_first_record() -> Vec<u8> {
+        // CF E0 00 <8-byte GUID> + record body + cost (02 C9 03 E8 = 1000 BE)
+        // + trailer
+        let hex = "CF E0 00 00 FA F1 6B B9 AF 04 03 \
+                   CF 40 00 00 41 95 3B 9C 71 02 C0 01 01 \
+                   02 C9 03 E8 \
+                   CB 01 BF 63 42 02 C0 01";
+        hex_to_bytes(hex)
+    }
+
+    /// Real first-component slice of scFFComponentUpgradesCostPrototype.
+    /// One component with 5 tier costs (500/1250/2500/5000/7500).
+    fn upgrades_first_record() -> Vec<u8> {
+        let hex = "CF E0 00 00 FA F1 6B B9 AF 02 09 05 05 01 \
+                   04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01 \
+                   02 C9 01 F4 \
+                   CB 01 BF 63 42 02 C0 01 02 \
+                   04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01 \
+                   02 C9 04 E2 \
+                   CB 01 BF 63 42 02 C0 01 03 \
+                   04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01 \
+                   02 C9 09 C4 \
+                   CB 01 BF 63 42 02 C0 01 04 \
+                   04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01 \
+                   02 C9 13 88 \
+                   CB 01 BF 63 42 02 C0 01 05 \
+                   04 03 CF 40 00 00 41 95 3B 9C 71 02 C0 01 01 \
+                   02 C9 1D 4C \
+                   CB 01 BF 63 42 02 C0 01";
+        hex_to_bytes(hex)
+    }
+
+    fn hex_to_bytes(hex: &str) -> Vec<u8> {
+        hex.split_whitespace()
+            .map(|s| u8::from_str_radix(s, 16).expect("hex"))
+            .collect()
+    }
+
+    #[test]
+    fn decode_components_cost_first_record_is_1000_req() {
+        let bytes = components_first_record();
+        let costs = decode_components_cost(&bytes).unwrap();
+        assert_eq!(costs.len(), 1);
+        assert_eq!(costs[0].target_guid, "00FAF16BB9AF0403");
+        assert_eq!(costs[0].cost, 1000);
+        assert_eq!(costs[0].tier, 0);
+        assert_eq!(costs[0].kind, CostKind::ComponentUnlock);
+    }
+
+    #[test]
+    fn decode_component_upgrades_cost_first_record_is_5_tiers() {
+        let bytes = upgrades_first_record();
+        let costs = decode_component_upgrades_cost(&bytes).unwrap();
+        assert_eq!(costs.len(), 5);
+        let expected_costs = [500u32, 1250, 2500, 5000, 7500];
+        for (i, expected) in expected_costs.iter().enumerate() {
+            assert_eq!(costs[i].tier, (i + 1) as u8);
+            assert_eq!(costs[i].cost, *expected, "tier {} cost", i + 1);
+            assert_eq!(costs[i].kind, CostKind::TierUpgrade);
+        }
+        // All 5 tiers share the same target_guid.
+        let g0 = &costs[0].target_guid;
+        assert!(costs.iter().all(|c| &c.target_guid == g0));
+    }
+
+    #[test]
+    fn decode_handles_empty_payload() {
+        assert!(decode_components_cost(&[]).unwrap().is_empty());
+        assert!(decode_component_upgrades_cost(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn cost_kind_sql_round_trips() {
+        assert_eq!(CostKind::ComponentUnlock.as_sql(), "component_unlock");
+        assert_eq!(CostKind::TierUpgrade.as_sql(), "tier_upgrade");
+    }
+}

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -3,6 +3,7 @@
 pub mod appearance;
 pub mod discipline;
 pub mod gsf_ability;
+pub mod gsf_costs;
 pub mod gsf_talent;
 pub mod item;
 


### PR DESCRIPTION
## Summary

Closes #172 (this PR's issue) and **closes #115** (huttspawn-blocking original ask). First per-singleton decoder on top of the #171 singleton pipeline.

Reads `scFFComponentsCostPrototype` (unlock costs) and `scFFComponentUpgradesCostPrototype` (per-tier upgrade costs) from the singletons table, decodes the records, populates `gsf_requisition_costs`.

## Wire format (verified against live spice extract)

- **Components**: `<CF E0 00 + 8-byte GUID>` + record body + `02 C9 <u16 BE cost>`
- **Upgrades**: `<CF E0 00 + 8-byte GUID>` + 5-tier array of identical records, with tier index byte (01..05) preceding each tier's CF40 marker

Cost values use a `02 C9` marker + 2-byte BE value. Typical GSF progression: 500 / 1250 / 2500 / 5000 / 7500 requisition.

## Schema

New table `gsf_requisition_costs`:
```sql
target_guid    TEXT NOT NULL,
cost_kind      TEXT NOT NULL CHECK (cost_kind IN ('component_unlock', 'tier_upgrade')),
tier           INTEGER NOT NULL,    -- 0 for component_unlock, 1..5 for tier_upgrade
cost           INTEGER NOT NULL,
target_game_id TEXT,                -- resolved from objects.guid where possible
target_fqn     TEXT,
PRIMARY KEY (target_guid, cost_kind, tier)
```

## Verification (live ~/swtor/Assets extraction)

- **500 component_unlock rows** (close to expected ~506)
- **1,981 tier_upgrade rows** split as 507 / 507 / 507 / 230 / 230 across tiers 1-5
- Tier-count variance is correct — major systems (weapons, engines) have 5 tiers; minor systems (sensors, magazine) have 3. The decoder bounds at 5 tiers per component but stops early when the next `CF E0` marker is hit, so 3-tier components produce exactly 3 rows
- Cost range 500..7500 across both kinds, matching documented GSF requisition progression

## Tests

- `decode_components_cost`: 1000 requisition for first record (`E8 03 BE = 1000`)
- `decode_component_upgrades_cost`: 5 tiers at 500 / 1250 / 2500 / 5000 / 7500 (`01 F4` / `04 E2` / `09 C4` / `13 88` / `1D 4C`)
- Empty payload handling (both decoders)
- `CostKind` SQL round-trip
- Full test suite: 203 lib + 193 bin pass

## Test plan

- [x] `cargo test -p kessel` (full package): 203 lib + 193 bin + others all pass
- [x] `cargo clippy -p kessel -- -D warnings` passes
- [x] `cargo fmt -p kessel --check` passes
- [x] /legion-simplify: clean (after 2 fixes — `guid_hex` → `hex::encode_upper`; duplicate insert blocks extracted to a local closure)
- [x] Live extraction: 500 component unlocks + 1981 tier upgrades

## Downstream

Huttspawn deathsticks D1 can mirror `gsf_requisition_costs` via the existing ATTACH+INSERT pattern (same approach as `gsf_objects`, `gsf_talent_stats`). Each tree-step render on huttspawn's GSF component upgrade pages can now show the per-tier requisition cost from this table.

## Doctrine

PR #5 of the 16-issue sequence. Strictly serial — opened only after #187 merged. #173 (ability effect blocks) opens only after this merges.

Generated with Claude Code