### PR TITLE
feat(scripts): wire SCPT consumer into extraction pipeline (closes #182)

### DIFF
--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -1200,6 +1200,20 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_ability_tags_tag ON ability_tags(tag_hash);
             CREATE INDEX IF NOT EXISTS idx_ability_tags_game_id ON ability_tags(ability_game_id);
 
+            -- SCPT compiled-native script bodies (#182, closes #127's
+            -- consumer gap). One row per .scpt file at
+            -- /resources/systemgenerated/compilednative/<numeric_id>.
+            -- decoded_body is the post-XOR-decrypt body bytes (typically
+            -- x86-64 UI/SFX native code per kessel/src/scpt.rs docs).
+            -- Per-script semantic interpretation is a downstream consumer's
+            -- job; this table provides the raw decrypted bytes.
+            CREATE TABLE IF NOT EXISTS scripts (
+                script_id          INTEGER PRIMARY KEY,
+                decoded_size       INTEGER NOT NULL,
+                decoded_body_b64   TEXT NOT NULL,
+                extracted_at       INTEGER NOT NULL DEFAULT (unixepoch())
+            );
+
             -- Talent ↔ tag edges (#174). Same shape as ability_tags.
             CREATE TABLE IF NOT EXISTS talent_tags (
                 talent_fqn         TEXT NOT NULL,
@@ -2935,6 +2949,75 @@ impl Database {
         }
         self.flush()?;
         Ok(inserted)
+    }
+
+    /// Populate `scripts` with decrypted SCPT bodies (#182).
+    ///
+    /// Walks every `/resources/systemgenerated/compilednative/<numeric_id>`
+    /// file, runs `kessel::scpt::parse_and_decrypt`, and persists the body
+    /// (base64-encoded) plus the numeric_id from the SCPT header.
+    /// Per-script semantic interpretation (combat formulas, GSF physics,
+    /// UI script logic) lives downstream of this row; this populator
+    /// supplies the raw decoded bytes so consumers don't re-decrypt.
+    pub fn populate_scripts(
+        &self,
+        tor_dir: &std::path::Path,
+        hashes: &crate::hash::HashDictionary,
+    ) -> Result<u64> {
+        use crate::myp::Archive;
+        use crate::scpt;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+        use std::collections::HashSet;
+
+        let scpt_hashes: HashSet<u64> = hashes
+            .paths_matching("/resources/systemgenerated/compilednative/")
+            .into_iter()
+            .map(|(h, _)| h)
+            .collect();
+
+        let tor_files: Vec<std::path::PathBuf> = std::fs::read_dir(tor_dir)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false))
+            .collect();
+
+        let mut written = 0u64;
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        let mut insert = tx.prepare_cached(
+            "INSERT OR REPLACE INTO scripts (script_id, decoded_size, decoded_body_b64) \
+             VALUES (?1, ?2, ?3)",
+        )?;
+
+        for tor_path in &tor_files {
+            let mut archive = match Archive::open(tor_path) {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+            let entries: Vec<_> = match archive.entries() {
+                Ok(e) => e.cloned().collect(),
+                Err(_) => continue,
+            };
+            for entry in &entries {
+                if !scpt_hashes.contains(&entry.filename_hash) {
+                    continue;
+                }
+                let data = match archive.read_entry(entry) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+                let (header, body) = match scpt::parse_and_decrypt(&data) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                let body_b64 = BASE64.encode(&body);
+                insert.execute(params![header.numeric_id as i64, body.len(), body_b64])?;
+                written += 1;
+            }
+        }
+        drop(insert);
+        tx.commit()?;
+        Ok(written)
     }
 
     /// Populate `conversation_quest_refs` by scanning every NODE prototype

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -20,6 +20,7 @@ mod pbuk;
 mod prototypes_info;
 mod quest;
 mod schema;
+mod scpt;
 mod stb;
 mod unknowns;
 mod xml_utf16;
@@ -563,6 +564,12 @@ fn main() -> Result<()> {
     // are passive auras with effects on a parent activator or in a hook.
     let gsf_ability_stats_count = db.populate_gsf_ability_stats()?;
     println!("  GSF ability stats: {}", gsf_ability_stats_count);
+
+    // SCPT scripts (#182). Decrypt every .scpt file in
+    // /resources/systemgenerated/compilednative/ and persist the body as a
+    // base64-encoded blob. Per-script semantic interpretation downstream.
+    let scripts_count = db.populate_scripts(&args.input, &hash_dict)?;
+    println!("  Scripts: {}", scripts_count);
 
     // Conversation entities (#175). Wire every cnv.* NODE prototype into
     // the `objects` table (kind = Conversation) so all ~10,735 conversations


### PR DESCRIPTION
## Summary

Wire the existing \`kessel::scpt\` decoder (shipped in #127 with no consumer) into the extraction pipeline. Adds \`scripts\` table and \`populate_scripts\` populator.

## Live extraction

**1,196 scripts** decoded (matches the count documented in \`scpt.rs\`). Average body size ~14 KB; range 30 B to 410 KB. Each row carries the decrypted body as base64 (\`decoded_body_b64\`).

## What this is NOT

Per-script semantic interpretation (combat formulas, GSF physics, UI script logic) lives downstream. This PR's contribution is "do the decrypt once, store the bytes so consumers don't redo the work."

Per \`scpt.rs\` docstring: SCPT bodies decrypt to native x86-64 UI/SFX code, not Pawn bytecode or gameplay-formula data. Downstream consumers that want to disassemble are responsible for that.

## Test plan

- [x] \`cargo test -p kessel\` (all pass; no new tests needed -- the decoder was already tested in #127)
- [x] \`cargo clippy -p kessel -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] /legion-simplify clean
- [x] Live extract: 1,196 \`scripts\` rows

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>