### PR TITLE
feat(epp,fxspec): UTF-16-LE XML decoders + populated tables (closes #183)

### DIFF
--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -59,6 +59,24 @@ fn extract_ascii_strings(payload: &[u8], min_len: usize) -> Vec<String> {
     out
 }
 
+/// Convert a `.fxspec` resource path into the path-relative key used by
+/// `<fxSpecString>` references in `.epp` files. Returns None when the
+/// path doesn't contain a `/fxspec/` segment or a `.fxspec` suffix. Used
+/// by `populate_fx_specs` (#183) to make `appearance_specs.fx_spec_refs`
+/// joinable to `fx_specs.fqn`.
+///
+/// Example: `/resources/art/fx/fxspec/abilities/sith_warrior/sw_massacre_sword_glow.fxspec`
+/// → `abilities/sith_warrior/sw_massacre_sword_glow`.
+fn fxspec_fqn_from_path(path: &str) -> Option<String> {
+    let after_marker = path.split_once("/fxspec/")?.1;
+    let trimmed = after_marker.strip_suffix(".fxspec")?;
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 /// Best-effort faction inference from FQN structure. Returns Some when a
 /// clear faction segment is present, None otherwise. Used by
 /// `populate_npc_details_typed` (#176).
@@ -1199,6 +1217,29 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_ability_tags_tag ON ability_tags(tag_hash);
             CREATE INDEX IF NOT EXISTS idx_ability_tags_game_id ON ability_tags(ability_game_id);
+
+            -- Appearance specs (#183). One row per .epp file at
+            -- /resources/gamedata/epp/.../<name>.epp. FQN is the dotted
+            -- form of the path-relative key. appearance_actions and
+            -- fx_spec_refs are JSON arrays decoded from the XML body;
+            -- raw_xml preserves the full XML for downstream typed-field
+            -- consumers.
+            CREATE TABLE IF NOT EXISTS appearance_specs (
+                fqn                 TEXT PRIMARY KEY,
+                appearance_actions  TEXT,
+                fx_spec_refs        TEXT,
+                raw_xml             TEXT NOT NULL
+            );
+
+            -- FX specs (#183). One row per .fxspec file. node_classes is a
+            -- JSON array of the class names listed in the <classes> block;
+            -- raw_xml preserves the full XML for per-node-instance
+            -- consumers.
+            CREATE TABLE IF NOT EXISTS fx_specs (
+                fqn                 TEXT PRIMARY KEY,
+                node_classes_json   TEXT NOT NULL,
+                raw_xml             TEXT NOT NULL
+            );
 
             -- SCPT compiled-native script bodies (#182, closes #127's
             -- consumer gap). One row per .scpt file at
@@ -2949,6 +2990,144 @@ impl Database {
         }
         self.flush()?;
         Ok(inserted)
+    }
+
+    /// Populate `appearance_specs` from every `.epp` file in the archives
+    /// (#183).
+    ///
+    /// Each row carries the FQN extracted from the XML root attribute,
+    /// JSON-encoded lists of distinct AppearanceAction types and fxSpec
+    /// refs found in the body, and the raw decoded XML. Per-file decode
+    /// failures are skipped silently rather than aborting the walk.
+    pub fn populate_appearance_specs(
+        &self,
+        tor_dir: &std::path::Path,
+        hashes: &crate::hash::HashDictionary,
+    ) -> Result<u64> {
+        use crate::myp::Archive;
+        use crate::schema::epp;
+        use std::collections::HashSet;
+
+        let epp_hashes: HashSet<u64> = hashes
+            .paths_matching(".epp")
+            .into_iter()
+            .filter(|(_, p)| p.ends_with(".epp"))
+            .map(|(h, _)| h)
+            .collect();
+
+        let tor_files: Vec<std::path::PathBuf> = std::fs::read_dir(tor_dir)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false))
+            .collect();
+
+        let mut written = 0u64;
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        let mut insert = tx.prepare_cached(
+            "INSERT OR REPLACE INTO appearance_specs \
+               (fqn, appearance_actions, fx_spec_refs, raw_xml) \
+             VALUES (?1, ?2, ?3, ?4)",
+        )?;
+        for tor_path in &tor_files {
+            let mut archive = match Archive::open(tor_path) {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+            let entries: Vec<_> = match archive.entries() {
+                Ok(e) => e.cloned().collect(),
+                Err(_) => continue,
+            };
+            for entry in &entries {
+                if !epp_hashes.contains(&entry.filename_hash) {
+                    continue;
+                }
+                let data = match archive.read_entry(entry) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+                let spec = match epp::decode_epp(&data) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                let actions = serde_json::to_string(&spec.appearance_actions)?;
+                let refs = serde_json::to_string(&spec.fx_spec_refs)?;
+                insert.execute(params![spec.fqn, actions, refs, spec.raw_xml])?;
+                written += 1;
+            }
+        }
+        drop(insert);
+        tx.commit()?;
+        Ok(written)
+    }
+
+    /// Populate `fx_specs` from every `.fxspec` file in the archives (#183).
+    ///
+    /// FQN is derived from the resource path between `/fxspec/` and the
+    /// trailing `.fxspec`, matching the path-relative keys used by
+    /// `appearance_specs.fx_spec_refs`. node_classes is JSON-encoded.
+    pub fn populate_fx_specs(
+        &self,
+        tor_dir: &std::path::Path,
+        hashes: &crate::hash::HashDictionary,
+    ) -> Result<u64> {
+        use crate::myp::Archive;
+        use crate::schema::fxspec;
+        use std::collections::HashSet;
+
+        let fx_hashes: HashSet<(u64, String)> = hashes
+            .paths_matching(".fxspec")
+            .into_iter()
+            .filter(|(_, p)| p.ends_with(".fxspec"))
+            .map(|(h, p)| (h, p.clone()))
+            .collect();
+        let by_hash: std::collections::HashMap<u64, String> = fx_hashes.iter().cloned().collect();
+
+        let tor_files: Vec<std::path::PathBuf> = std::fs::read_dir(tor_dir)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false))
+            .collect();
+
+        let mut written = 0u64;
+        let conn = self.conn.lock().unwrap();
+        let tx = conn.unchecked_transaction()?;
+        let mut insert = tx.prepare_cached(
+            "INSERT OR REPLACE INTO fx_specs (fqn, node_classes_json, raw_xml) \
+             VALUES (?1, ?2, ?3)",
+        )?;
+        for tor_path in &tor_files {
+            let mut archive = match Archive::open(tor_path) {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+            let entries: Vec<_> = match archive.entries() {
+                Ok(e) => e.cloned().collect(),
+                Err(_) => continue,
+            };
+            for entry in &entries {
+                let Some(path) = by_hash.get(&entry.filename_hash) else {
+                    continue;
+                };
+                let Some(fqn) = fxspec_fqn_from_path(path) else {
+                    continue;
+                };
+                let data = match archive.read_entry(entry) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+                let spec = match fxspec::decode_fxspec(&data, fqn) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                let classes = serde_json::to_string(&spec.node_classes)?;
+                insert.execute(params![spec.fqn, classes, spec.raw_xml])?;
+                written += 1;
+            }
+        }
+        drop(insert);
+        tx.commit()?;
+        Ok(written)
     }
 
     /// Populate `scripts` with decrypted SCPT bodies (#182).

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -565,6 +565,15 @@ fn main() -> Result<()> {
     let gsf_ability_stats_count = db.populate_gsf_ability_stats()?;
     println!("  GSF ability stats: {}", gsf_ability_stats_count);
 
+    // EPP appearance specs + FX specs (#183). UTF-16-LE XML files. epp
+    // carries appearance action lists + fxSpec refs; fxspec carries node
+    // class lists. The two tables JOIN via appearance_specs.fx_spec_refs
+    // → fx_specs.fqn (path-relative keys).
+    let appearance_count = db.populate_appearance_specs(&args.input, &hash_dict)?;
+    println!("  Appearance specs: {}", appearance_count);
+    let fxspec_count = db.populate_fx_specs(&args.input, &hash_dict)?;
+    println!("  FX specs: {}", fxspec_count);
+
     // SCPT scripts (#182). Decrypt every .scpt file in
     // /resources/systemgenerated/compilednative/ and persist the body as a
     // base64-encoded blob. Per-script semantic interpretation downstream.

--- a/kessel/src/schema/epp.rs
+++ b/kessel/src/schema/epp.rs
@@ -1,0 +1,160 @@
+//! `.epp` (Appearance Spec) UTF-16-LE XML decoder. Issue #183.
+//!
+//! Wire format: UTF-16-LE BOM + XML rooted at
+//! `<Appearance fqn="..." GUID="...">`. Each appearance has one or more
+//! `<SubAppearance>` blocks. Each SubAppearance carries an
+//! `<AppearanceActionList>` of `<AppearanceAction type="...">` elements.
+//! The action types observed in v7.x include `PlayAnimAppFunctionType`,
+//! `PlayFXAppFunctionType`, `PopWeaponInAppFunctionType`, etc.
+//!
+//! `<AppearanceAction type="PlayFXAppFunctionType">` blocks contain a
+//! `<fxSpecString refType="weak_fxSpec">PATH</fxSpecString>` element that
+//! names the `.fxspec` resource by path-relative key (e.g.
+//! `abilities/sith_warrior/sw_massacre_sword_glow`).
+//!
+//! This decoder extracts the fqn, the list of action types, and the list
+//! of fxSpec references. Per-action typed-field decoding (caster bones,
+//! priority classes, animation note triggers) is left for downstream
+//! consumers operating on the raw_xml field.
+
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppearanceSpec {
+    /// FQN from the root `<Appearance fqn="...">` attribute.
+    pub fqn: String,
+    /// Distinct `<AppearanceAction type="...">` values in document order.
+    pub appearance_actions: Vec<String>,
+    /// Distinct `<fxSpecString>PATH</fxSpecString>` values in document order.
+    pub fx_spec_refs: Vec<String>,
+    /// Full decoded UTF-8 XML text. Preserved for downstream debug + future
+    /// per-action typed-field consumers.
+    pub raw_xml: String,
+}
+
+fn root_fqn_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"<Appearance\b[^>]*\bfqn="([^"]+)""#).unwrap())
+}
+
+fn action_type_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r#"<AppearanceAction\b[^>]*\btype="([^"]+)""#).unwrap())
+}
+
+fn fxspec_string_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"<fxSpecString\b[^>]*>([^<]+)</fxSpecString>").unwrap())
+}
+
+/// Decode a UTF-16-LE EPP XML file into a structured AppearanceSpec.
+pub fn decode_epp(bytes: &[u8]) -> Result<AppearanceSpec> {
+    let raw_xml = crate::xml_utf16::decode_xml_bom(bytes)?;
+    let fqn = root_fqn_re()
+        .captures(&raw_xml)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+        .ok_or_else(|| anyhow!("EPP root <Appearance fqn=...> not found"))?;
+
+    let mut appearance_actions = Vec::new();
+    for cap in action_type_re().captures_iter(&raw_xml) {
+        let v = cap.get(1).unwrap().as_str().to_string();
+        if !appearance_actions.contains(&v) {
+            appearance_actions.push(v);
+        }
+    }
+
+    let mut fx_spec_refs = Vec::new();
+    for cap in fxspec_string_re().captures_iter(&raw_xml) {
+        let v = cap.get(1).unwrap().as_str().trim().to_string();
+        if !v.is_empty() && !fx_spec_refs.contains(&v) {
+            fx_spec_refs.push(v);
+        }
+    }
+
+    Ok(AppearanceSpec {
+        fqn,
+        appearance_actions,
+        fx_spec_refs,
+        raw_xml,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synth_epp(xml: &str) -> Vec<u8> {
+        let mut bytes = vec![0xFFu8, 0xFE];
+        for c in xml.encode_utf16() {
+            bytes.extend_from_slice(&c.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn decode_epp_extracts_fqn_actions_and_fxspecs() {
+        let xml = r#"<Appearance fqn="epp.sith_warrior.massacre.cast_instant" GUID="2028117916909568">
+   <SubAppearanceList>
+      <SubAppearance>
+         <AppearanceActionList>
+            <AppearanceAction type="PlayAnimAppFunctionType">
+               <casterAnim>cb_2saber_sp2_attack_right_12</casterAnim>
+            </AppearanceAction>
+            <AppearanceAction type="PopWeaponInAppFunctionType">
+               <whichActor>caster</whichActor>
+            </AppearanceAction>
+            <AppearanceAction type="PlayFXAppFunctionType">
+               <fxSpecString refType="weak_fxSpec">abilities/sith_warrior/sw_massacre_sword_glow</fxSpecString>
+            </AppearanceAction>
+            <AppearanceAction type="PlayFXAppFunctionType">
+               <fxSpecString refType="weak_fxSpec">audio_ability_general_dummy</fxSpecString>
+            </AppearanceAction>
+         </AppearanceActionList>
+      </SubAppearance>
+   </SubAppearanceList>
+</Appearance>"#;
+        let bytes = synth_epp(xml);
+        let spec = decode_epp(&bytes).unwrap();
+        assert_eq!(spec.fqn, "epp.sith_warrior.massacre.cast_instant");
+        assert_eq!(
+            spec.appearance_actions,
+            vec![
+                "PlayAnimAppFunctionType",
+                "PopWeaponInAppFunctionType",
+                "PlayFXAppFunctionType"
+            ]
+        );
+        assert_eq!(
+            spec.fx_spec_refs,
+            vec![
+                "abilities/sith_warrior/sw_massacre_sword_glow",
+                "audio_ability_general_dummy"
+            ]
+        );
+    }
+
+    #[test]
+    fn decode_epp_errors_on_missing_root() {
+        let bytes = synth_epp("<NotAppearance/>");
+        assert!(decode_epp(&bytes).is_err());
+    }
+
+    #[test]
+    fn decode_epp_handles_empty_action_list() {
+        let xml = r#"<Appearance fqn="epp.x">
+   <SubAppearanceList>
+      <SubAppearance>
+         <AppearanceActionList />
+      </SubAppearance>
+   </SubAppearanceList>
+</Appearance>"#;
+        let bytes = synth_epp(xml);
+        let spec = decode_epp(&bytes).unwrap();
+        assert_eq!(spec.fqn, "epp.x");
+        assert!(spec.appearance_actions.is_empty());
+        assert!(spec.fx_spec_refs.is_empty());
+    }
+}

--- a/kessel/src/schema/fxspec.rs
+++ b/kessel/src/schema/fxspec.rs
@@ -1,0 +1,137 @@
+//! `.fxspec` (FX Spec / nodeWClasses) UTF-16-LE XML decoder. Issue #183.
+//!
+//! Wire format: UTF-16-LE without BOM. The XML root is `<nodeWClasses>`
+//! with a `<classes>` block listing class names and a `<marshalData>`
+//! block carrying per-node-instance field data. The class names are the
+//! routing/type information; the marshalData is per-node attribute soup.
+//!
+//! This decoder extracts the FQN (derived from the source file path by
+//! the caller, since the XML itself doesn't carry one), the list of class
+//! names, and preserves the full raw_xml for downstream consumers that
+//! want per-node detail.
+
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FxSpec {
+    /// FQN derived from the source path (e.g.
+    /// `art.fx.fxspec.abilities.sith_warrior.sw_massacre_sword_glow`).
+    /// The XML body does not embed the FQN; the populator computes it from
+    /// the resource path before calling `decode_fxspec`.
+    pub fqn: String,
+    /// Distinct `<class>NAME</class>` values inside the `<classes>` block.
+    pub node_classes: Vec<String>,
+    /// Full decoded UTF-8 XML text. Preserved for downstream typed-field
+    /// consumers (per-node marshalData parsing is out of scope here).
+    pub raw_xml: String,
+}
+
+fn class_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"<class>([^<]+)</class>").unwrap())
+}
+
+/// Decode a UTF-16-LE FX-spec XML file. `fqn` is supplied by the caller
+/// because the XML body itself doesn't embed one.
+pub fn decode_fxspec(bytes: &[u8], fqn: String) -> Result<FxSpec> {
+    let raw_xml = decode_utf16_le_or_bom(bytes)?;
+    let mut node_classes = Vec::new();
+    for cap in class_re().captures_iter(&raw_xml) {
+        let v = cap.get(1).unwrap().as_str().trim().to_string();
+        if !v.is_empty() && !node_classes.contains(&v) {
+            node_classes.push(v);
+        }
+    }
+    Ok(FxSpec {
+        fqn,
+        node_classes,
+        raw_xml,
+    })
+}
+
+/// Decode bytes as UTF-16-LE, accepting an optional BOM. .fxspec files
+/// in v7.x archives ship WITHOUT a BOM but are still UTF-16-LE; .epp files
+/// ship WITH the `FF FE` BOM. This function handles both shapes plus a
+/// UTF-8 fallback for safety.
+fn decode_utf16_le_or_bom(bytes: &[u8]) -> Result<String> {
+    if bytes.len() < 2 {
+        return Err(anyhow!("fxspec too short: {} bytes", bytes.len()));
+    }
+    let (kind, payload) = match (bytes[0], bytes[1]) {
+        (0xFF, 0xFE) => ("utf16le", &bytes[2..]),
+        (0xFE, 0xFF) => ("utf16be", &bytes[2..]),
+        // No BOM but the second byte is 0x00 -- characteristic of UTF-16-LE
+        // ASCII content (which all SWTOR fxspec files are).
+        (_, 0x00) => ("utf16le", bytes),
+        _ => ("utf8", bytes),
+    };
+    let s = match kind {
+        "utf16le" | "utf16be" => {
+            if payload.len() % 2 != 0 {
+                return Err(anyhow!("UTF-16 payload has odd byte count"));
+            }
+            let units: Vec<u16> = payload
+                .chunks_exact(2)
+                .map(|c| {
+                    if kind == "utf16le" {
+                        u16::from_le_bytes([c[0], c[1]])
+                    } else {
+                        u16::from_be_bytes([c[0], c[1]])
+                    }
+                })
+                .collect();
+            String::from_utf16(&units).map_err(|e| anyhow!("invalid UTF-16: {e}"))?
+        }
+        _ => std::str::from_utf8(payload)
+            .map_err(|e| anyhow!("invalid UTF-8: {e}"))?
+            .to_string(),
+    };
+    Ok(s.trim_end_matches('\u{0}').to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synth_fxspec_le(xml: &str) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for c in xml.encode_utf16() {
+            bytes.extend_from_slice(&c.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn decode_fxspec_extracts_class_names() {
+        let xml = r"<nodeWClasses><classes><class>_FxSpec</class><class>_FxSound</class></classes><marshalData/></nodeWClasses>";
+        let bytes = synth_fxspec_le(xml);
+        let spec = decode_fxspec(&bytes, "art.fx.fxspec.test".to_string()).unwrap();
+        assert_eq!(spec.fqn, "art.fx.fxspec.test");
+        assert_eq!(spec.node_classes, vec!["_FxSpec", "_FxSound"]);
+    }
+
+    #[test]
+    fn decode_fxspec_handles_bom_prefix() {
+        let xml = r"<nodeWClasses><classes><class>_FxSpec</class></classes></nodeWClasses>";
+        let mut bytes = vec![0xFFu8, 0xFE];
+        bytes.extend(synth_fxspec_le(xml));
+        let spec = decode_fxspec(&bytes, "art.fx.fxspec.bom_variant".to_string()).unwrap();
+        assert_eq!(spec.node_classes, vec!["_FxSpec"]);
+    }
+
+    #[test]
+    fn decode_fxspec_dedupes_class_names() {
+        let xml = r"<nodeWClasses><classes><class>_FxSpec</class><class>_FxSpec</class></classes></nodeWClasses>";
+        let bytes = synth_fxspec_le(xml);
+        let spec = decode_fxspec(&bytes, "x".into()).unwrap();
+        assert_eq!(spec.node_classes, vec!["_FxSpec"]);
+    }
+
+    #[test]
+    fn decode_fxspec_errors_on_truncated_payload() {
+        let bytes = [0xFFu8];
+        assert!(decode_fxspec(&bytes, "x".into()).is_err());
+    }
+}

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -3,6 +3,8 @@
 pub mod appearance;
 pub mod discipline;
 pub mod effect_block;
+pub mod epp;
+pub mod fxspec;
 pub mod gsf_ability;
 pub mod gsf_costs;
 pub mod gsf_talent;


### PR DESCRIPTION
## Summary

Decode the 20K+ \`.epp\` Appearance Spec files and 22K+ \`.fxspec\` FX Spec files into two new typed tables. Both are UTF-16-LE XML; \`.epp\` ships with a BOM, \`.fxspec\` ships without (handled inline).

## Live extraction

| Table | Rows | Coverage |
|---|---:|---|
| \`appearance_specs\` | 20,416 | 99% have decoded action lists, 83% have fx refs |
| \`fx_specs\` | 22,226 | 100% have decoded class lists |

## Schema

- \`appearance_specs(fqn PK, appearance_actions, fx_spec_refs, raw_xml)\` — JSON arrays for actions + fx refs; raw_xml preserved for downstream typed-field consumers
- \`fx_specs(fqn PK, node_classes_json, raw_xml)\`

The two tables JOIN via \`appearance_specs.fx_spec_refs\` → \`fx_specs.fqn\` (path-relative keys, e.g. \`abilities/sith_warrior/sw_massacre_sword_glow\`).

## Verification

Massacre's \`cast_instant\` appearance:
\`\`\`json
appearance_actions: ["PlayAnimAppFunctionType", "PopWeaponInAppFunctionType", "PlayFXAppFunctionType"]
fx_spec_refs: ["abilities/sith_warrior/sw_massacre_sword_glow",
               "audio_ability_general_dummy",
               "abilities/sith_warrior/sw_massacre_target_impact", ...]
\`\`\`

Both \`sw_massacre_sword_glow\` and \`sw_massacre_target_impact\` resolve in \`fx_specs.fqn\`.

## Test plan

- [x] \`cargo test -p kessel\` (219 unit, all pass — including 7 new epp/fxspec tests)
- [x] \`cargo clippy -p kessel -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] /legion-simplify clean
- [x] Live extract verified Massacre JOIN

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>