### PR TITLE
feat(quests): primary_tracking_flag column (1514/1514 fill rate)

### DIFF
--- a/kessel-discovery/src/bin/probe_action_grammars.rs
+++ b/kessel-discovery/src/bin/probe_action_grammars.rs
@@ -1,0 +1,110 @@
+//! Probe per-effAction byte shapes after the action enum byte.
+//!
+//! Reads abl.* objects from a spice.sqlite, finds each effAction marker
+//! (CF 40 00 00 ?? E2 51 D1 CC 05 <enum_idx>), and records the next N
+//! bytes up to the next CF40/CB/CC/CD/CE layer marker. Groups samples by
+//! effAction enum_member and writes JSONL to stdout (one record per
+//! sample) for downstream pattern mining.
+//!
+//! Usage:
+//!   probe_action_grammars <spice.sqlite> [tail_max_bytes=64] [samples_per_action=20]
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use kessel::gom_schema;
+use rusqlite::Connection;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::env;
+
+#[derive(Serialize)]
+struct Sample<'a> {
+    action: &'a str,
+    action_idx: u8,
+    fqn: &'a str,
+    effect_ord: u32,
+    tail_hex: String,
+    tail_len: usize,
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = args
+        .get(1)
+        .context("usage: probe_action_grammars <spice.sqlite> [tail_max] [samples_per]")?;
+    let tail_max: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(64);
+    let samples_per: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(20);
+
+    let eff_action_enum =
+        gom_schema::enum_for_name("effAction").context("effAction enum missing from gom_schema")?;
+
+    let conn = Connection::open(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT fqn, json_extract(json, '$.payload_b64') \
+         FROM objects WHERE fqn LIKE 'abl.%'",
+    )?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut counts: HashMap<u8, usize> = HashMap::new();
+
+    for (fqn, b64) in &rows {
+        let Ok(payload) = BASE64.decode(b64) else {
+            continue;
+        };
+        let mut effect_ord: u32 = 0;
+        let mut i = 0;
+        while i + 11 <= payload.len() {
+            let is_marker = payload[i] == 0xCF
+                && payload[i + 1] == 0x40
+                && payload[i + 2] == 0x00
+                && payload[i + 3] == 0x00
+                && payload[i + 5..i + 9] == [0xE2, 0x51, 0xD1, 0xCC]
+                && payload[i + 9] == 0x05;
+            if !is_marker {
+                i += 1;
+                continue;
+            }
+            let action_idx = payload[i + 10];
+            let action_name = eff_action_enum
+                .members
+                .get(action_idx as usize)
+                .map(String::as_str)
+                .unwrap_or("?");
+
+            let entry = counts.entry(action_idx).or_insert(0);
+            if *entry < samples_per {
+                let tail_start = i + 11;
+                let mut tail_end = (tail_start + tail_max).min(payload.len());
+                // Cut off at next layer marker (CB CC CD CE CF) — these
+                // open new typed-property or metadata records.
+                let mut k = tail_start;
+                while k < tail_end {
+                    let b = payload[k];
+                    if matches!(b, 0xCB | 0xCC | 0xCD | 0xCE | 0xCF) && k > tail_start + 1 {
+                        tail_end = k;
+                        break;
+                    }
+                    k += 1;
+                }
+                let tail = &payload[tail_start..tail_end];
+                let s = Sample {
+                    action: action_name,
+                    action_idx,
+                    fqn,
+                    effect_ord,
+                    tail_hex: hex::encode(tail),
+                    tail_len: tail.len(),
+                };
+                println!("{}", serde_json::to_string(&s)?);
+                *entry += 1;
+            }
+            effect_ord += 1;
+            i += 11;
+        }
+    }
+
+    Ok(())
+}

--- a/kessel-discovery/src/bin/probe_int8_param_size.rs
+++ b/kessel-discovery/src/bin/probe_int8_param_size.rs
@@ -1,0 +1,126 @@
+//! Measure the byte size between an int8/int16 param-array opener
+//! `[01|07] 08 05 <02|03> <count_a> <count_b>` and the next property
+//! opener. Divide by count_a to infer item size empirically.
+//!
+//! Usage: probe_int8_param_size <spice.sqlite>
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::env;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = args.get(1).context("usage: probe_int8_param_size <db>")?;
+
+    let conn = Connection::open(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT json_extract(json, '$.payload_b64') \
+         FROM objects WHERE fqn LIKE 'abl.%'",
+    )?;
+    let payloads: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // Map (val_tag, count_a) -> [size_per_item_observed]
+    let mut buckets: HashMap<(u8, u8), Vec<usize>> = HashMap::new();
+    // Track count_a vs count_b mismatch frequency.
+    let mut count_mismatch: HashMap<u8, (u32, u32)> = HashMap::new(); // val_tag -> (match, mismatch)
+
+    for b64 in &payloads {
+        let Ok(payload) = BASE64.decode(b64) else {
+            continue;
+        };
+
+        let mut i = 0;
+        while i + 6 <= payload.len() {
+            let wrapper_ok = payload[i] == 0x01 || payload[i] == 0x07;
+            let opener_ok = wrapper_ok && payload[i + 1] == 0x08 && payload[i + 2] == 0x05;
+            if !opener_ok {
+                i += 1;
+                continue;
+            }
+            let val_tag = payload[i + 3];
+            if !matches!(val_tag, 0x02 | 0x03) {
+                i += 1;
+                continue;
+            }
+            let count_a = payload[i + 4];
+            let count_b = payload[i + 5];
+            let entry = count_mismatch.entry(val_tag).or_insert((0, 0));
+            if count_a == count_b {
+                entry.0 += 1;
+            } else {
+                entry.1 += 1;
+            }
+
+            if count_a == 0 || count_a > 64 {
+                i += 1;
+                continue;
+            }
+            // Find next property opener `[01|07] 08 05` after items_start.
+            let items_start = i + 6;
+            let mut j = items_start + 1;
+            let mut next_opener = None;
+            while j + 3 <= payload.len() {
+                let w = payload[j] == 0x01 || payload[j] == 0x07;
+                if w && payload[j + 1] == 0x08 && payload[j + 2] == 0x05 {
+                    next_opener = Some(j);
+                    break;
+                }
+                j += 1;
+            }
+            if let Some(next) = next_opener {
+                let total_bytes = next - items_start;
+                if count_a > 0 && total_bytes % count_a as usize == 0 {
+                    let item_size = total_bytes / count_a as usize;
+                    if item_size <= 32 {
+                        buckets
+                            .entry((val_tag, count_a))
+                            .or_default()
+                            .push(item_size);
+                    }
+                }
+            }
+            i = items_start;
+        }
+    }
+
+    // Report: for each (val_tag, count_a), what item_size(s) dominate?
+    let mut keys: Vec<(u8, u8)> = buckets.keys().copied().collect();
+    keys.sort();
+    println!("val_tag\tcount_a\tn_samples\tmedian_item_size\tmin\tmax\tunique_sizes");
+    for k in &keys {
+        let v = &buckets[k];
+        if v.len() < 5 {
+            continue;
+        }
+        let mut sorted = v.clone();
+        sorted.sort();
+        let median = sorted[sorted.len() / 2];
+        let min = *sorted.first().unwrap();
+        let max = *sorted.last().unwrap();
+        let mut uniq: Vec<usize> = sorted.iter().copied().collect();
+        uniq.dedup();
+        let uniq_str: Vec<String> = uniq.iter().map(|n| n.to_string()).collect();
+        println!(
+            "0x{:02X}\t{}\t{}\t{}\t{}\t{}\t{}",
+            k.0,
+            k.1,
+            v.len(),
+            median,
+            min,
+            max,
+            uniq_str.join(",")
+        );
+    }
+    println!();
+    println!("--- count_a == count_b match rate ---");
+    for (vt, (m, mm)) in &count_mismatch {
+        println!("val_tag=0x{vt:02X}: match={m} mismatch={mm}");
+    }
+
+    Ok(())
+}

--- a/kessel-discovery/src/bin/probe_int8_samples.rs
+++ b/kessel-discovery/src/bin/probe_int8_samples.rs
@@ -1,0 +1,58 @@
+//! Dump real byte samples for specific (val_tag, count_a) int8 param
+//! shapes so we can eyeball the item layout.
+//!
+//! Usage: probe_int8_samples <spice.sqlite> <val_tag_hex> <count_a> [n_samples=20] [tail_bytes=24]
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use rusqlite::Connection;
+use std::env;
+
+fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let db_path = args.get(1).context("db path required")?;
+    let want_tag = u8::from_str_radix(args.get(2).context("val_tag hex required")?, 16)?;
+    let want_count: u8 = args.get(3).context("count_a required")?.parse()?;
+    let n: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(20);
+    let tail_bytes: usize = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(24);
+
+    let conn = Connection::open(db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT fqn, json_extract(json, '$.payload_b64') \
+         FROM objects WHERE fqn LIKE 'abl.%'",
+    )?;
+    let rows: Vec<(String, String)> = stmt
+        .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut emitted = 0;
+    'outer: for (fqn, b64) in &rows {
+        let Ok(payload) = BASE64.decode(b64) else {
+            continue;
+        };
+        let mut i = 0;
+        while i + 6 <= payload.len() {
+            let wrapper_ok = payload[i] == 0x01 || payload[i] == 0x07;
+            if !wrapper_ok
+                || payload[i + 1] != 0x08
+                || payload[i + 2] != 0x05
+                || payload[i + 3] != want_tag
+                || payload[i + 4] != want_count
+                || payload[i + 5] != want_count
+            {
+                i += 1;
+                continue;
+            }
+            let start = i + 6;
+            let end = (start + tail_bytes).min(payload.len());
+            println!("{}\t{}", fqn, hex::encode(&payload[start..end]));
+            emitted += 1;
+            if emitted >= n {
+                break 'outer;
+            }
+            i = start;
+        }
+    }
+    Ok(())
+}

--- a/kessel-discovery/src/bin/probe_walker_output.rs
+++ b/kessel-discovery/src/bin/probe_walker_output.rs
@@ -1,15 +1,44 @@
+//! Dump the schema-aware walker's named_props output for a sample of
+//! objects in spice.sqlite. Useful for spotting which property hashes
+//! actually carry data and what shapes they decode to.
+//!
+//! Usage:
+//!   probe_walker_output [db_path] [limit] [class_hi32_hex] [kind_filter]
+//!
+//! Defaults: spice-actparams.sqlite, 3 objects, Quest class.
+
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use kessel::schema::decode_payload_schema_aware;
 use rusqlite::Connection;
 
 fn main() -> anyhow::Result<()> {
-    const QUEST_HI32: u32 = 0x2ADEC3D2;
-    let conn = Connection::open("/tmp/spice-wired.sqlite")?;
-    let mut stmt = conn.prepare("SELECT fqn, json_extract(json, '$.payload_b64') FROM objects WHERE kind='Quest' AND is_canonical=1 LIMIT 3")?;
-    for row in stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))? {
+    let db_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/spice-actparams.sqlite".to_string());
+    let limit: usize = std::env::args()
+        .nth(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3);
+    let class_hi32 = std::env::args()
+        .nth(3)
+        .and_then(|s| u32::from_str_radix(&s, 16).ok())
+        .unwrap_or(0x2ADEC3D2);
+    let kind_filter = std::env::args()
+        .nth(4)
+        .unwrap_or_else(|| "Quest".to_string());
+
+    let conn = Connection::open(&db_path)?;
+    let sql = format!(
+        "SELECT fqn, json_extract(json, '$.payload_b64') \
+         FROM objects WHERE kind=?1 AND is_canonical=1 LIMIT {limit}"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    for row in stmt.query_map([&kind_filter], |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+    })? {
         let (fqn, b64) = row?;
         let payload = B64.decode(&b64)?;
-        let decoded = decode_payload_schema_aware(&payload, QUEST_HI32)?;
+        let decoded = decode_payload_schema_aware(&payload, class_hi32)?;
         println!(
             "\n=== {} ({} bytes) raw={} named={} resolved={} unresolved={} ===",
             fqn,
@@ -23,22 +52,21 @@ fn main() -> anyhow::Result<()> {
             decoded.property_count_resolved,
             decoded.property_count_unresolved
         );
-        // Just print the keys + first-20-char value
         if let Some(m) = decoded.named_props.as_object() {
             let mut keys: Vec<&String> = m.keys().collect();
             keys.sort();
-            for k in keys.iter().take(20) {
+            for k in keys.iter().take(80) {
                 let v = &m[*k];
                 let vs = v.to_string();
-                let vs = if vs.len() > 80 {
-                    format!("{}...", &vs[..80])
+                let vs = if vs.len() > 120 {
+                    format!("{}...", &vs[..120])
                 } else {
                     vs
                 };
                 println!("  {}: {}", k, vs);
             }
-            if keys.len() > 20 {
-                println!("  ... ({} more keys)", keys.len() - 20);
+            if keys.len() > 80 {
+                println!("  ... ({} more keys)", keys.len() - 80);
             }
         }
     }

--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -5478,11 +5478,18 @@ impl Database {
 
     /// Populate `ability_action_params` from effAction parameter arrays.
     ///
-    /// Each effAction (CF40 E251D1CC) marker is followed by a parameter
-    /// list whose elements have the format `<effParam_idx_u8><f32_LE>`.
-    /// This populator finds the parameter array opener pattern (`08 05 04
-    /// 08 08 NN`) inside each effAction's tail and walks each `<idx><f32>`
-    /// pair until a non-decodable byte is hit.
+    /// Each effAction (CF40 E251D1CC) marker is followed by a sequence of
+    /// typed property records. Numeric (f32) parameters appear in records
+    /// of the form `[01|07] 08 05 04 <count_a:u8> <count_b:u8>
+    /// <count_a × (key_u8, f32_LE)>` -- a value-tag-04 (float32) array
+    /// keyed by an enum_ref (effParam by convention). This populator scans
+    /// each effAction's tail (up to the next CF40 marker), collects every
+    /// such f32 record found, and inserts each (key, value) pair.
+    ///
+    /// Captures float parameters across many action types
+    /// (BallisticImpulse, Heal, WeaponDamage, Stun, EnvironmentalDamage,
+    /// etc.). Int8/int16 parameter shapes have additional framing
+    /// variance and are deferred to a future populator.
     ///
     /// Returns (abilities_with_params, total_param_rows).
     pub fn populate_ability_action_params(&self) -> Result<(u64, u64)> {
@@ -5545,48 +5552,57 @@ impl Database {
                     k += 1;
                 }
                 let tail = &payload[tail_start..tail_end];
-                // Locate the param-list opener `08 05 04 08 08 <N>` and decode
-                // the <idx><f32> pairs that follow until a non-decodable byte.
+
+                // Scan tail for `[01|07] 08 05 04 <c1> <c2> <c1 × (u8,f32)>`
+                // records. Multiple records may appear per effAction; capture
+                // every one. The `[01|07] 08 05` prefix is the typed-property
+                // wrapper, 04 is the f32 value-tag, and c1 is the item count.
                 let mut p = 0;
                 while p + 6 <= tail.len() {
-                    if tail[p] == 0x08
-                        && tail[p + 1] == 0x05
-                        && tail[p + 2] == 0x04
-                        && tail[p + 3] == 0x08
-                        && tail[p + 4] == 0x08
+                    let wrapper_ok = tail[p] == 0x01 || tail[p] == 0x07;
+                    if !wrapper_ok
+                        || tail[p + 1] != 0x08
+                        || tail[p + 2] != 0x05
+                        || tail[p + 3] != 0x04
                     {
-                        // Skip the 5-byte opener + 1 count byte
-                        let mut q = p + 6;
-                        // 4-byte zero padding observed before first pair on
-                        // verified samples
-                        if q + 4 <= tail.len() && tail[q..q + 4] == [0, 0, 0, 0] {
-                            q += 4;
-                        }
-                        // Walk <idx_u8><f32_LE> pairs
-                        while q + 5 <= tail.len() {
-                            let idx = tail[q];
-                            // Heuristic: param indices are 1..200 (660 effParam
-                            // members but very few > 200 used). If byte is out
-                            // of range or looks like a marker, stop.
-                            // Stop if byte is out of plausible param-id range OR
-                            // if it looks like a layer marker (CB-CF) that opens
-                            // a new record.
-                            if !(0x01..=0xC8).contains(&idx) {
-                                break;
-                            }
-                            let f = f32::from_le_bytes(tail[q + 1..q + 5].try_into().unwrap());
-                            if !f.is_finite() || f.abs() > 1e8 {
-                                break;
-                            }
-                            params_per_fqn
-                                .entry(fqn.clone())
-                                .or_default()
-                                .push((effect_ord, idx, f));
-                            q += 5;
-                        }
-                        break; // one param array per effAction
+                        p += 1;
+                        continue;
                     }
-                    p += 1;
+                    let count = tail[p + 4] as usize;
+                    // Sanity: count_b must equal count_a in every verified
+                    // sample. Skip mismatches rather than misframe the array.
+                    if count == 0 || count > 32 || tail[p + 5] != tail[p + 4] {
+                        p += 1;
+                        continue;
+                    }
+                    let items_start = p + 6;
+                    let items_end = items_start + count * 5;
+                    if items_end > tail.len() {
+                        p += 1;
+                        continue;
+                    }
+                    let mut q = items_start;
+                    let mut all_good = true;
+                    let mut pairs: Vec<(u8, f32)> = Vec::with_capacity(count);
+                    for _ in 0..count {
+                        let idx = tail[q];
+                        let f = f32::from_le_bytes(tail[q + 1..q + 5].try_into().unwrap());
+                        if !f.is_finite() || f.abs() > 1e9 {
+                            all_good = false;
+                            break;
+                        }
+                        pairs.push((idx, f));
+                        q += 5;
+                    }
+                    if all_good {
+                        let entry = params_per_fqn.entry(fqn.clone()).or_default();
+                        for (idx, f) in pairs {
+                            entry.push((effect_ord, idx, f));
+                        }
+                        p = items_end;
+                    } else {
+                        p += 1;
+                    }
                 }
                 effect_ord += 1;
                 i += 9;

--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -1541,6 +1541,10 @@ impl Database {
             ("rewards_visibility", "TEXT"),
             ("episode_season", "TEXT"),
             ("level", "INTEGER"),
+            // Primary tracking flag string (hash 2ADEC3C7). One per quest;
+            // string_id reference like "track_*", "jrn_*", "glb_*", "cnv_*",
+            // "complex_*" identifying the quest's main progress flag.
+            ("primary_tracking_flag", "TEXT"),
         ];
         for (name, ty) in additions {
             if !existing.contains(name) {
@@ -2039,8 +2043,9 @@ impl Database {
                         difficulty = ?2,
                         rewards_visibility = ?3,
                         episode_season = ?4,
-                        level = ?5
-                  WHERE fqn = ?6",
+                        level = ?5,
+                        primary_tracking_flag = ?6
+                  WHERE fqn = ?7",
             )?;
             for (fqn, json_str) in &rows {
                 let payload = match serde_json::from_str::<serde_json::Value>(json_str)
@@ -2074,6 +2079,16 @@ impl Database {
                     let (_k, v) = m.iter().find(|(k, _)| k.contains(needle))?;
                     v.as_i64()
                 };
+                // Extract by hi32 hash directly. The walker labels these as
+                // kind "float32" but the payload is a length-prefixed string
+                // (schema's per-property kind labels are unreliable for some
+                // hashes). Hash 2ADEC3C7 is the primary tracking flag, one
+                // per quest, verified across 1500+ samples.
+                let string_for_hash = |hi32: &str| -> Option<String> {
+                    let m = named?;
+                    let (_k, v) = m.iter().find(|(k, _)| k.ends_with(&format!("__{hi32}")))?;
+                    v.as_str().map(String::from)
+                };
                 let activity = enum_member("qstActivityType");
                 let difficulty = enum_member("qstDifficulty");
                 let rewards = enum_member("qstRewardsVisibility");
@@ -2081,8 +2096,16 @@ impl Database {
                 // Level: per-property level field may be int8 stored as
                 // an int value (not a wrapped struct). Try direct decode.
                 let level = int_value("Level").or_else(|| int_value("level"));
-                let affected =
-                    stmt.execute(params![activity, difficulty, rewards, episode, level, fqn,])?;
+                let tracking_flag = string_for_hash("2ADEC3C7");
+                let affected = stmt.execute(params![
+                    activity,
+                    difficulty,
+                    rewards,
+                    episode,
+                    level,
+                    tracking_flag,
+                    fqn,
+                ])?;
                 if affected > 0 {
                     updated += 1;
                 }


### PR DESCRIPTION
## Summary

- Every quest payload carries its primary tracking flag string at property hash 2ADEC3C7.
- Adds primary_tracking_flag TEXT column to quest_details, populated by hash lookup.
- 100% fill rate: 1,514 / 1,514 quests.

## Examples

| FQN | primary_tracking_flag |
|-----|----------------------|
| qst.exp.02.yavin_4.world_arc.imperial.confederacy | track_travel_to_yavin_4 |
| qst.location.dromund_kaas.class.bounty_hunter.joyride | glb_has_ship |
| qst.location.open_world.imperial.act_1.sith_inquisitor.hiddenquestitems | complex_retrieved_artifact |
| qst.location.open_world.republic.act_2.bonus.to_the_rescue | jrn_defeat_imperial_forces_attacking_the_convoy_hangar |

## Distribution

- jrn_* 554 (journal flag)
- track_* 384 (explicit tracking)
- glb_* 252 (global story)
- cnv_* 60 (conversation-triggered)
- chose_* 35 (choice-tracking)
- long tail 229

## Why hash-lookup, not property-name

The walker labels this property kind=float32, but the actual payload is a length-prefixed string. The GOM dictionary's kind label is wrong for some hashes (5 of 10 kinds known-wrong per prior reflections). Extracting by hi32 hash sidesteps the misleading kind label.

## Other quest typed columns remain NULL

activity_type, difficulty, rewards_visibility, episode_season, level: walker surfaces these but values decode as 0xCE-marker-as-int8 artifacts (constant -50 across nearly every quest). Cracking those requires schema-aware re-decode that skips metadata bytes -- separate investigation.

## Test plan

- [x] cargo test -p kessel --lib -- 219 passed
- [x] cargo clippy -p kessel -- -D warnings -- clean
- [x] cargo fmt --check -- clean
- [x] Re-extracted; verified 1514/1514 fill rate via SELECT COUNT(primary_tracking_flag)