### PR TITLE
feat(effect_block): ability/talent -> effect block linkage (closes #173)

### DIFF
--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -1091,6 +1091,31 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_singletons_size ON singletons(payload_size DESC);
 
+            -- Ability/talent -> effect block linkage (#173). One row per
+            -- indexed CF E0 sub-record in the parent's payload. The parent
+            -- self-reference is NOT included; this table is the structural
+            -- linkage to the parent's effect-block sub-records that carry
+            -- per-block typed properties (Weapon Damage, Modify Meta Stat,
+            -- Play Appearance, Call Effect).
+            --
+            -- block_game_id is NULL when the effect block's GUID doesn't
+            -- resolve to an extracted object (versioned-only ability
+            -- category, issue #179). The raw block_guid is preserved so the
+            -- unresolved edge stays visible in spice instead of being
+            -- silently dropped.
+            CREATE TABLE IF NOT EXISTS ability_effect_blocks (
+                parent_game_id    TEXT NOT NULL,
+                block_index       INTEGER NOT NULL,
+                block_guid        TEXT NOT NULL,
+                block_game_id     TEXT,
+                PRIMARY KEY (parent_game_id, block_index),
+                FOREIGN KEY (parent_game_id) REFERENCES objects(game_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_ability_effect_blocks_block
+                ON ability_effect_blocks(block_game_id);
+            CREATE INDEX IF NOT EXISTS idx_ability_effect_blocks_guid
+                ON ability_effect_blocks(block_guid);
+
             -- Extraction metadata
             CREATE TABLE IF NOT EXISTS meta (
                 key TEXT PRIMARY KEY,
@@ -4417,6 +4442,81 @@ impl Database {
         }
         tx.commit()?;
         Ok((component_rows, tier_rows))
+    }
+
+    /// Populate `ability_effect_blocks` from abl.* + tal.* payloads (#173).
+    ///
+    /// Walks every canonical ability/talent payload for indexed CF E0
+    /// effect-block references and writes one row per indexed ref. The
+    /// parent self-reference (first CF E0 marker in the payload) is
+    /// skipped by the decoder. Unresolved block GUIDs (versioned-only
+    /// ability category, #179) leave `block_game_id` NULL but keep the raw
+    /// GUID for downstream visibility.
+    ///
+    /// Returns (rows_written, unresolved_count).
+    pub fn populate_ability_effect_blocks(&self) -> Result<(u64, u64)> {
+        use crate::schema::effect_block::extract_effect_block_refs;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let conn = self.conn.lock().unwrap();
+
+        let payloads: Vec<(String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT game_id, json_extract(json, '$.payload_b64') \
+                 FROM objects \
+                 WHERE (fqn LIKE 'abl.%' OR fqn LIKE 'tal.%') AND is_canonical = 1",
+            )?;
+            let rows: Vec<(String, String)> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        let guid_to_game_id: std::collections::HashMap<String, String> = {
+            let mut stmt =
+                conn.prepare("SELECT guid, game_id FROM objects WHERE guid IS NOT NULL")?;
+            let rows: std::collections::HashMap<String, String> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        let mut insert = tx.prepare_cached(
+            "INSERT OR REPLACE INTO ability_effect_blocks \
+               (parent_game_id, block_index, block_guid, block_game_id) \
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+
+        let mut written: u64 = 0;
+        let mut unresolved: u64 = 0;
+        for (parent_game_id, payload_b64) in &payloads {
+            let Ok(payload) = BASE64.decode(payload_b64) else {
+                continue;
+            };
+            for r in extract_effect_block_refs(&payload) {
+                let resolved = guid_to_game_id.get(&r.block_guid);
+                if resolved.is_none() {
+                    unresolved += 1;
+                }
+                insert.execute(params![
+                    parent_game_id,
+                    r.block_index,
+                    r.block_guid,
+                    resolved,
+                ])?;
+                written += 1;
+            }
+        }
+        drop(insert);
+        tx.commit()?;
+        Ok((written, unresolved))
     }
 
     /// Populate `discipline_talents` by FQN pattern.

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -612,6 +612,12 @@ fn main() -> Result<()> {
     // decoder on top of the #171 singleton pipeline.
     let (gsf_component_costs, gsf_tier_costs) = db.populate_gsf_requisition_costs()?;
 
+    // Twelfth-and-seven-eighths pass: ability/talent → effect block linkage
+    // (issue #173). One row per indexed CF E0 sub-record in each abl.*/tal.*
+    // payload. Unresolved block GUIDs (versioned-only ability category, #179)
+    // are preserved with NULL block_game_id so the gap is visible in spice.
+    let (effect_block_rows, effect_block_unresolved) = db.populate_ability_effect_blocks()?;
+
     // Thirteenth pass: derive discipline→talent + class_utility_talents.
     // Per-origin utility talents fan to both combat styles; combat-discipline
     // talents stay scoped to their own discipline (no fan-out).
@@ -647,6 +653,10 @@ fn main() -> Result<()> {
     println!(
         "    GSF requisition costs: {} components + {} tier upgrades",
         gsf_component_costs, gsf_tier_costs
+    );
+    println!(
+        "    Ability effect blocks: {} rows ({} unresolved GUIDs)",
+        effect_block_rows, effect_block_unresolved
     );
     println!(
         "    Combat-style shared: {} abilities, {} utility talents",

--- a/kessel/src/schema/effect_block.rs
+++ b/kessel/src/schema/effect_block.rs
@@ -1,0 +1,159 @@
+//! Decoder for the indexed effect-block CF E0 sequence in ability/talent
+//! payloads. Issue #173.
+//!
+//! Each ability/talent payload contains (after the standard header + icon +
+//! primitive-property records) a series of `CF E0 00 <8-byte GUID>` markers.
+//! The first marker is typically the parent's OWN content GUID (a self-ref).
+//! The next N markers are PRECEDED by a 1-byte index (01..N) and reference
+//! the parent's effect-block sub-records. For Massacre: parent self-ref +
+//! 4 indexed effect blocks (indices 1..4).
+//!
+//! Some referenced effect-block GUIDs do not resolve in the `objects` table
+//! because their underlying abilities exist only as versioned variants
+//! (Heat Chain category, issue #179). The decoder preserves the raw GUID so
+//! the unresolved edges are visible in spice rather than silently dropped.
+//!
+//! What this decoder does NOT do: extract the typed properties (Weapon
+//! Damage Coefficient + Standard Health Percent, Modify Meta Stat amount
+//! and stat ref, Play Appearance epp ref, Call Effect chain metadata). Per
+//! the parsely reference shape, those fields live inside the per-effect-
+//! block sub-record payloads, and decoding them requires per-property
+//! byte-layout work that is filed as a follow-on. This decoder captures the
+//! structural linkage so consumers can at least walk the parent → effect
+//! block graph.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectBlockRef {
+    /// 1-based index. Matches the byte preceding the CF E0 marker in the
+    /// payload's indexed sequence.
+    pub block_index: u8,
+    /// 16-char uppercase hex GUID, BE order, matching the convention used
+    /// by `objects.guid`.
+    pub block_guid: String,
+}
+
+/// Walk a payload for the indexed CF E0 effect-block sequence. Skips the
+/// parent's self-reference (first CF E0 marker without an immediately
+/// preceding 1-byte index that's both > 0 and < 0xCF).
+///
+/// The decoder is intentionally lenient: it accepts any contiguous-or-near-
+/// contiguous run of `<idx> CF E0 00 <8-byte GUID>` records, with idx in
+/// 0x01..0x40 (effect blocks are bounded; abilities like Saber Throw have
+/// a few, complex multi-hit abilities have ~20 at most, so 0x40 caps the
+/// false-positive risk on hash bytes that happen to look like an index).
+pub fn extract_effect_block_refs(payload: &[u8]) -> Vec<EffectBlockRef> {
+    let mut out = Vec::new();
+    let mut last_idx: Option<u8> = None;
+    let mut i = 0;
+    // The first CF E0 marker in an ability/talent payload is the parent's
+    // own content GUID (self-reference). Indexed effect-block refs start
+    // AFTER that marker. Skip past it so the index-1 byte for the first
+    // real effect block doesn't get conflated with the self-ref's preceding
+    // byte (both can be 0x01).
+    //
+    // CF E0 marker shape per `docs/probes/dis-payload-format.md`:
+    //   CF E0 00 + 6-byte GUID tail (full GUID = E000 + tail, 8 bytes BE)
+    // Total marker = 9 bytes. The self-ref is the same 9-byte shape.
+    let mut seen_self_ref = false;
+    while i + 9 <= payload.len() {
+        if payload[i] != 0xCF || payload[i + 1] != 0xE0 || payload[i + 2] != 0x00 {
+            i += 1;
+            continue;
+        }
+        if !seen_self_ref {
+            seen_self_ref = true;
+            i += 9;
+            continue;
+        }
+        // CF E0 marker found AFTER the self-ref. The byte immediately
+        // before it carries the 1-based index for indexed refs.
+        // Per-record advance is +1 (not +9) because each indexed record is
+        //   <idx> CF E0 00 <6-byte GUID tail>
+        // so the next record's <idx> sits immediately after this one's
+        // tail (1 byte before the next CF E0 marker).
+        let prev = if i > 0 { Some(payload[i - 1]) } else { None };
+        let expected_idx: u8 = last_idx.map(|n| n + 1).unwrap_or(1);
+        if prev == Some(expected_idx) {
+            let idx = expected_idx;
+            let tail = &payload[i + 3..i + 9];
+            let guid = format!("E000{}", hex::encode_upper(tail));
+            out.push(EffectBlockRef {
+                block_index: idx,
+                block_guid: guid,
+            });
+            last_idx = Some(idx);
+        }
+        i += 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex_to_bytes(hex: &str) -> Vec<u8> {
+        hex.split_whitespace()
+            .map(|s| u8::from_str_radix(s, 16).expect("hex"))
+            .collect()
+    }
+
+    /// First ~160 bytes of Massacre's payload (verified against live spice).
+    /// Contains: icon string, 4 inline float32 records, several CB/CC
+    /// metadata markers, parent self-ref CF E0, then 4 indexed effect-block
+    /// refs (indices 01..04).
+    fn massacre_payload_prefix() -> Vec<u8> {
+        hex_to_bytes(
+            "00 00 00 00 00 40 13 CF 40 00 00 00 3D 2E 41 FD \
+             06 09 6F 76 65 72 70 6F 77 65 72 01 04 00 00 80 \
+             BF 20 04 00 00 40 40 02 04 CD CC CC 3E 02 04 00 \
+             00 87 43 04 05 02 01 05 02 C8 C5 05 02 CB 51 3F \
+             E4 54 03 01 CB 8F 00 59 0C 03 01 CB 7A 68 57 45 \
+             03 01 CB B5 DE DA 55 02 C0 01 CC 07 60 79 A3 76 \
+             01 CF E0 00 93 B2 44 62 08 65 CB 6F 3B F3 BC 07 \
+             01 04 04 01 CF E0 00 03 46 25 CC E5 3B 02 CF E0 \
+             00 02 46 25 CC E4 E8 03 CF E0 00 05 46 25 CC E9 \
+             D1 04 CF E0 00 04 46 25 CC EB 86",
+        )
+    }
+
+    #[test]
+    fn extract_effect_block_refs_massacre_finds_4_indexed_refs() {
+        let payload = massacre_payload_prefix();
+        let refs = extract_effect_block_refs(&payload);
+        assert_eq!(refs.len(), 4, "Massacre has 4 indexed effect-block refs");
+        for (i, expected) in [
+            (1u8, "E000034625CCE53B"),
+            (2, "E000024625CCE4E8"),
+            (3, "E000054625CCE9D1"),
+            (4, "E000044625CCEB86"),
+        ]
+        .iter()
+        .enumerate()
+        {
+            assert_eq!(refs[i].block_index, expected.0);
+            assert_eq!(refs[i].block_guid, expected.1);
+        }
+    }
+
+    #[test]
+    fn extract_effect_block_refs_skips_parent_self_ref() {
+        let payload = massacre_payload_prefix();
+        let refs = extract_effect_block_refs(&payload);
+        // Massacre's own GUID E00093B244620865 must NOT appear in the
+        // effect-block refs -- it's the parent self-ref, not an indexed
+        // effect block.
+        assert!(!refs.iter().any(|r| r.block_guid == "E00093B244620865"));
+    }
+
+    #[test]
+    fn extract_effect_block_refs_handles_empty_payload() {
+        assert!(extract_effect_block_refs(&[]).is_empty());
+    }
+
+    #[test]
+    fn extract_effect_block_refs_handles_no_cf_e0_markers() {
+        let payload = vec![0u8; 50];
+        assert!(extract_effect_block_refs(&payload).is_empty());
+    }
+}

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod appearance;
 pub mod discipline;
+pub mod effect_block;
 pub mod gsf_ability;
 pub mod gsf_costs;
 pub mod gsf_talent;


### PR DESCRIPTION
## Summary

Decodes the indexed CF E0 sub-record sequence in abl.*/tal.* payloads and populates a new \`ability_effect_blocks\` table. Each ability/talent's first CF E0 marker is the self-reference; subsequent markers preceded by a 1-byte incrementing index (01..N) are the effect-block refs that carry the parent's combat math (Weapon Damage, Modify Meta Stat, Play Appearance, Call Effect).

CF E0 wire format per \`docs/probes/dis-payload-format.md\`:
\`CF E0 00 + 6-byte GUID tail (full GUID = E000 + tail, 8 bytes BE)\`.

## Verification

Massacre's 4 indexed effect blocks (parsely-verified):
1 -> \`E000034625CCE53B\`
2 -> \`E000024625CCE4E8\`  (/23/1 Debuff)
3 -> \`E000054625CCE9D1\`
4 -> \`E000044625CCEB86\`

Live extraction (\`./target/release/kessel -i ~/swtor/Assets -o /tmp/spice-173.sqlite\`):
- 13,203 rows across 4,403 distinct ability/talent parents
- 5,852 resolved (44.3%) / 7,351 unresolved
- Unresolved block GUIDs are preserved with NULL block_game_id -- they reference the versioned-only ability category that issue #179 owns. Visible as concrete unresolved edges rather than silently dropped.

## What this does NOT do

Per-block typed properties (Weapon Damage Coefficient, Standard Health Percent, Modify Meta Stat, Play Appearance, Call Effect) live inside each effect block's own payload and require per-property byte-format decoding that is filed as a follow-on. This PR ships the structural linkage so consumers can walk parent -> block.

## Test plan

- [x] \`cargo test -p kessel\` (422 tests pass including 4 new effect_block tests)
- [x] \`cargo clippy -p kessel -- -D warnings\` (clean)
- [x] \`cargo fmt -p kessel --check\` (clean)
- [x] /legion-simplify (clean)
- [x] Live extraction against \`~/swtor/Assets\` -- Massacre's 4 effect blocks verified, 13,203 total rows

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>