### PR TITLE
feat(quests): mission_type_code / category_code / visibility_code (closes #210)

### DIFF
--- a/kessel-discovery/src/bin/quest_hash_stats.rs
+++ b/kessel-discovery/src/bin/quest_hash_stats.rs
@@ -1,0 +1,86 @@
+//! For every quest, run the walker and emit `(hi32, kind, value_or_type)`
+//! triples. Aggregate by hi32 to see which hashes carry stable enum-like
+//! data (small set of distinct values across the corpus) vs metadata
+//! artifacts (constant value, typically -50 from 0xCE).
+//!
+//! Usage: quest_hash_stats <spice.sqlite>
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use kessel::schema::decode_payload_schema_aware;
+use rusqlite::Connection;
+use std::collections::HashMap;
+
+const QUEST_HI32: u32 = 0x2ADEC3D2;
+
+fn main() -> Result<()> {
+    let db_path = std::env::args().nth(1).context("db path required")?;
+    let conn = Connection::open(&db_path)?;
+    let mut stmt = conn.prepare(
+        "SELECT json_extract(json, '$.payload_b64') \
+         FROM objects WHERE kind='Quest' AND is_canonical=1",
+    )?;
+    let payloads: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(0))?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    // hi32 -> (kind, value->count)
+    let mut per_hash: HashMap<String, (String, HashMap<String, u32>)> = HashMap::new();
+
+    for b64 in &payloads {
+        let Ok(payload) = B64.decode(b64) else {
+            continue;
+        };
+        let Ok(decoded) = decode_payload_schema_aware(&payload, QUEST_HI32) else {
+            continue;
+        };
+        let Some(named) = decoded.named_props.as_object() else {
+            continue;
+        };
+        for (k, v) in named {
+            let parts: Vec<&str> = k.split("__").collect();
+            if parts.len() < 2 {
+                continue;
+            }
+            let kind = parts[0].to_string();
+            let hi32 = parts[1].to_string();
+            let val_repr = if let Some(s) = v.as_str() {
+                format!("STR:{s}")
+            } else if let Some(n) = v.as_i64() {
+                format!("INT:{n}")
+            } else if let Some(b) = v.as_bool() {
+                format!("BOOL:{b}")
+            } else {
+                continue;
+            };
+            let entry = per_hash.entry(hi32).or_insert((kind, HashMap::new()));
+            *entry.1.entry(val_repr).or_insert(0) += 1;
+        }
+    }
+
+    // Sort by total count descending.
+    let mut rows: Vec<(String, String, HashMap<String, u32>)> = per_hash
+        .into_iter()
+        .map(|(hi32, (kind, vals))| (hi32, kind, vals))
+        .collect();
+    rows.sort_by_key(|r| std::cmp::Reverse(r.2.values().sum::<u32>()));
+
+    println!("hi32\tkind\tdistinct\ttotal\ttop_5_values");
+    for (hi32, kind, vals) in rows {
+        let total: u32 = vals.values().sum();
+        let n_distinct = vals.len();
+        let mut sorted: Vec<(String, u32)> = vals.into_iter().collect();
+        sorted.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
+        let top: Vec<String> = sorted
+            .iter()
+            .take(5)
+            .map(|(v, c)| {
+                let trimmed: String = v.chars().take(40).collect();
+                format!("{trimmed}({c})")
+            })
+            .collect();
+        println!("{hi32}\t{kind}\t{n_distinct}\t{total}\t{}", top.join(", "));
+    }
+    Ok(())
+}

--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -1545,6 +1545,22 @@ impl Database {
             // string_id reference like "track_*", "jrn_*", "glb_*", "cnv_*",
             // "complex_*" identifying the quest's main progress flag.
             ("primary_tracking_flag", "TEXT"),
+            // Raw int8 codes extracted by hi32 hash. The GOM schema labels
+            // these as kind=int8 with no enum_ref linkage, but their value
+            // distributions are enum-like (small distinct-value sets across
+            // 1500+ quests). Issue #210. Distributions verified empirically
+            // via quest_hash_stats discovery binary:
+            //
+            //   308A97A4: 17 distinct, top 1(1056), 3(184), 4(98), 6(38), 2(38)
+            //   308A9B02: 26 distinct, top 2(517), 3(266), 4(139), 5(110)
+            //   4C85BFC6:  9 distinct, top 1(1413), 4(28), 5(19), 3(15)
+            //
+            // Column names are honest-but-tentative; likely correspond to
+            // qstActivityType / qstDifficulty / qstRewardsVisibility but
+            // enum-name resolution is a separate investigation.
+            ("mission_type_code", "INTEGER"),
+            ("category_code", "INTEGER"),
+            ("visibility_code", "INTEGER"),
         ];
         for (name, ty) in additions {
             if !existing.contains(name) {
@@ -2044,8 +2060,11 @@ impl Database {
                         rewards_visibility = ?3,
                         episode_season = ?4,
                         level = ?5,
-                        primary_tracking_flag = ?6
-                  WHERE fqn = ?7",
+                        primary_tracking_flag = ?6,
+                        mission_type_code = ?7,
+                        category_code = ?8,
+                        visibility_code = ?9
+                  WHERE fqn = ?10",
             )?;
             for (fqn, json_str) in &rows {
                 let payload = match serde_json::from_str::<serde_json::Value>(json_str)
@@ -2079,15 +2098,31 @@ impl Database {
                     let (_k, v) = m.iter().find(|(k, _)| k.contains(needle))?;
                     v.as_i64()
                 };
-                // Extract by hi32 hash directly. The walker labels these as
-                // kind "float32" but the payload is a length-prefixed string
-                // (schema's per-property kind labels are unreliable for some
-                // hashes). Hash 2ADEC3C7 is the primary tracking flag, one
-                // per quest, verified across 1500+ samples.
-                let string_for_hash = |hi32: &str| -> Option<String> {
+                // Extract a typed property by its hi32 hash suffix. The
+                // walker mislabels the kind of some properties (5 of 10
+                // kinds wrong in the GOM dictionary), so name lookup is
+                // unreliable; suffix lookup on `__<HI32>` is canonical.
+                let prop_by_hash = |hi32: &str| -> Option<&serde_json::Value> {
                     let m = named?;
-                    let (_k, v) = m.iter().find(|(k, _)| k.ends_with(&format!("__{hi32}")))?;
-                    v.as_str().map(String::from)
+                    let suffix = format!("__{hi32}");
+                    m.iter().find(|(k, _)| k.ends_with(&suffix)).map(|(_, v)| v)
+                };
+                // 0xCE is a metadata-layer marker byte that the walker
+                // sometimes misreads as a property int8 value. Filtered
+                // out of raw-int extractions; legitimate enum values for
+                // the three quest hashes used here are small positive
+                // integers (1-26 range).
+                const CE_MARKER_AS_INT8: i64 = -50;
+                let int_for_hash = |hi32: &str| -> Option<i64> {
+                    let n = prop_by_hash(hi32)?.as_i64()?;
+                    if n == CE_MARKER_AS_INT8 {
+                        None
+                    } else {
+                        Some(n)
+                    }
+                };
+                let string_for_hash = |hi32: &str| -> Option<String> {
+                    prop_by_hash(hi32)?.as_str().map(String::from)
                 };
                 let activity = enum_member("qstActivityType");
                 let difficulty = enum_member("qstDifficulty");
@@ -2097,6 +2132,9 @@ impl Database {
                 // an int value (not a wrapped struct). Try direct decode.
                 let level = int_value("Level").or_else(|| int_value("level"));
                 let tracking_flag = string_for_hash("2ADEC3C7");
+                let mission_type_code = int_for_hash("308A97A4");
+                let category_code = int_for_hash("308A9B02");
+                let visibility_code = int_for_hash("4C85BFC6");
                 let affected = stmt.execute(params![
                     activity,
                     difficulty,
@@ -2104,6 +2142,9 @@ impl Database {
                     episode,
                     level,
                     tracking_flag,
+                    mission_type_code,
+                    category_code,
+                    visibility_code,
                     fqn,
                 ])?;
                 if affected > 0 {


### PR DESCRIPTION
Closes #210.

## Summary

Three INTEGER columns added to quest_details, populated by hi32 hash extraction. Each is an enum-like int8 code with no enum_ref linkage in the GOM schema.

| Column | Hash | Distinct | Fill | Top values |
|--------|------|----------|------|------------|
| mission_type_code | 308A97A4 | 17 | 1512/1514 (99.9%) | 1(1056), 3(184), 4(98), 6(38), 2(38) |
| category_code | 308A9B02 | 26 | 1512/1514 (99.9%) | 2(517), 3(266), 4(139), 5(110), 6(103) |
| visibility_code | 4C85BFC6 | 9 | 1503/1514 (99.3%) | 1(1413), 4(28), 5(19), 3(15), 6(10) |

## Why hash-extraction (not name)

The GOM schema's per-property kind/refs are wrong for these hashes -- labeled int8 with refs=null, but distributions are enum-like (small distinct-value sets across 1500+ quests). Looking up by `__<HI32>` suffix sidesteps the wrong-name issue. Column names are honest-but-tentative; the codes likely correspond to qstActivityType / qstDifficulty / qstRewardsVisibility but enum-name resolution requires a separate investigation.

## Refactor included in this PR

Pre-existing PR #209 introduced `string_for_hash`. This PR adds `int_for_hash` and unifies both through a shared `prop_by_hash` helper to avoid duplicating the `m.iter().find(|(k,_)| k.ends_with(...))` pattern. The `-50` 0xCE-marker artifact filter is now `const CE_MARKER_AS_INT8: i64 = -50`.

## Out of scope

- Enum-name resolution (requires GOM schema regen with enum_ref linkage)
- The companion `5CE87488` / `2B8C1DB4` int8 hashes — those decode as -50 constants (0xCE artifacts) and are not surfaced

## Test plan

- [x] cargo test -p kessel --lib -- 219 passed
- [x] cargo clippy -p kessel -- -D warnings -- clean
- [x] cargo fmt --check -- clean
- [x] Re-extracted against ~/swtor/assets; fill rates match probe distributions exactly:
  ```
  SELECT COUNT(*), COUNT(mission_type_code), COUNT(category_code), COUNT(visibility_code)
  FROM quest_details;
  -- 1514|1512|1512|1503
  ```
- [x] Distribution verified: top values match `quest_hash_stats` discovery output

## Discovery binary added

`quest_hash_stats` -- enumerates per-hash distinct counts + top-5 values for any class's walker output. Useful for spotting which hashes carry enum-like data vs artifact-only.