### PR TITLE
feat(node): broaden NODE-object populator to non-cnv prototypes (closes #181)

### DIFF
--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -2895,24 +2895,20 @@ impl Database {
         Ok(written)
     }
 
-    /// Insert one row per `cnv.*` NODE prototype into the `objects` table
-    /// (kind = Conversation), making the 10,735 conversation entities
-    /// queryable alongside PBUK objects (#175).
+    /// Insert one row per PROT-magic .node file into the `objects` table
+    /// (#175 entity layer for cnv.*, #181 extended to non-cnv prototypes
+    /// like creature.*, stg.*, etc.).
     ///
-    /// NODE files at `/resources/systemgenerated/prototypes/<num>.node` carry
-    /// the full conversation playback data. This populator wires them into
-    /// the objects table so downstream consumers can join conversation GUIDs
-    /// back to their FQN + payload, the same way they can for PBUK objects.
+    /// NODE files at `/resources/systemgenerated/prototypes/<num>.node` use
+    /// the PROT format documented in `kessel/src/node.rs`. This populator
+    /// walks every .node file with a valid PROT header, builds a synthetic
+    /// GOM header so the existing `GameObject` constructor reads the
+    /// content GUID the same way it does for PBUK objects, and emits one
+    /// row per file. The `kind` column is derived from the FQN prefix by
+    /// `from_gom_with_overrides`.
     ///
-    /// The internal conversation graph (per-node dialog text, branch
-    /// children, condition expressions, quest-hook type) lives inside each
-    /// payload as standard GOM templates + property records -- decoding that
-    /// per-node structure is filed as a follow-on. This PR ships the entity
-    /// layer so consumers can at least enumerate every conversation by FQN +
-    /// content GUID + size.
-    ///
-    /// Returns the number of conversation objects inserted.
-    pub fn populate_conversation_objects(
+    /// Returns the number of NODE objects inserted.
+    pub fn populate_node_objects(
         &self,
         tor_dir: &std::path::Path,
         hashes: &crate::hash::HashDictionary,
@@ -2961,7 +2957,10 @@ impl Database {
                     fqn_end += 1;
                 }
                 let fqn = match std::str::from_utf8(&data[fqn_start..fqn_end]) {
-                    Ok(s) if s.starts_with("cnv.") => s.to_string(),
+                    // Accept any FQN that contains a dot (kessel's basic
+                    // shape check). Empty or non-dotted FQNs are likely
+                    // corrupt PROT headers.
+                    Ok(s) if s.contains('.') => s.to_string(),
                     _ => continue,
                 };
                 let payload_start = fqn_end + 1;

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -580,13 +580,13 @@ fn main() -> Result<()> {
     let scripts_count = db.populate_scripts(&args.input, &hash_dict)?;
     println!("  Scripts: {}", scripts_count);
 
-    // Conversation entities (#175). Wire every cnv.* NODE prototype into
-    // the `objects` table (kind = Conversation) so all ~10,735 conversations
-    // are queryable alongside PBUK objects. Per-node graph structure
-    // (dialog text, branches, conditions, quest-hook type) lives inside each
-    // payload as standard GOM templates and is filed as a follow-on decode.
-    let cnv_objects = db.populate_conversation_objects(&args.input, &hash_dict)?;
-    println!("  Conversation objects: {}", cnv_objects);
+    // NODE-format prototype entities (#175 cnv + #181 non-cnv). Walks every
+    // PROT-magic .node file in /resources/systemgenerated/prototypes/ and
+    // emits one row per file into the `objects` table. The `kind` column
+    // is FQN-derived (Conversation for cnv.*, Creature for creature.*,
+    // etc.). Per-prototype-class typed decoders are follow-ons.
+    let node_objects = db.populate_node_objects(&args.input, &hash_dict)?;
+    println!("  NODE objects: {}", node_objects);
 
     // Conversation refs from NODE files (cnv.* prototypes). One pass through
     // the .tor archives extracts CF GUID refs to quest, npc, achievement,


### PR DESCRIPTION
## Summary

Rename \`populate_conversation_objects\` → \`populate_node_objects\` and drop the cnv-only FQN filter. Accept any PROT-format .node file whose decoded FQN contains a dot. Kind is FQN-derived (Conversation for cnv.*, Creature for creature.*, etc.).

## Current-archive impact: zero new rows

Investigation against the live v7.x archive: **58,405 .node hash entries** exist in the hash dictionary but **only 10,735 actual .node files** ship in the archives — and **all 10,735 have FQNs starting with \`cnv.\`**. The 47,670 missing entries are stale (probably an older build's hash list carried forward).

The plan's framing of "14K non-cnv .node files" is **corrected**: per the live archive, that population does not exist as of v7.x. The plan was right that the corpus contained non-cnv .node files at one point, but they don't ship now.

## Why ship anyway

Forward-compatibility. If a future SWTOR patch reintroduces non-cnv .node prototypes (creature/stage/player-ability), the existing pipeline picks them up without code changes. The rename clarifies the populator's actual scope (all NODE files, not just conversations).

Per the per-prototype-kind typed-decoder follow-on note in the issue: those would file as separate issues if/when the data shows up.

## Test plan

- [x] \`cargo test -p kessel\` (all pass, no behavioral changes for current corpus)
- [x] \`cargo clippy -p kessel -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] /legion-simplify clean
- [x] Live extract: NODE objects = 10,735 (unchanged from #175 baseline -- confirms no new rows for current corpus, as expected)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>