### PR TITLE
feat(abilities): widen action-params walker (11x row coverage)

### DIFF
--- a/kessel-discovery/src/bin/probe_action_grammars.rs
+++ b/kessel-discovery/src/bin/probe_action_grammars.rs
@@ -1,0 +1,110 @@
+//! Probe per-effAction byte shapes after the action enum byte.
+//!
+//! Reads abl.* objects from a spice.sqlite, finds each effAction marker
+//! (CF 40 00 00 ?? E2 51 D1 CC 05 <enum_idx>), and records the next N
+//! bytes up to the next CF40/CB/CC/CD/CE layer marker. Groups samples by
+//! effAction enum_member and writes JSONL to stdout (one record per
+//! sample) for downstream pattern mining.
+//!
+//! Usage:
+//!   probe_action_grammars <spice.sqlite> [tail_max_bytes=64] [samples_per_action=20]
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use kessel::gom_schema;
+use rusqlite::Connection;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::env;
+
+#[derive(Serialize)]
+struct Sample<'a> {
+    action: &'a str,
+    action_idx: u8,
+    fqn: &'a str,
+    effect_ord: u32,
+    tail_hex: String,
+    tail_len: usize,
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = args
+        .get(1)
+        .context("usage: probe_action_grammars <spice.sqlite> [tail_max] [samples_per]")?;
+    let tail_max: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(64);
+    let samples_per: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(20);
+
+    let eff_action_enum =
+        gom_schema::enum_for_name("effAction").context("effAction enum missing from gom_schema")?;
+
+    let conn = Connection::open(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT fqn, json_extract(json, '$.payload_b64') \
+         FROM objects WHERE fqn LIKE 'abl.%'",
+    )?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut counts: HashMap<u8, usize> = HashMap::new();
+
+    for (fqn, b64) in &rows {
+        let Ok(payload) = BASE64.decode(b64) else {
+            continue;
+        };
+        let mut effect_ord: u32 = 0;
+        let mut i = 0;
+        while i + 11 <= payload.len() {
+            let is_marker = payload[i] == 0xCF
+                && payload[i + 1] == 0x40
+                && payload[i + 2] == 0x00
+                && payload[i + 3] == 0x00
+                && payload[i + 5..i + 9] == [0xE2, 0x51, 0xD1, 0xCC]
+                && payload[i + 9] == 0x05;
+            if !is_marker {
+                i += 1;
+                continue;
+            }
+            let action_idx = payload[i + 10];
+            let action_name = eff_action_enum
+                .members
+                .get(action_idx as usize)
+                .map(String::as_str)
+                .unwrap_or("?");
+
+            let entry = counts.entry(action_idx).or_insert(0);
+            if *entry < samples_per {
+                let tail_start = i + 11;
+                let mut tail_end = (tail_start + tail_max).min(payload.len());
+                // Cut off at next layer marker (CB CC CD CE CF) — these
+                // open new typed-property or metadata records.
+                let mut k = tail_start;
+                while k < tail_end {
+                    let b = payload[k];
+                    if matches!(b, 0xCB | 0xCC | 0xCD | 0xCE | 0xCF) && k > tail_start + 1 {
+                        tail_end = k;
+                        break;
+                    }
+                    k += 1;
+                }
+                let tail = &payload[tail_start..tail_end];
+                let s = Sample {
+                    action: action_name,
+                    action_idx,
+                    fqn,
+                    effect_ord,
+                    tail_hex: hex::encode(tail),
+                    tail_len: tail.len(),
+                };
+                println!("{}", serde_json::to_string(&s)?);
+                *entry += 1;
+            }
+            effect_ord += 1;
+            i += 11;
+        }
+    }
+
+    Ok(())
+}

--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -5478,11 +5478,18 @@ impl Database {
 
     /// Populate `ability_action_params` from effAction parameter arrays.
     ///
-    /// Each effAction (CF40 E251D1CC) marker is followed by a parameter
-    /// list whose elements have the format `<effParam_idx_u8><f32_LE>`.
-    /// This populator finds the parameter array opener pattern (`08 05 04
-    /// 08 08 NN`) inside each effAction's tail and walks each `<idx><f32>`
-    /// pair until a non-decodable byte is hit.
+    /// Each effAction (CF40 E251D1CC) marker is followed by a sequence of
+    /// typed property records. Numeric (f32) parameters appear in records
+    /// of the form `[01|07] 08 05 04 <count_a:u8> <count_b:u8>
+    /// <count_a × (key_u8, f32_LE)>` -- a value-tag-04 (float32) array
+    /// keyed by an enum_ref (effParam by convention). This populator scans
+    /// each effAction's tail (up to the next CF40 marker), collects every
+    /// such f32 record found, and inserts each (key, value) pair.
+    ///
+    /// Captures float parameters across many action types
+    /// (BallisticImpulse, Heal, WeaponDamage, Stun, EnvironmentalDamage,
+    /// etc.). Int8/int16 parameter shapes have additional framing
+    /// variance and are deferred to a future populator.
     ///
     /// Returns (abilities_with_params, total_param_rows).
     pub fn populate_ability_action_params(&self) -> Result<(u64, u64)> {
@@ -5545,48 +5552,57 @@ impl Database {
                     k += 1;
                 }
                 let tail = &payload[tail_start..tail_end];
-                // Locate the param-list opener `08 05 04 08 08 <N>` and decode
-                // the <idx><f32> pairs that follow until a non-decodable byte.
+
+                // Scan tail for `[01|07] 08 05 04 <c1> <c2> <c1 × (u8,f32)>`
+                // records. Multiple records may appear per effAction; capture
+                // every one. The `[01|07] 08 05` prefix is the typed-property
+                // wrapper, 04 is the f32 value-tag, and c1 is the item count.
                 let mut p = 0;
                 while p + 6 <= tail.len() {
-                    if tail[p] == 0x08
-                        && tail[p + 1] == 0x05
-                        && tail[p + 2] == 0x04
-                        && tail[p + 3] == 0x08
-                        && tail[p + 4] == 0x08
+                    let wrapper_ok = tail[p] == 0x01 || tail[p] == 0x07;
+                    if !wrapper_ok
+                        || tail[p + 1] != 0x08
+                        || tail[p + 2] != 0x05
+                        || tail[p + 3] != 0x04
                     {
-                        // Skip the 5-byte opener + 1 count byte
-                        let mut q = p + 6;
-                        // 4-byte zero padding observed before first pair on
-                        // verified samples
-                        if q + 4 <= tail.len() && tail[q..q + 4] == [0, 0, 0, 0] {
-                            q += 4;
-                        }
-                        // Walk <idx_u8><f32_LE> pairs
-                        while q + 5 <= tail.len() {
-                            let idx = tail[q];
-                            // Heuristic: param indices are 1..200 (660 effParam
-                            // members but very few > 200 used). If byte is out
-                            // of range or looks like a marker, stop.
-                            // Stop if byte is out of plausible param-id range OR
-                            // if it looks like a layer marker (CB-CF) that opens
-                            // a new record.
-                            if !(0x01..=0xC8).contains(&idx) {
-                                break;
-                            }
-                            let f = f32::from_le_bytes(tail[q + 1..q + 5].try_into().unwrap());
-                            if !f.is_finite() || f.abs() > 1e8 {
-                                break;
-                            }
-                            params_per_fqn
-                                .entry(fqn.clone())
-                                .or_default()
-                                .push((effect_ord, idx, f));
-                            q += 5;
-                        }
-                        break; // one param array per effAction
+                        p += 1;
+                        continue;
                     }
-                    p += 1;
+                    let count = tail[p + 4] as usize;
+                    // Sanity: count_b must equal count_a in every verified
+                    // sample. Skip mismatches rather than misframe the array.
+                    if count == 0 || count > 32 || tail[p + 5] != tail[p + 4] {
+                        p += 1;
+                        continue;
+                    }
+                    let items_start = p + 6;
+                    let items_end = items_start + count * 5;
+                    if items_end > tail.len() {
+                        p += 1;
+                        continue;
+                    }
+                    let mut q = items_start;
+                    let mut all_good = true;
+                    let mut pairs: Vec<(u8, f32)> = Vec::with_capacity(count);
+                    for _ in 0..count {
+                        let idx = tail[q];
+                        let f = f32::from_le_bytes(tail[q + 1..q + 5].try_into().unwrap());
+                        if !f.is_finite() || f.abs() > 1e9 {
+                            all_good = false;
+                            break;
+                        }
+                        pairs.push((idx, f));
+                        q += 5;
+                    }
+                    if all_good {
+                        let entry = params_per_fqn.entry(fqn.clone()).or_default();
+                        for (idx, f) in pairs {
+                            entry.push((effect_ord, idx, f));
+                        }
+                        p = items_end;
+                    } else {
+                        p += 1;
+                    }
                 }
                 effect_ord += 1;
                 i += 9;


### PR DESCRIPTION
## Summary

- Replace BallisticImpulse-specific opener `08 05 04 08 08 NN` with the generalized typed-property f32-array shape: `[01|07] 08 05 04 <count_a> <count_b> <count_a × (key_u8, f32_LE)>`.
- Catches float parameters from every action type that uses the standard wrapper, not just BallisticImpulse.
- Adds `probe_action_grammars` discovery binary for further per-action grammar mining.

## Coverage uplift

| Metric                | Before | After  | Multiplier |
|-----------------------|--------|--------|------------|
| Total param rows      | 1,637  | 21,692 | 13x        |
| Abilities with params | 184    | 2,016  | 11x        |
| WeaponDamage rows     | ~0     | 287    | -          |
| Heal rows             | 0      | 149    | -          |
| Stun rows             | ~12    | 449    | 37x        |
| EnvironmentalDamage   | ~10    | 294    | 29x        |

## Out of scope

- Int8/int16 parameter shapes (val_tag 0x02/0x03) have additional framing variance (count_b semantics differ across val_tags) -- deferred to a future populator.
- effparam_name resolution accuracy: index 136 surfaces as effParam_IgnoreDualWieldModifier for Massacre but value 1.54 strongly suggests the live coefficient. Enum-member alignment is a separate investigation.

## Test plan

- [x] cargo test -p kessel --lib -- 219 passed
- [x] cargo clippy -p kessel -- -D warnings -- clean
- [x] cargo fmt --check -- clean
- [x] Re-extracted against ~/swtor/assets; verified row uplift
- [x] Spot-checked Massacre params decode to the same effParam IDs as prior populator