### PR TITLE
docs(probes): typed-value encoding investigation + tighten CLAUDE.md (plan 019e65a5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,92 +1,48 @@
 # Kessel
 
-SWTOR game data extractor. Parses binary `.tor` archives and outputs structured data to SQLite.
+SWTOR game data extractor. Parses binary `.tor` archives, outputs SQLite.
+
+## DO NOT PUT SHIT IN HERE. RECALL/REFLECT.
+
+This file is for **basic operational info only**. Everything else lives in legion:
+
+- `legion recall --repo kessel --context "..."` — your own prior findings
+- `legion consult --context "..."` — every agent's findings
+- `legion reflect --repo kessel --text "..."` — write a new finding
+
+Findings (format bytes, decode breakthroughs, "known gaps", architecture
+prose, per-system notes) DO NOT belong in this file. They rot here while
+legion stays current. Last time this file lied to me about per-property
+byte decode being unsolved when reflection `019e4d75` had solved it five
+days earlier. Don't repeat that.
 
 ## Workspace layout
 
-Cargo workspace with two crates:
-
-- `kessel/` -- the production crate (the `kessel` binary + library). This is what ships.
-- `kessel-discovery/` -- one-off reverse-engineering tools, probes, dumps, scanners. Not shipped by default; built on demand for discovery work.
+- `kessel/` — production crate (the `kessel` binary + library). What ships.
+- `kessel-discovery/` — one-off reverse-engineering tools. Built on demand.
 
 ## Build and test
 
 ```bash
-# Default: only builds production `kessel` binary
-cargo build --release
+cargo build --release          # builds production kessel binary only
 cargo test -p kessel
 cargo clippy -p kessel -- -D warnings
 cargo fmt --check
-
-# Full workspace (includes ~60 discovery binaries)
-cargo build --release --workspace
 cargo build --release -p kessel-discovery --bin <name>  # one-off recon tool
 ```
 
 ## Run extraction
 
 ```bash
-# Minimum (hash dictionary auto-downloads from Jedipedia)
 ./target/release/kessel -i ~/swtor/Assets -o spice.sqlite
-
-# With icons
 ./target/release/kessel -i ~/swtor/Assets -o spice.sqlite --icons --icons-output ./icons
-
-# Unfiltered (no content filters, keeps NPC/internal objects)
 ./target/release/kessel -i ~/swtor/Assets -o spice.sqlite --unfiltered
 ```
 
-## Architecture
-
-Binary format layers: `.tor` (MYP archive) -> PBUK container -> DBLB block -> GOM objects (ZSTD compressed).
-
-Data flow:
-1. `myp.rs` reads .tor archives, decompresses entries (zstd/zlib)
-2. `hash.rs` resolves 64-bit file hashes to paths via Jedipedia dictionary
-3. `pbuk.rs` extracts GOM objects from PBUK/DBLB containers
-4. `schema/mod.rs` converts binary GOM objects to structured `GameObject` (GUID, FQN, game_id, kind, icon_name, string_id)
-5. `stb.rs` extracts localized strings from STB string tables
-6. `grammar.rs` cleans SWTOR template syntax from descriptions (rules in `grammar.toml`)
-7. `db.rs` batch-inserts objects and strings to SQLite
-8. `dds.rs` converts DDS textures to WebP icons, matched to objects by name
-
-## Key concepts
-
-- **FQN** (Fully Qualified Name): dot-separated object identifier like `abl.sith_warrior.skill.rage.ravage`. The prefix determines the object kind.
-- **game_id**: deterministic identifier `sha256(fqn:guid)[0:16]`. Used for icon filenames and frontend lookups.
-- **string_id**: links objects to their localized strings in STB tables via `objects.string_id = strings.id2`.
-- **Grammar rules**: embedded at compile time from `grammar.toml`. Template rules handle `<<N[...]>>` patterns, literal rules do exact replacements, cleanup rules are regex post-processing.
-
 ## Code conventions
 
-- No `unwrap()` in library code -- use `anyhow` for error propagation
-- Batch database inserts (flush at 5000 items)
-- All hashing uses SHA-256 truncated to 16 hex chars
-- Icon IDs must match the frontend `computeIconId()` function
-- JSON for all data interchange (no TOML/YAML for data)
-
-## Known gaps
-
-- GSF talent stat extraction covers 250/350 talents (#80, gsf_talent_stats
-  table). The remaining ~100 are flag-only talents whose effects live on the
-  parent ability or in script hooks; surfacing those would require
-  parent-ability stat-block parsing as a separate pass.
-- No automated test for full extraction pipeline (needs SWTOR assets).
-- GSF per-component combat math (per-laser damage, range, accuracy, firing
-  arc) lives in `swtor.exe`, not in any `.tor` data file. Confirmed via
-  exhaustive byte search (legion `019e4cbb`). Recovery path: Sean's in-game
-  capture, or swtor.exe decompile (out of kessel scope).
-- CC field hash → name dictionary unknown. The 4-byte CC hashes (6F6FAE37
-  stringRef, 17E2840B abilityRef, etc.) referenced in MAPPINGS.md are not in
-  client.gom -- they live in a separate proprietary Bioware namespace.
-  Requires a known-plaintext attack to reverse (spike issue #144).
-- SCPT compiled-native scripts (1,196 in
-  `/resources/systemgenerated/compilednative/`) contain UI/SFX logic, not
-  combat math. Decoder available as `kessel::scpt` (#127) but no consumer
-  wired by default.
-- Per-property post-CF40 value byte layout (int8/16/32, enum_ref, string,
-  array, class_ref) is not yet decoded. The schema-aware walker (#125)
-  resolves marker names and emits typed property keys, but value extraction
-  is foundation-only on quest_details (#129) and quest_objectives (#130) --
-  values are recorded as `"PRESENT"` flags rather than decoded enum members
-  or ints. Follow-on PRs lift these per Quest/Ability/Item/Npc class.
+- No `unwrap()` in library code — use `anyhow` for error propagation.
+- Batch database inserts (flush at 5000 items).
+- All hashing uses SHA-256 truncated to 16 hex chars.
+- Icon IDs must match the frontend `computeIconId()` function.
+- JSON for all data interchange (no TOML/YAML for data).

--- a/docs/plans/wire-typed-values.md
+++ b/docs/plans/wire-typed-values.md
@@ -1,0 +1,155 @@
+# Plan: Wire client.gom typed-value decode into production kessel
+
+## The work is one thing: understand the encoding completely before any code lands.
+
+No phases. No LOC estimates. No "primitives are easy, lift them first." Those
+framings race past the investigation. Verified from one example does not
+generalize.
+
+## Verification (what's actually true right now)
+
+Ran the verification myself, against the live archive 2026-05-26:
+
+**Solid:**
+- `client.gom` (920,956 bytes) extracts cleanly.
+- `kessel-discovery/src/bin/extract_client_gom_final.rs` compiles and runs;
+  produces 10,006 property records, 2,220 class records, 9 root systems.
+- Type-tag distribution matches prior reflection exactly.
+- All 9 root classes already embedded in `kessel/resources/gom_classes.json`.
+- `kessel::gom_schema::property_for_cf40(hi32)` lookup works in production.
+
+**NOT solid:**
+- Payload value encoding does NOT cleanly follow the schema's declared
+  type tag. Verified counter-examples:
+  - Property `3D2E41FD` schema says float32 (type_tag=0x06), payload
+    encodes as `06 09 'overpower'` (length-prefixed string).
+  - Property `384B7939` schema says enum_ref (type_tag=0x05), payload
+    bytes don't match any enum hash in the dictionary.
+  - Property `5CE87488` schema says int8 (type_tag=0x02), payload encodes
+    as one byte (value=2). THIS ONE case is clean.
+- The byte at position +4 after `CF 40 00 00` ("type_flags" in the
+  current walker comment) varies per record: observed 0x00, 0x0a, 0x11,
+  0x13, 0x40. This byte is currently ignored. It may be the real
+  payload-encoding selector.
+
+I have **one data point** where the dictionary matches the encoding (int8).
+That is not enough to write a decoder.
+
+## What the investigation must answer before any code
+
+The investigation is the work. It is not a "phase 1" that unlocks fast
+follow-on phases. It is the whole thing right now. The output is a doc that
+explains every byte position for every observed encoding pattern, backed by
+real-payload samples from across multiple object kinds.
+
+Specific questions, each requiring real-payload evidence:
+
+1. **What does the `type_flags` byte at +4 actually do?**
+   - Histogram its values across all CF40 markers in every PBUK payload kind
+     (abl, tal, qst, itm, npc, mpn, schem, cdx, ach, dis, hyd, cnv, etc).
+   - For each observed `type_flags` value, classify what encoding follows.
+   - Is `type_flags` a property-encoding override, a record-framing flag, or
+     something else?
+
+2. **Why does a schema-declared float32 property encode as a string?**
+   - Is the decoder mis-classifying the schema record's type_tag byte?
+   - Is the payload allowed to deviate from the schema type per record?
+   - Is `3D2E41FD` a wrapper / generic property whose encoded type is
+     payload-determined?
+   - This is the single most important question. The dictionary is useless
+     for production if encoding doesn't follow schema type.
+
+3. **What is the on-wire shape of enum_ref values?**
+   - The dictionary maps enum hashes to member lists. The payload bytes
+     after a CF40 enum_ref marker don't match any hash in Massacre's case.
+   - Is there a length prefix? A different ID space? An index encoded
+     differently than I expected?
+   - Find at least 10 enum_ref markers across multiple objects where the
+     intended value is known (e.g. via parsely cross-reference) and trace
+     the byte mapping.
+
+4. **What is the on-wire shape of class_ref values?**
+   - The dictionary maps class hashes to property lists. Same questions as
+     enum_ref: how does the payload encode the reference?
+
+5. **What is the on-wire shape of array values?**
+   - The existing `dis-payload-format.md` probe documented `02 09 XX XX` as
+     an array opener for dis.*. Does the same shape apply to typed-property
+     arrays in other classes? Or is each class's array encoding different?
+   - Length prefix? Element-type prefix? Terminator?
+
+6. **What is the on-wire shape of string values?**
+   - "overpower" looked like `<length-byte><N-byte ascii>` — confirm
+     across hundreds of cases.
+   - Are there UTF-8 strings? UTF-16 strings? Null-terminated strings?
+   - How does the decoder distinguish string encodings without the schema
+     type telling it?
+
+7. **What are the unknown type tags (0x0E, 0x11, 0x12, 0x14, 0x15)?**
+   - ~726 records use them. Some show up in payloads. Map their encoding.
+
+8. **Do encoding patterns differ per class?**
+   - Test the same property hi32 across different object kinds. If the
+     same property encodes differently in abl vs qst, that's a per-class
+     overlay we need to model.
+
+9. **What's the relationship to dis-payload-format.md?**
+   - That probe documented dis-specific markers (CB submarker, CA opener,
+     E0 self-reference). Are those a special case of the typed-property
+     encoding, or a separate layer on top?
+
+## Output
+
+A document at `docs/probes/typed-value-encoding.md` that, for every observed
+encoding pattern:
+
+- Names the pattern.
+- Cites at least 3 real-payload examples (FQN + byte offset).
+- Documents the exact byte layout (offset, size, meaning per byte).
+- Identifies the discriminator (what makes the decoder pick this pattern).
+- Notes any cross-class variations.
+
+When the doc exists and Sean (or whoever's reading) can predict the bytes
+of an arbitrary CF40 marker's value tail from the doc alone, the
+investigation is done.
+
+## What comes after the investigation
+
+That's a question for after the investigation. Not before. Code follows
+understanding. Pre-committing to a code shape now would lock in the same
+"int8 works so the others probably do too" extrapolation that produced the
+wrong "5 phase" plan in the first place.
+
+After the doc exists, the right next step might be:
+- One PR that wires every encoding the doc explains, all at once.
+- Or several PRs split by encoding family.
+- Or a different architecture entirely if the investigation reveals that
+  per-class overlays are big enough that a generic walker doesn't apply.
+
+Don't decide that now. Investigate first.
+
+## What this plan does NOT do
+
+- Promise timelines.
+- Promise LOC counts.
+- Promise that primitive types are easy.
+- Promise that the schema dictionary is sufficient.
+- Promise that the existing `decode_payload_schema_aware` shape is
+  the right place for the value decoder.
+
+It commits to one outcome: a doc that explains every byte of the encoding,
+backed by enough real-payload evidence that the explanation can't be wrong
+on the unverified cases.
+
+## What this plan DOES do
+
+- Acknowledge what's verified and what's not.
+- Refuse to extrapolate from one data point.
+- Treat the investigation as the work, not the gate to the work.
+- Let the architecture follow the understanding, not vice-versa.
+
+## Out of scope
+
+- GSF combat math (in swtor.exe, confirmed `019e4cbb`).
+- CC field-hash namespace (separate proprietary hash, separate spike).
+- base_guid column from #179 (independent PR; can land in parallel).

--- a/docs/probes/typed-value-encoding.md
+++ b/docs/probes/typed-value-encoding.md
@@ -1,0 +1,231 @@
+# Typed-value encoding (CF40 marker value tails)
+
+Investigation issue: legion plan `019e65a5`. Status: in progress 2026-05-26.
+Output of an exhaustive scan over 9,285,576 CF40 markers across 415,612
+canonical PBUK objects.
+
+## TL;DR — verified
+
+1. **The tail's first byte equals the schema's `type_tag` in 100% of resolved markers.**
+   When `gom_schema::property_for_cf40(hi32)` returns `Some(prop)`, the byte
+   at `payload[i + 9]` equals `prop.type_tag`. This is the on-wire type
+   marker. The schema dictionary is reliable for *which tag* a property
+   uses.
+
+2. **The `type_flags` byte at `payload[i + 4]` is determined by the property,
+   not by context.** 15,156 of 15,157 distinct hi32s have exactly ONE
+   type_flags value across all their occurrences. Knowing the hi32 means
+   knowing the type_flags. type_flags carries no extra information the
+   walker needs to interpret.
+
+3. **The dictionary's per-tag LABELS are guesses and several are wrong.**
+   The extractor `extract_client_gom_final.rs` labeled the type tags based
+   on schema-record body sizes, then those labels became canon in
+   `kessel/resources/gom_properties.json`. Verified mislabels:
+
+   | tag | decoder label | actual on-wire encoding | evidence |
+   |---|---|---|---|
+   | 0x01 | bool | *unclear* — 41% int32-shape, 37% int8-shape, only 0.8% bool-shape | hypothesis-test 8,177 markers |
+   | 0x02 | int8 | int8 (1 byte) | confirmed via Massacre 5CE87488 = 2, plus 51% int8-positive rate |
+   | 0x03 | int16 | **int8** (1 byte, NOT 2 bytes) | 100% of 50,000 samples had tail[1] in {0..4} |
+   | 0x04 | int32 | **float32** (4 LE bytes) | 99.9% of 1,158 samples decode to plausible floats; sample values 30.0, 2.0, -1.0, 1.5, 33.34 |
+   | 0x05 | enum_ref | *not* an 8-byte enum hash — structured list/sequence | none of 76,933 samples match enum-hash format |
+   | 0x06 | float32 | **length-prefixed string** `<06><u8 len><N ASCII>` | 67.8% of 200K samples decode cleanly; 0% are plausible floats |
+   | 0x07 | string | composite/wrapper (contains nested sub-tagged values) | 100% of 90,164 samples have inner-tag byte at tail[1] |
+   | 0x08 | array | array opener (wraps inner-tagged elements) | 99.9% wrap-shape; common inner tags 0x06, 0x01, 0x02 |
+   | 0x09 | class_ref_strong | class ref via embedded CF E0 GUID | 100% wrap; sample `09 02 00 CF E0 00 <6-byte GUID>` |
+   | 0x12 | unknown_12 | **Vec3 of 3 LE float32** (1+12=13 bytes) | 100% of 50,000 samples have 3 plausible floats |
+
+## TL;DR — NOT verified
+
+- 0x01 encoding (decoder label "bool" but hypothesis tests suggest it's
+  something else — needs per-sample investigation by hi32 family).
+- 0x05 encoding (decoder label "enum_ref" but on-wire shape is not an
+  8-byte enum hash; appears to be a list-of-items, maybe with count prefix).
+- 0x07 encoding (decoder label "string" but on-wire it's a composite
+  wrapper; need to characterize the wrapper grammar).
+- 0x0E, 0x11, 0x14, 0x15 encodings (decoder labels all "unknown" — no
+  hypothesis tested cleanly).
+- 0x08 array element-count + termination (the opener is confirmed, the
+  element grammar is partially mapped).
+
+## Method
+
+`kessel-discovery/src/bin/probe_typed_encoding.rs` walks every canonical
+PBUK object in spice and writes one JSONL record per CF40 marker to
+`/tmp/typed-encoding-samples.jsonl` (2.5GB, 9,285,576 markers). Each
+record carries `(kind, fqn, off, type_flags, hi32, schema_kind,
+schema_type_tag, schema_refs, first-32-bytes-of-tail)`.
+
+Analysis ran in Python: histogram type_flags, histogram tail[0] per
+schema_kind, then per-hypothesis pass/fail counting against plausible
+encodings (`bool_1`, `int8_pos`, `int16_small`, `int32_small`,
+`float32_plaus`, `str_u8len`, `wrap_inner_tag`).
+
+## Per-tag findings (verified)
+
+### Tag 0x02 — int8
+- Format: `<02><value_i8>`
+- Tail length: 2 bytes
+- Confidence: high. Spot-checked against Massacre's 10 repeated
+  `5CE87488` markers, all decode to value = 2.
+- Note: the byte AFTER the int8 value is the next record's first byte
+  (typically a different layer's marker like CB/CC/CE/CF).
+
+### Tag 0x03 — int8 (NOT int16 as labeled)
+- Format: `<03><value_i8>`
+- Tail length: 2 bytes
+- Confidence: high. 50,000 samples all have tail[1] in {0, 1, 2, 3, 4}.
+- Decoder mislabeled this as int16 based on schema body size; on-wire
+  it stores a single byte.
+
+### Tag 0x04 — float32 (NOT int32 as labeled)
+- Format: `<04><value_f32_LE>`
+- Tail length: 5 bytes (1 tag + 4 value)
+- Confidence: high. 1,157 / 1,158 samples are plausible floats. Sample
+  decoded values: 30.0, 2.0, -1.0, 1.5, 33.34, 6.469.
+
+### Tag 0x06 — length-prefixed string (NOT float32 as labeled)
+- Format: `<06><len_u8><len bytes ASCII>`
+- Tail length: 2 + len bytes
+- Confidence: medium-high. 67.8% of 200K samples match the
+  `<u8><printable>` shape; 0% are plausible floats. The remaining 32%
+  may be longer strings (len > 200 needs different prefix), Unicode
+  strings, or some encoding variant — to investigate further.
+
+### Tag 0x09 — class_ref via CF E0 GUID
+- Format: `<09><02><00><CF E0 00 + 6-byte content GUID tail>`
+- Tail length: 12 bytes
+- Confidence: medium. Samples consistent across Quest hi32=BD7C6F8D.
+  Some variants embed a CC sub-marker before the CF E0; needs further
+  characterization.
+
+### Tag 0x12 — Vec3 of float32 (NOT "unknown" as labeled)
+- Format: `<12><x_f32_LE><y_f32_LE><z_f32_LE>`
+- Tail length: 13 bytes (1 tag + 12 value)
+- Confidence: very high. 100% of 50,000 samples (50,000/50,000) have
+  3 plausible LE float32s after the tag.
+- Sample values from Dynamic objects (likely positions or scales):
+  `(0.289, 0.7, 0.732)`, `(0.308, 1.225, 0.708)`, `(0.398, 0.0, 0.311)`.
+
+## Per-tag findings (NOT verified, encoding open)
+
+### Tag 0x01 — decoder label "bool", actually a wrapper containing another marker
+- byte[1] distribution (top): 0xCF=2,990 / 0x02=1,693 / 0xCC=128 /
+  0x08=119 / 0xCB=22 / 0x01=18 / 0xCE=16. The dominant 0xCF means most
+  0x01-tagged tails are immediately followed by another CF40 or CF E0
+  marker.
+- Sample `01 CF E0 00 1B 49 2F E3 D7 DA ...` — 0x01 followed by a
+  CF E0 content-GUID ref. Sample `01 CF 40 00 00 02 27 8F FC 5D` —
+  0x01 followed by a CF 40 template marker.
+- Hypothesis: 0x01 is a "ref-or-marker wrapper" that holds another
+  decodable token immediately after.
+- NOT verified: what 0x01 means semantically vs 0x07/0x09 which are
+  also wrappers. Per-property characterization needed.
+
+### Tag 0x05 — decoder label "enum_ref", actual structured list with count
+- byte[1] distribution: 2..17 dominant (counts 2740..4899 each),
+  suggesting byte[1] is an element count for a small list.
+- Sample `05 06 0C 08 05 04 00 00 01 08 05 02 06 06 1A 04` (epp):
+  `05 06` = list-of-6 elements? then `0C 08 05 04 ...` repeating.
+- Sample `05 02 01 02 CA 19 24 EB 01 02 CA 19 25 44 01 07` (NpcPackage):
+  `05 02` = list-of-2 then `01 02 CA 19 24 EB` (one CA-prefixed ref)
+  + `01 02 CA 19 25 44` (another CA ref).
+- Hypothesis: `<05><u8 count><N elements>`. Element format varies per
+  property.
+
+### Tag 0x07 — decoder label "string", actually a tagged wrapper
+- Inner tag distribution (byte[1]): 0x09 = 44,034 / 0x06 = 9,418 /
+  0x01 = 2,783 / 0x02 = 641. Dominantly 0x09 (class_ref).
+- 100% of 90,164 tested samples have tail[1] in the known type-tag
+  space.
+- Hypothesis: 0x07 = "typed-value wrapper" that announces "the next
+  byte is the actual inner type tag of the value that follows."
+- Common pattern: `07 09 ...` = wrapped class_ref. `07 06 ...` =
+  wrapped length-prefixed string.
+
+### Tag 0x08 — array opener with element-type byte
+- byte[1] = element type tag. Top values: 0x06=5,796 / 0x02=5,369 /
+  0x01=5,282 / 0x05=513.
+- Common patterns: `08 01 03 ...`, `08 06 09 ...`, `08 02 09 ...`,
+  `08 06 06 ...`, `08 02 02 ...`, `08 05 03 ...`.
+- Hypothesis: `<08><element_type><N or first-element-marker><elements>`.
+- For `08 06 09 01 01 D2 09 'On Arrive' ...`: element_type=0x06
+  (string), and `09 'On Arrive'` is one length-prefixed string with
+  length=9.
+- Open: how many elements? Is there a count byte or a termination
+  marker? The pattern between consecutive `08` headers in the same
+  payload needs more bisection.
+
+### Tags 0x0E, 0x11, 0x14, 0x15
+- No reliable hypothesis yet. Counts: 0x0E = 9 records in schema, 0x11
+  = 133, 0x12 = 342 (Vec3 confirmed), 0x14 = 63, 0x15 = 179.
+- These are infrequent. Investigation deferred until the primary
+  consumers (Quest, Ability, Item, Npc, Talent) are wired and any of
+  these tags actually appear in their typed columns.
+
+## What the schema dictionary IS reliable for
+
+- The hi32 → property record lookup (`property_for_cf40`) — 100%
+  reliable.
+- The `class.property_refs[i].low32 == property.id.high32` resolution —
+  per the prior reflection, 100% for root classes.
+- The `tail[0] == property.type_tag` — 100% across the 8.7M resolved
+  markers tested.
+
+## What the schema dictionary is NOT reliable for
+
+- The HUMAN-LABEL of each type tag. The decoder's labels
+  (bool, int8, int16, int32, enum_ref, float32, string, array,
+  class_ref_strong) are best-guesses from schema-record sizes, not
+  payload evidence. Re-derive from this doc's verified column.
+
+## Implications for production wiring
+
+- **Cannot trust the `kind` field on `GomProperty`** for any of:
+  0x01 (was "bool"), 0x03 (was "int16"), 0x04 (was "int32"),
+  0x05 (was "enum_ref"), 0x06 (was "float32"), 0x07 (was "string").
+  These need re-labeling in `kessel/resources/gom_properties.json` or
+  bypassed entirely (use the verified table in this doc as the
+  authoritative mapping until the resource file is regenerated).
+
+- **Can trust the `type_tag` field on `GomProperty`** — it IS the
+  on-wire tag byte.
+
+- **Can write a per-tag decoder** for the verified tags:
+  0x02 (int8), 0x03 (int8), 0x04 (float32), 0x06 (string), 0x09
+  (class_ref-via-GUID), 0x12 (Vec3).
+
+- **Cannot yet write a decoder** for 0x01, 0x05, 0x07, 0x08, or the
+  unknown tags. Each needs per-property characterization.
+
+- **Do not extrapolate.** "int8 works, so int16/int32 follow the same
+  pattern" — wrong. The investigation already disproved that.
+
+## Open questions parked
+
+1. Tag 0x01 actual encoding (likely wrapper, not bool).
+2. Tag 0x05 actual encoding (structured list, count prefix unknown).
+3. Tag 0x07 actual encoding (composite wrapper, grammar undetermined).
+4. Tag 0x08 array element-count and termination grammar.
+5. Tags 0x0E, 0x11, 0x14, 0x15 encodings.
+6. Why some hi32 properties have decoder-mislabeled types — is the
+   schema-record body size insufficient to determine type, or is the
+   decoder's size-to-type mapping faulty?
+7. The `type_flags` byte's actual meaning. It's per-property stable,
+   but what does each observed value (0x00, 0x01, 0x02, 0x03, 0x04,
+   0x0B, 0x0D, 0x11, 0x42, etc.) signify? Best guess: a property
+   modifier (mutability, default-vs-stored, optional). Not blocking
+   for value decode, but useful to understand.
+8. The 32% of 0x06 strings that don't decode as `<u8 len><ASCII>` —
+   are these UTF-8 strings, longer-length-prefix strings, or some
+   variant?
+
+## What comes after this doc
+
+Per the plan-rewrite, no code lands until enough of the open questions
+are answered to write a correct decoder. The verified subset (0x02,
+0x03, 0x04, 0x06, 0x09, 0x12) is enough to start unlocking real values
+in some columns, but the plan's "what comes after the investigation"
+section is intentionally undecided. The next step is more probing on
+0x01, 0x05, 0x07, 0x08 — not code.

--- a/kessel-discovery/src/bin/probe_dump_client_gom.rs
+++ b/kessel-discovery/src/bin/probe_dump_client_gom.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use kessel::hash::HashDictionary;
+use kessel::myp::Archive;
+use std::path::PathBuf;
+fn main() -> Result<()> {
+    let mut hd = HashDictionary::new();
+    hd.load(&PathBuf::from("/Users/seansilvius/.cache/kessel/hashes_filename.txt"))?;
+    let hash = hd.paths_matching("/resources/systemgenerated/client.gom").into_iter().map(|(h, _)| h).next().expect("client.gom not in dict");
+    for tor_path in std::fs::read_dir(&PathBuf::from("/Users/seansilvius/swtor/Assets"))?.filter_map(|e| e.ok()).map(|e| e.path()).filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false)) {
+        let mut a = match Archive::open(&tor_path) { Ok(a) => a, Err(_) => continue };
+        let entries: Vec<_> = match a.entries() { Ok(e) => e.cloned().collect(), Err(_) => continue };
+        for entry in entries {
+            if entry.filename_hash == hash {
+                let data = a.read_entry(&entry)?;
+                std::fs::write("/tmp/client.gom.bin", &data)?;
+                eprintln!("wrote /tmp/client.gom.bin ({} bytes)", data.len());
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}

--- a/kessel-discovery/src/bin/probe_dump_client_gom.rs
+++ b/kessel-discovery/src/bin/probe_dump_client_gom.rs
@@ -4,11 +4,28 @@ use kessel::myp::Archive;
 use std::path::PathBuf;
 fn main() -> Result<()> {
     let mut hd = HashDictionary::new();
-    hd.load(&PathBuf::from("/Users/seansilvius/.cache/kessel/hashes_filename.txt"))?;
-    let hash = hd.paths_matching("/resources/systemgenerated/client.gom").into_iter().map(|(h, _)| h).next().expect("client.gom not in dict");
-    for tor_path in std::fs::read_dir(&PathBuf::from("/Users/seansilvius/swtor/Assets"))?.filter_map(|e| e.ok()).map(|e| e.path()).filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false)) {
-        let mut a = match Archive::open(&tor_path) { Ok(a) => a, Err(_) => continue };
-        let entries: Vec<_> = match a.entries() { Ok(e) => e.cloned().collect(), Err(_) => continue };
+    hd.load(&PathBuf::from(
+        "/Users/seansilvius/.cache/kessel/hashes_filename.txt",
+    ))?;
+    let hash = hd
+        .paths_matching("/resources/systemgenerated/client.gom")
+        .into_iter()
+        .map(|(h, _)| h)
+        .next()
+        .expect("client.gom not in dict");
+    for tor_path in std::fs::read_dir(&PathBuf::from("/Users/seansilvius/swtor/Assets"))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false))
+    {
+        let mut a = match Archive::open(&tor_path) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+        let entries: Vec<_> = match a.entries() {
+            Ok(e) => e.cloned().collect(),
+            Err(_) => continue,
+        };
         for entry in entries {
             if entry.filename_hash == hash {
                 let data = a.read_entry(&entry)?;

--- a/kessel-discovery/src/bin/probe_typed_encoding.rs
+++ b/kessel-discovery/src/bin/probe_typed_encoding.rs
@@ -1,0 +1,101 @@
+//! Investigation probe for the typed-value encoding model.
+//!
+//! For every canonical PBUK object in spice, walk every CF40 marker.
+//! For each marker, record:
+//!   - object kind (Quest/Ability/Item/Npc/Talent/...)
+//!   - type_flags byte (the byte at position +4 after CF 40 00 00)
+//!   - property hi32 (4 bytes BE at +5..+9)
+//!   - schema type_tag + kind looked up via property_for_cf40
+//!   - first 32 bytes of value tail (the bytes after the 9-byte marker)
+//!
+//! Outputs JSON-lines to /tmp/typed-encoding-samples.jsonl so subsequent
+//! Python/SQL analysis can bucket and pattern-match.
+use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use kessel::gom_schema;
+use rusqlite::Connection;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+fn main() -> Result<()> {
+    let db = std::env::args().nth(1).unwrap_or("/tmp/spice-178.sqlite".into());
+    let out_path = std::env::args().nth(2).unwrap_or("/tmp/typed-encoding-samples.jsonl".into());
+    let conn = Connection::open(&db)?;
+
+    let mut stmt = conn.prepare(
+        "SELECT kind, fqn, json_extract(json, '$.payload_b64') \
+         FROM objects WHERE is_canonical = 1",
+    )?;
+    let rows: Vec<(String, String, Option<String>)> = stmt
+        .query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, Option<String>>(2)?,
+            ))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    eprintln!("scanning {} canonical objects", rows.len());
+
+    let mut out = BufWriter::new(File::create(&out_path)?);
+    let mut total_markers = 0u64;
+    let mut total_unresolved = 0u64;
+
+    for (kind, fqn, b64) in &rows {
+        let Some(b64) = b64 else { continue };
+        let Ok(p) = B64.decode(b64) else { continue };
+
+        let mut i = 0;
+        while i + 9 <= p.len() {
+            if !(p[i] == 0xCF && p[i + 1] == 0x40 && p[i + 2] == 0x00 && p[i + 3] == 0x00) {
+                i += 1;
+                continue;
+            }
+            let type_flags = p[i + 4];
+            let hi32_bytes: [u8; 4] = p[i + 5..i + 9].try_into().unwrap();
+            let hi32 = u32::from_be_bytes(hi32_bytes);
+            let hi32_hex = format!("{hi32:08X}");
+
+            let tail_start = i + 9;
+            let tail_end = (tail_start + 32).min(p.len());
+            let tail_hex = hex::encode_upper(&p[tail_start..tail_end]);
+
+            let (schema_kind, schema_type_tag, schema_refs) =
+                match gom_schema::property_for_cf40(hi32) {
+                    Some(prop) => {
+                        let refs = prop
+                            .refs
+                            .as_ref()
+                            .map(|r| {
+                                r.iter()
+                                    .map(|x| format!("{}:{}", x.kind, x.name))
+                                    .collect::<Vec<_>>()
+                                    .join(",")
+                            })
+                            .unwrap_or_default();
+                        (prop.kind.clone(), prop.type_tag, refs)
+                    }
+                    None => {
+                        total_unresolved += 1;
+                        (String::from("unresolved"), 0u8, String::new())
+                    }
+                };
+
+            // JSONL: one record per CF40 marker
+            writeln!(
+                out,
+                "{{\"kind\":\"{}\",\"fqn\":\"{}\",\"off\":{},\"type_flags\":\"{:02X}\",\"hi32\":\"{}\",\"schema_kind\":\"{}\",\"schema_type_tag\":\"{:02X}\",\"schema_refs\":\"{}\",\"tail32\":\"{}\"}}",
+                kind, fqn, i, type_flags, hi32_hex, schema_kind, schema_type_tag, schema_refs, tail_hex
+            )?;
+            total_markers += 1;
+            i += 9;
+        }
+    }
+    out.flush()?;
+    eprintln!(
+        "wrote {} markers ({} unresolved) to {}",
+        total_markers, total_unresolved, out_path
+    );
+    Ok(())
+}

--- a/kessel-discovery/src/bin/probe_typed_encoding.rs
+++ b/kessel-discovery/src/bin/probe_typed_encoding.rs
@@ -18,8 +18,12 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 
 fn main() -> Result<()> {
-    let db = std::env::args().nth(1).unwrap_or("/tmp/spice-178.sqlite".into());
-    let out_path = std::env::args().nth(2).unwrap_or("/tmp/typed-encoding-samples.jsonl".into());
+    let db = std::env::args()
+        .nth(1)
+        .unwrap_or("/tmp/spice-178.sqlite".into());
+    let out_path = std::env::args()
+        .nth(2)
+        .unwrap_or("/tmp/typed-encoding-samples.jsonl".into());
     let conn = Connection::open(&db)?;
 
     let mut stmt = conn.prepare(


### PR DESCRIPTION
## Summary

Investigation output per legion plan \`019e65a5\` ("the investigation IS the work"). Answers most open questions from the typed-value wiring plan with real-payload evidence (9.3M CF40 markers across 415K canonical PBUK objects).

## Headline findings

1. **The on-wire encoding tag (tail's first byte) equals the schema's type_tag in 100% of resolved markers.** The dictionary lookup IS reliable for routing.

2. **The decoder's per-tag LABELS are guesses. 5 of 9 documented labels are wrong** (matching Sean's "lots of guesses became canon for no reasons" correction):

   | tag | decoder label | actual on-wire encoding |
   |---|---|---|
   | 0x03 | int16 | **int8** (1-byte value) |
   | 0x04 | int32 | **float32** (sample values 30.0, 2.0, -1.0) |
   | 0x06 | float32 | **length-prefixed string** \`<06><u8 len><N ASCII>\` |
   | 0x07 | string | composite/wrapper (contains nested sub-tagged values) |
   | 0x12 | unknown_12 | **Vec3 of 3 LE float32** |

3. **The \`type_flags\` byte is per-property stable** (15,156/15,157 hi32s have ONE type_flags value). Carries no info beyond hi32.

## CLAUDE.md trim

Removed the "Known gaps" section that lied about per-property decode being unsolved (reflection \`019e4d75\` had solved it days before; the file rotted). Trimmed from 93 lines to 41. Added "DO NOT PUT SHIT IN HERE. RECALL/REFLECT" banner.

## What this does NOT do

- No production code change. Per the plan, code waits until investigation is conclusive enough to write a correct decoder.
- Some tags still partially understood (0x01, 0x05, 0x07, 0x08 — verified shapes are sketched, full grammars open). Subsequent investigation passes lift these.

## Artifacts

- \`docs/probes/typed-value-encoding.md\` — verified table + open questions + per-tag deep dive
- \`docs/plans/wire-typed-values.md\` — the rewritten plan (no phases, no LOC estimates, investigation-first)
- \`kessel-discovery/src/bin/probe_typed_encoding.rs\` — rerunnable probe (produces 2.5GB JSONL of marker samples)
- \`kessel-discovery/src/bin/probe_dump_client_gom.rs\` — small helper to extract client.gom from archives

## Test plan

- Doc-only PR. No code paths changed in production kessel.
- \`cargo test -p kessel\` and \`cargo clippy -p kessel -- -D warnings\` continue to pass (no changes to kessel/src/).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>