### PR TITLE
feat(disciplines): icon-apc fallback for 3 source-data gaps

### DIFF
--- a/kessel-discovery/src/bin/scan_missing_apc.rs
+++ b/kessel-discovery/src/bin/scan_missing_apc.rs
@@ -1,0 +1,113 @@
+//! Scan raw .tor PBUK rows for the 3 specific apc.* FQNs that are missing
+//! from kessel's current extraction (causing discipline icon/mod_tree gaps
+//! for Shadow Kinetic Combat, Shadow Serenity, Commando Gunnery).
+//!
+//! Answers: are these FQNs in the source archive but dropped during
+//! extraction (kessel bug), or absent from the source entirely (Bioware
+//! data gap that needs a fallback)?
+//!
+//! Usage: scan_missing_apc -i ~/swtor/assets -H ~/swtor/data/hashes_filename.txt
+
+use anyhow::Result;
+use kessel::hash::HashDictionary;
+use kessel::myp::Archive;
+use kessel::pbuk;
+use std::path::PathBuf;
+
+const TARGETS: &[&str] = &[
+    "apc.jedi_consular.shadow.combat",
+    "apc.jedi_consular.shadow.combat_mods", // present (sanity)
+    "apc.jedi_consular.shadow.serenity",    // present (sanity)
+    "apc.jedi_consular.shadow.serenity_mods",
+    "apc.trooper.commando.gunnery", // present (sanity)
+    "apc.trooper.commando.gunnery_mods",
+    // Also probe for kinetic_combat variant naming
+    "apc.jedi_consular.shadow.kinetic_combat",
+    "apc.jedi_consular.shadow.kinetic_combat_mods",
+];
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut input_dir = PathBuf::from(".");
+    let mut hash_path: Option<PathBuf> = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-i" | "--input" => {
+                input_dir = PathBuf::from(&args[i + 1]);
+                i += 2;
+            }
+            "-H" | "--hashes" => {
+                hash_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    let hash_path = hash_path.unwrap_or_else(|| input_dir.join("hashes_filename.txt"));
+    let mut hashes = HashDictionary::new();
+    hashes.load(&hash_path)?;
+
+    let tor_files: Vec<_> = std::fs::read_dir(&input_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "tor"))
+        .collect();
+    eprintln!(
+        "Scanning {} .tor files for {} target FQNs",
+        tor_files.len(),
+        TARGETS.len()
+    );
+
+    let mut hits: std::collections::HashMap<&'static str, Vec<String>> =
+        std::collections::HashMap::new();
+    for t in TARGETS {
+        hits.insert(*t, Vec::new());
+    }
+
+    for tor_path in &tor_files {
+        let Ok(mut archive) = Archive::open(tor_path) else {
+            continue;
+        };
+        let entries: Vec<_> = match archive.entries() {
+            Ok(it) => it.cloned().collect(),
+            Err(_) => continue,
+        };
+        for entry in &entries {
+            let path = match hashes.get(entry.filename_hash) {
+                Some(p) => p.clone(),
+                None => continue,
+            };
+            if !path.contains("/buckets/") || !path.ends_with(".bkt") {
+                continue;
+            }
+            let Ok(data) = archive.read_entry(entry) else {
+                continue;
+            };
+            let Ok(objects) = pbuk::parse(&data) else {
+                continue;
+            };
+            for obj in &objects {
+                for t in TARGETS {
+                    if obj.fqn == *t || obj.fqn.starts_with(&format!("{t}/")) {
+                        hits.get_mut(*t).unwrap().push(format!(
+                            "{}/{}",
+                            tor_path.file_name().unwrap().to_string_lossy(),
+                            obj.fqn
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    println!("\n--- Scan results ---");
+    for t in TARGETS {
+        let h = hits.get(t).unwrap();
+        println!("  {} hit(s) for {}", h.len(), t);
+        for line in h.iter().take(3) {
+            println!("    {line}");
+        }
+    }
+    Ok(())
+}

--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -5554,6 +5554,29 @@ impl Database {
             rows
         };
 
+        // Build fqn -> game_id lookup for combat-style `base` apc objects.
+        // Used as fallback when a discipline's icon_apc GUID doesn't resolve
+        // (verified gap: 3 disciplines reference apc objects absent from the
+        // game's .tor archives -- shadow.combat icon, shadow.serenity_mods,
+        // commando.gunnery_mods. scan_missing_apc found 0 archive hits for
+        // those specific FQNs.). The combat-style's base apc is a workable
+        // placeholder icon for huttspawn rendering; the mod_tree case has no
+        // sensible fallback and stays NULL.
+        let base_apc_lookup: std::collections::HashMap<String, String> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT fqn, game_id FROM objects \
+                 WHERE fqn LIKE 'apc.%.base' AND is_canonical = 1",
+            )?;
+            let rows: std::collections::HashMap<String, String> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
 
@@ -5620,7 +5643,20 @@ impl Database {
                     continue;
                 };
 
-                let icon_game_id = guid_to_game_id.get(&record.icon_apc_guid);
+                // Resolve icon and mod_tree GUIDs. When the icon GUID is
+                // unresolved (source-data gap), fall back to the combat
+                // style's `apc.<origin>.<style>.base` placeholder so
+                // downstream renderers always have something to display.
+                // fqn_prefix is `abl.<origin>.skill.<disc>`; segment 1 is
+                // the origin.
+                let icon_game_id: Option<String> = guid_to_game_id
+                    .get(&record.icon_apc_guid)
+                    .cloned()
+                    .or_else(|| {
+                        let origin = fqn_prefix.split('.').nth(1)?;
+                        let fallback_fqn = format!("apc.{origin}.{combat_style}.base");
+                        base_apc_lookup.get(&fallback_fqn).cloned()
+                    });
                 let mod_tree_game_id = guid_to_game_id.get(&record.mod_tree_apc_guid);
                 let signature_game_id = guid_to_game_id.get(&record.signature_ability_guid);
 


### PR DESCRIPTION
Empirically solves the "3 disciplines missing apc refs" gap I flagged in the discipline audit.

## Root cause (verified)

Bioware's `dis.*` payloads reference apc GUIDs for 3 disciplines that don't exist in any .tor archive. Verified with new `scan_missing_apc` discovery binary:

```
Scanning 101 .tor files for 8 target FQNs
  0 hit(s) for apc.jedi_consular.shadow.combat       ← missing (icon)
  1 hit(s) for apc.jedi_consular.shadow.combat_mods
  1 hit(s) for apc.jedi_consular.shadow.serenity
  0 hit(s) for apc.jedi_consular.shadow.serenity_mods ← missing (mod_tree)
  1 hit(s) for apc.trooper.commando.gunnery
  0 hit(s) for apc.trooper.commando.gunnery_mods     ← missing (mod_tree)
```

Not a kessel extraction bug — upstream Bioware data has dangling refs.

## Fix

When the discipline's icon GUID doesn't resolve, fall back to the combat-style's `apc.<origin>.<style>.base` placeholder (e.g. `apc.jedi_consular.shadow.base`). Less precise than per-discipline icon, but better than NULL for huttspawn rendering.

mod_tree intentionally stays NULL when missing — using a sibling discipline's mod tree would be actively misleading (different mod choices per discipline).

## Coverage

| Column | Before | After |
|--------|--------|-------|
| icon_apc_game_id | 47/48 | **48/48 (100%)** |
| mod_tree_apc_game_id | 46/48 | 46/48 (unchanged) |
| signature_ability_game_id | 48/48 | 48/48 |
| codename | 48/48 | 48/48 |

## Verification

The previously-missing `jedi_consular/combat` now has icon = `apc.jedi_consular.shadow.base` (fallback) and existing mod_tree = `apc.jedi_consular.shadow.combat_mods`.

## Out of scope

- 2 mod_tree NULLs (Shadow Serenity, Commando Gunnery): legitimate source gaps with no good fallback.
- Discipline codename oddities (e.g. jedi_consular/combat row has codename "sent_combat"): separate investigation; the dis.shadow.combat payload encodes that string — Bioware's internal naming, not a kessel bug.

## Test plan

- [x] cargo test -p kessel --lib — 219 passed
- [x] cargo clippy -p kessel -- -D warnings — clean
- [x] cargo fmt --check — clean
- [x] Re-extracted; verified icon 48/48, mod_tree 46/48 (unchanged), the 3 flagged disciplines have icon populated
- [x] Refactor pre-push: removed a dead `base_fqn` lookup in the fallback closure (would never match — entries are `apc.<origin>.<class>.base`, not `apc.<class>.base`)