### PR TITLE
chore(release): v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-05-29
+
 ### Added
 
 - **Prototype-decode data tables** -- `conquest_events` (event roster: names + planets + invasion/themed kind), `conquest_schedule` (496-week conquest rotation, `week_ordinal` -> `event_ordinal` joining `conquest_events`; relative weeks, no calendar anchor), `companions` (full `npc.companion.*` roster, ~287 rows, display names + class/source category), `armor_classes` (9-class taxonomy from `cbtArmorTablePrototype`), `stat_curve_values` (raw per-level shield curve floats from `cbtShieldPerLevel`, grouped by `curve_hash`), and `gsf_crew` (Galactic Starfighter crew from `scffCrewPrototype`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "kessel"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "base64",

--- a/kessel/Cargo.toml
+++ b/kessel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kessel"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 license.workspace = true
 description = "SWTOR data miner - extracts game objects from .tor archives"


### PR DESCRIPTION
## Release v0.0.6 — huttspawn A1 spice

Cuts the release for the clean A1 data shipment. Bumps `kessel` 0.0.5 → 0.0.6 and finalizes `CHANGELOG` `[Unreleased]` → `[0.0.6] - 2026-05-29`.

### Highlights since 0.0.5
- **New prototype-decode tables:** `conquest_events` (90), `conquest_schedule` (496-week rotation), `companions` (287), `armor_classes` (9), `stat_curve_values` (26,166), `gsf_crew` (51).
- **Schema cleanup:** 8 redundant/dead tables dropped (`quest_rewards`, `item_schema_details`, `talent_effects`, `meta` + 4 foundation placeholders) — zero data loss, **65 tables** total.
- Plus the typed-decode / discipline / identity-model work captured in the changelog.

### Verified
- Fresh complete extraction off this branch: `PRAGMA integrity_check` = ok, 65 tables, 409,769 objects, all new tables populated.
- 230 lib tests pass, clippy -D warnings + fmt clean.

After merge: tag `v0.0.6`.

### Downstream
huttspawn must repoint `quest_rewards` → `mission_rewards` and `item_schema_details` → `item_details` (bullpen heads-up posted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)