### PR TITLE
feat(items): item itemization tables (rating, budget, modifier packages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Cargo semver](https://doc.rust-lang.org/cargo/reference/semver.
 
 ## [Unreleased]
 
+### Added
+
+- **Item itemization tables** -- `item_rating_table` (`item_level` x `quality` -> `rating`, 2,010 rows), `item_budget_table` (`quality` x `item_level` x `permille` 0..999 -> stat budget `value`, ~800k rows), and `item_modifier_packages` (`mod_id` -> per-stat `permille` split, 3,635 rows). SWTOR item stats are computed, not stored per item: an item carries only `(base level, quality, modifierSetID)`, and these three tables turn that into numbers (`rating = item_rating_table[level][quality]`; `stat = item_budget_table[quality][level][permille]`, where the item's modifier package supplies each stat's permille index into the budget curve). Decoded from the `itmRatingTablePrototype` / `itmBudgetedAttributesPrototype` / `itmModifierPackageTablePrototype` singletons via a new typed-value GOM reader (`gom_reader`) that mirrors the reference `GomBinaryReader`/`ScriptObjectReader` grammar (variable-width number codec + inline type tags; DOM-free because the stream is self-describing). Oracle-verified: `budget[artifact][89]` reproduces the known relic magnitudes 484 and 167. The per-item link (materializing each item's own `modifierSetID` onto these tables) is a separate follow-up.
+
 ## [0.0.6] - 2026-05-29
 
 ### Added

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -558,6 +558,47 @@ JOIN schematic_materials sm ON sm.schematic_fqn = s.schematic_fqn
 WHERE s.schematic_fqn = 'itm.schem.gen.quest_imp.rdps1.chest.heavy.premium.03x1_craft';
 ```
 
+### item_rating_table / item_budget_table / item_modifier_packages
+
+SWTOR item stats are *computed*, not stored per item. An item object carries only three inputs (base level, quality, modifier-set id); these three lookup tables turn that into numbers. They are decoded from the `itmRatingTablePrototype` / `itmBudgetedAttributesPrototype` / `itmModifierPackageTablePrototype` singletons via the typed-value GOM reader (`kessel::gom_reader`).
+
+The formula:
+
+```
+rating = item_rating_table[item_level][quality]
+stat_s = item_budget_table[quality][item_level][ package.permille(s) ]
+```
+
+`item_rating_table` -- 2,010 rows (201 levels x 10 qualities).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `item_level` | INTEGER | Item level 0..200. |
+| `quality` | TEXT | `cheap`, `standard`, `premium`, `prototype`, `artifact`, `legendary`, `legacy`, `quest`, `currency`, `moddable`. |
+| `rating` | INTEGER | Item rating for that level+quality. PK `(item_level, quality)`. |
+
+`item_budget_table` -- ~800k rows (4 qualities x ~200 levels x 1000 permille slots).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `quality` | TEXT | `premium`, `prototype`, `artifact`, `legendary` (the only qualities the budget curve carries). |
+| `item_level` | INTEGER | Item level (list position 0..199). |
+| `permille` | INTEGER | Budget slot index 0..999 (0.1% steps); a modifier package selects which permille feeds each stat. |
+| `value` | INTEGER | Stat budget at that slot. PK `(quality, item_level, permille)`. |
+
+`item_modifier_packages` -- 3,635 rows. The stat split per modifier set.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `mod_id` | INTEGER | Modifier set id (an item's `itmModifierSetID`). |
+| `stat_index` | INTEGER | STAT enum index (zero-based). |
+| `stat_name` | TEXT | STAT enum member name, e.g. `STAT_att_mastery`, `STAT_att_endurance`. |
+| `permille` | INTEGER | Permille this stat receives from the slot budget. PK `(mod_id, stat_index)`. |
+
+**Oracle:** `item_budget_table` at `quality='artifact'`, `item_level=89` contains the known artifact relic magnitudes 484 and 167.
+
+**Known gap (follow-up):** the per-item link is not yet materialized -- kessel does not yet emit each item's own `(item_level, quality, modifierSetID)` columns, so joining a specific `itm.*` row to these tables requires that decode (item object payloads are CF40-marker structured, unlike the clean singletons).
+
 ---
 
 ## Conversation tables

--- a/kessel-discovery/src/bin/verify_item_itemization.rs
+++ b/kessel-discovery/src/bin/verify_item_itemization.rs
@@ -28,7 +28,11 @@ fn singleton(conn: &Connection, fqn: &str) -> Result<Vec<u8>> {
 fn quality_name(idx: i64) -> Option<String> {
     let e = kessel::gom_schema::enum_for_name("itmQuality")?;
     let m = e.members.get(usize::try_from(idx).ok()?)?;
-    Some(m.strip_prefix("itmQuality").unwrap_or(m).to_ascii_lowercase())
+    Some(
+        m.strip_prefix("itmQuality")
+            .unwrap_or(m)
+            .to_ascii_lowercase(),
+    )
 }
 
 fn stat_name(idx: i64) -> Option<String> {

--- a/kessel-discovery/src/bin/verify_item_itemization.rs
+++ b/kessel-discovery/src/bin/verify_item_itemization.rs
@@ -1,0 +1,121 @@
+//! Oracle check for the item itemization decode. Opens the canonical v22 DB
+//! read-only, pulls the three prototype singletons, decodes them with the
+//! production `kessel::gom_reader`, and asserts the known truths:
+//!   - budget[artifact][89] contains 484 and 167 (a real artifact relic)
+//!   - rating and modifier-package tables are non-empty and well-shaped
+//!
+//! Read-only: never writes to the DB, never copies it. Run with:
+//!   cargo run -p kessel-discovery --bin verify_item_itemization
+
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use kessel::gom_reader::{read_first_field, GomValue};
+use rusqlite::{Connection, OpenFlags};
+
+const DB: &str = "/Users/seansilvius/swtor/data/spice.sqlite";
+
+fn singleton(conn: &Connection, fqn: &str) -> Result<Vec<u8>> {
+    let b64: String = conn
+        .query_row(
+            "SELECT payload_b64 FROM singletons WHERE fqn = ?1",
+            [fqn],
+            |r| r.get(0),
+        )
+        .with_context(|| format!("singleton {fqn} not found"))?;
+    Ok(BASE64.decode(b64)?)
+}
+
+fn quality_name(idx: i64) -> Option<String> {
+    let e = kessel::gom_schema::enum_for_name("itmQuality")?;
+    let m = e.members.get(usize::try_from(idx).ok()?)?;
+    Some(m.strip_prefix("itmQuality").unwrap_or(m).to_ascii_lowercase())
+}
+
+fn stat_name(idx: i64) -> Option<String> {
+    let e = kessel::gom_schema::enum_for_name("STAT")?;
+    e.members.get(usize::try_from(idx).ok()?).cloned()
+}
+
+fn main() -> Result<()> {
+    let conn = Connection::open_with_flags(DB, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+
+    // -- Rating --
+    let rating = read_first_field(&singleton(&conn, "itmRatingTablePrototype")?)?;
+    let mut rating_rows = 0usize;
+    for (_lvl, inner) in rating.as_map().unwrap_or(&[]) {
+        rating_rows += inner.as_map().map_or(0, |m| m.len());
+    }
+    println!("rating rows: {rating_rows}");
+
+    // -- Budget: find artifact, level 89, scan for 484 and 167 --
+    let budget = read_first_field(&singleton(&conn, "itmBudgetedAttributesPrototype")?)?;
+    let mut budget_rows = 0usize;
+    let mut has_484 = false;
+    let mut has_167 = false;
+    for (q_key, levels) in budget.as_map().unwrap_or(&[]) {
+        let (Some(q), Some(level_list)) = (q_key.as_i64(), levels.as_list()) else {
+            continue;
+        };
+        let qname = quality_name(q).unwrap_or_default();
+        for (level, slots) in level_list.iter().enumerate() {
+            let slot_list = slots.as_list().unwrap_or(&[]);
+            budget_rows += slot_list.len();
+            if qname == "artifact" && level == 89 {
+                for v in slot_list {
+                    match v.as_i64() {
+                        Some(484) => has_484 = true,
+                        Some(167) => has_167 = true,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    println!("budget rows: {budget_rows}");
+    println!("budget[artifact][89] has 484: {has_484}, has 167: {has_167}");
+
+    // -- Modifier packages: count splits, print one example --
+    let modpkg = read_first_field(&singleton(&conn, "itmModifierPackageTablePrototype")?)?;
+    let mut modpkg_rows = 0usize;
+    let mut example: Option<String> = None;
+    for (mod_key, pkg_val) in modpkg.as_map().unwrap_or(&[]) {
+        let Some(mod_id) = mod_key.as_i64() else {
+            continue;
+        };
+        let pkg = match pkg_val {
+            GomValue::List(items) => items.first(),
+            other @ GomValue::Embedded(_) => Some(other),
+            _ => None,
+        };
+        let Some(pct_map) = pkg
+            .and_then(GomValue::embedded_first_map)
+            .and_then(GomValue::as_map)
+        else {
+            continue;
+        };
+        let mut split: Vec<String> = Vec::new();
+        for (stat_key, pct_val) in pct_map {
+            let (Some(si), Some(p)) = (stat_key.as_i64(), pct_val.as_i64()) else {
+                continue;
+            };
+            modpkg_rows += 1;
+            if p > 0 {
+                split.push(format!("{}={}", stat_name(si).unwrap_or_default(), p));
+            }
+        }
+        if example.is_none() && split.len() >= 2 {
+            example = Some(format!("mod {mod_id}: {}", split.join(" + ")));
+        }
+    }
+    println!("modifier-package rows: {modpkg_rows}");
+    if let Some(ex) = example {
+        println!("example split: {ex}");
+    }
+
+    let ok = rating_rows > 0 && budget_rows > 0 && modpkg_rows > 0 && has_484 && has_167;
+    println!("\nVERDICT: {}", if ok { "WORKS" } else { "FAILED" });
+    if !ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/kessel/src/db.rs
+++ b/kessel/src/db.rs
@@ -796,6 +796,47 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_companions_category ON companions(category);
             CREATE INDEX IF NOT EXISTS idx_companions_name ON companions(name);
 
+            -- Item itemization tables. SWTOR item stats are computed, not
+            -- stored per item: an item carries only (base level, quality,
+            -- modifier set id), and these three tables turn that into numbers.
+            -- Decoded from the itmRatingTablePrototype /
+            -- itmBudgetedAttributesPrototype / itmModifierPackageTablePrototype
+            -- singletons via the typed-value GOM grammar (gom_reader).
+            --
+            --   rating = item_rating_table[item_level][quality]
+            --   stat   = item_budget_table[quality][item_level][permille]
+            -- where the item's modifier package (item_modifier_packages, keyed
+            -- by itmModifierSetID) supplies the per-stat permille index into
+            -- the budget curve. Oracle: budget[artifact][89] holds 484 and 167.
+            CREATE TABLE IF NOT EXISTS item_rating_table (
+                item_level INTEGER NOT NULL,
+                quality    TEXT NOT NULL,
+                rating     INTEGER NOT NULL,
+                PRIMARY KEY (item_level, quality)
+            );
+
+            -- Per-quality, per-level budget curve. permille is the 0..999 slot
+            -- index (0.1% steps); a modifier package picks which permille feeds
+            -- each stat. ~796k rows (4 qualities x ~199 levels x 1000 slots).
+            CREATE TABLE IF NOT EXISTS item_budget_table (
+                quality    TEXT NOT NULL,
+                item_level INTEGER NOT NULL,
+                permille   INTEGER NOT NULL,
+                value      INTEGER NOT NULL,
+                PRIMARY KEY (quality, item_level, permille)
+            );
+
+            -- Modifier package stat split. One row per (mod_id, stat): the
+            -- permille of the slot budget that stat receives (single-stat mods
+            -- = 1000; a 70/30 DPS armoring = strength 700 + endurance 300).
+            CREATE TABLE IF NOT EXISTS item_modifier_packages (
+                mod_id     INTEGER NOT NULL,
+                stat_index INTEGER NOT NULL,
+                stat_name  TEXT NOT NULL,
+                permille   INTEGER NOT NULL,
+                PRIMARY KEY (mod_id, stat_index)
+            );
+
             -- Mission NPCs: NPC references aggregated across a mission's
             -- entire phase tree. For qst-source missions this is the quest's
             -- own NPCs (same as quest_npcs). For mpn-prefix missions (alliance
@@ -5492,6 +5533,146 @@ impl Database {
         }
         tx.commit()?;
         Ok(inserted)
+    }
+
+    /// Populate the three item itemization tables from the rating, budget, and
+    /// modifier-package prototype singletons. SWTOR item stats are computed
+    /// from these (see the schema comment): rating from item_rating_table,
+    /// the stat budget pool from item_budget_table, and the per-stat split
+    /// from item_modifier_packages. Returns (rating, budget, modpkg) counts.
+    ///
+    /// Shapes (decoded with the typed-value GOM grammar):
+    ///   itmRatings              = Map<level, Map<quality, rating>>
+    ///   itmBudgetedAttributes   = Map<quality, List[level]<List[permille]<i64>>>
+    ///   itmModifierPackagesList = Map<mod_id, List<{..., itmModPkgAttributePercentages: Map<stat, permille>}>>
+    pub fn populate_item_itemization(&self) -> Result<(u64, u64, u64)> {
+        self.flush()?;
+        use crate::gom_reader::{read_first_field, GomValue};
+
+        // itmQuality enum index -> short quality key ("artifact", ...).
+        let quality_name = |idx: i64| -> Option<String> {
+            let e = crate::gom_schema::enum_for_name("itmQuality")?;
+            let m = e.members.get(usize::try_from(idx).ok()?)?;
+            Some(
+                m.strip_prefix("itmQuality")
+                    .unwrap_or(m)
+                    .to_ascii_lowercase(),
+            )
+        };
+        // STAT enum index -> full STAT_* member name.
+        let stat_name = |idx: i64| -> Option<String> {
+            let e = crate::gom_schema::enum_for_name("STAT")?;
+            e.members.get(usize::try_from(idx).ok()?).cloned()
+        };
+
+        // Load all payloads before taking the connection lock
+        // (load_singleton_payload locks internally).
+        let rating_payload = self.load_singleton_payload("itmRatingTablePrototype");
+        let budget_payload = self.load_singleton_payload("itmBudgetedAttributesPrototype");
+        let modpkg_payload = self.load_singleton_payload("itmModifierPackageTablePrototype");
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let (mut n_rating, mut n_budget, mut n_modpkg) = (0u64, 0u64, 0u64);
+
+        // -- Rating: Map<level, Map<quality, rating>> --
+        if let Some(payload) = &rating_payload {
+            let table = read_first_field(payload)?;
+            tx.execute("DELETE FROM item_rating_table", [])?;
+            let mut insert = tx.prepare_cached(
+                "INSERT OR REPLACE INTO item_rating_table (item_level, quality, rating) \
+                 VALUES (?1, ?2, ?3)",
+            )?;
+            for (level_key, inner) in table.as_map().unwrap_or(&[]) {
+                let (Some(level), Some(qmap)) = (level_key.as_i64(), inner.as_map()) else {
+                    continue;
+                };
+                for (q_key, r_val) in qmap {
+                    let (Some(q), Some(rating)) = (q_key.as_i64(), r_val.as_i64()) else {
+                        continue;
+                    };
+                    let Some(qname) = quality_name(q) else {
+                        continue;
+                    };
+                    insert.execute(params![level, qname, rating])?;
+                    n_rating += 1;
+                }
+            }
+        }
+
+        // -- Budget: Map<quality, List[level]<List[permille]<i64>>> --
+        if let Some(payload) = &budget_payload {
+            let table = read_first_field(payload)?;
+            tx.execute("DELETE FROM item_budget_table", [])?;
+            let mut insert = tx.prepare_cached(
+                "INSERT OR REPLACE INTO item_budget_table \
+                    (quality, item_level, permille, value) \
+                 VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for (q_key, levels) in table.as_map().unwrap_or(&[]) {
+                let (Some(q), Some(level_list)) = (q_key.as_i64(), levels.as_list()) else {
+                    continue;
+                };
+                let Some(qname) = quality_name(q) else {
+                    continue;
+                };
+                for (level, slots) in level_list.iter().enumerate() {
+                    let Some(slot_list) = slots.as_list() else {
+                        continue;
+                    };
+                    for (permille, val) in slot_list.iter().enumerate() {
+                        let Some(value) = val.as_i64() else { continue };
+                        insert.execute(params![qname, level as i64, permille as i64, value])?;
+                        n_budget += 1;
+                    }
+                }
+            }
+        }
+
+        // -- Modifier packages: Map<mod_id, List<{..., percentages: Map<stat, permille>}>> --
+        if let Some(payload) = &modpkg_payload {
+            let table = read_first_field(payload)?;
+            tx.execute("DELETE FROM item_modifier_packages", [])?;
+            let mut insert = tx.prepare_cached(
+                "INSERT OR REPLACE INTO item_modifier_packages \
+                    (mod_id, stat_index, stat_name, permille) \
+                 VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for (mod_key, pkg_val) in table.as_map().unwrap_or(&[]) {
+                let Some(mod_id) = mod_key.as_i64() else {
+                    continue;
+                };
+                // The package value is a single-element list wrapping the
+                // package object; accept a bare object too for robustness. The
+                // stat split (itmModPkgAttributePercentages) is the package
+                // object's sole map field.
+                let pkg = match pkg_val {
+                    GomValue::List(items) => items.first(),
+                    other @ GomValue::Embedded(_) => Some(other),
+                    _ => None,
+                };
+                let Some(pct_map) = pkg
+                    .and_then(GomValue::embedded_first_map)
+                    .and_then(GomValue::as_map)
+                else {
+                    continue;
+                };
+                for (stat_key, pct_val) in pct_map {
+                    let (Some(stat_idx), Some(permille)) = (stat_key.as_i64(), pct_val.as_i64())
+                    else {
+                        continue;
+                    };
+                    let Some(sname) = stat_name(stat_idx) else {
+                        continue;
+                    };
+                    insert.execute(params![mod_id, stat_idx, sname, permille])?;
+                    n_modpkg += 1;
+                }
+            }
+        }
+
+        tx.commit()?;
+        Ok((n_rating, n_budget, n_modpkg))
     }
 
     /// Populate `mission_npcs` and `mission_rewards` by walking each mission's

--- a/kessel/src/gom_reader.rs
+++ b/kessel/src/gom_reader.rs
@@ -1,0 +1,365 @@
+//! Typed-value GOM reader for prototype singletons.
+//!
+//! SWTOR prototype objects are stored as a self-describing binary stream. The
+//! grammar mirrors the reference `GomBinaryReader` / `ScriptObjectReader` from
+//! GomLib: a variable-width number codec plus a one-byte type tag in front of
+//! every value, so the stream can be walked without the client's class/field
+//! schema (the DOM). Only the field *names* need the schema; the field *values*
+//! and their delta-coded field ids are fully recoverable from the bytes.
+//!
+//! Number codec (`read_number`):
+//! - `b < 0xC0`             -> the literal byte value
+//! - `0xC0 ..= 0xC7`        -> read `b - 0xBF` following bytes, big-endian
+//! - `0xC8 ..= 0xCF`        -> read `b - 0xC7` following bytes, big-endian
+//! - `0xD0`                 -> the next single byte
+//! - `0xD2`                 -> a lookup-list flag; skip and re-read
+//!
+//! `read_signed_number` shares the codec but negates the `0xC0..=0xC7` range.
+//!
+//! Type tags (`GomTypeId`): `01` UInt64, `02` Int64, `03` Bool, `04` Float,
+//! `05` Enum, `06` String, `07` List, `08` Map, `09` EmbeddedClass,
+//! `0F` ClassRef.
+//!
+//! Container layout (each container re-reads its element type tag inline):
+//! - List: `<elem_tag> <len> <len2> { <idx> <value> }*`  (`len == len2`)
+//! - Map:  `<key_tag> <val_tag> <len> <len2> { <key> <value> }*`
+//!
+//! A value is read by `Reader::read_value(tag)` with the cursor positioned just
+//! past `tag`.
+
+use anyhow::{bail, Result};
+
+/// GOM type tag bytes. Only the variants observed in the itemization
+/// singletons are decoded; anything else is an error so a grammar drift is
+/// caught loudly rather than silently mis-parsed.
+mod tag {
+    pub const UINT64: u8 = 0x01;
+    pub const INT64: u8 = 0x02;
+    pub const BOOL: u8 = 0x03;
+    pub const FLOAT: u8 = 0x04;
+    pub const ENUM: u8 = 0x05;
+    pub const STRING: u8 = 0x06;
+    pub const LIST: u8 = 0x07;
+    pub const MAP: u8 = 0x08;
+    pub const EMBEDDED: u8 = 0x09;
+    pub const CLASS_REF: u8 = 0x0F;
+}
+
+/// A decoded GOM value. Enums carry the zero-based member index (the engine
+/// stores it one-based; the codec corrects it). Embedded objects retain each
+/// field's delta-summed id so callers can match a field by id low32 rather
+/// than by position.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GomValue {
+    Null,
+    U64(u64),
+    I64(i64),
+    Bool(bool),
+    F32(f32),
+    Enum(i64),
+    Str(String),
+    List(Vec<GomValue>),
+    Map(Vec<(GomValue, GomValue)>),
+    Embedded(Vec<(u64, GomValue)>),
+    ClassRef(u64),
+}
+
+impl GomValue {
+    /// The integer payload of `I64`/`U64`/`Enum`, if numeric.
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            GomValue::I64(v) | GomValue::Enum(v) => Some(*v),
+            GomValue::U64(v) => Some(*v as i64),
+            _ => None,
+        }
+    }
+
+    /// Map entries, if this is a `Map`.
+    pub fn as_map(&self) -> Option<&[(GomValue, GomValue)]> {
+        match self {
+            GomValue::Map(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    /// List entries, if this is a `List`.
+    pub fn as_list(&self) -> Option<&[GomValue]> {
+        match self {
+            GomValue::List(l) => Some(l),
+            _ => None,
+        }
+    }
+
+    /// In an `Embedded` object, the first field whose value is itself a `Map`.
+    /// Selecting by shape (rather than a field id) is deliberate: GOM field
+    /// ids drift across game patches, but a modifier-package object's only
+    /// map is its stat-split (`itmModPkgAttributePercentages`).
+    pub fn embedded_first_map(&self) -> Option<&GomValue> {
+        match self {
+            GomValue::Embedded(fields) => fields
+                .iter()
+                .map(|(_, v)| v)
+                .find(|v| matches!(v, GomValue::Map(_))),
+            _ => None,
+        }
+    }
+}
+
+/// Forward-only cursor over a prototype payload.
+pub struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    /// A reader positioned at `pos` within `buf`.
+    pub fn new(buf: &'a [u8], pos: usize) -> Self {
+        Reader { buf, pos }
+    }
+
+    fn read_u8(&mut self) -> Result<u8> {
+        let b = *self
+            .buf
+            .get(self.pos)
+            .ok_or_else(|| anyhow::anyhow!("gom_reader: unexpected end of payload"))?;
+        self.pos += 1;
+        Ok(b)
+    }
+
+    fn read_be(&mut self, n: usize) -> Result<u64> {
+        let mut val: u64 = 0;
+        for _ in 0..n {
+            val = (val << 8) | self.read_u8()? as u64;
+        }
+        Ok(val)
+    }
+
+    /// Variable-width unsigned number.
+    pub fn read_number(&mut self) -> Result<u64> {
+        let mut b = self.read_u8()?;
+        if b == 0xD2 {
+            // Lookup-list flag; the real prefix follows.
+            b = self.read_u8()?;
+        }
+        match b {
+            0x00..=0xBF => Ok(b as u64),
+            0xC0..=0xC7 => self.read_be((b - 0xBF) as usize),
+            0xC8..=0xCF => self.read_be((b - 0xC7) as usize),
+            0xD0 => Ok(self.read_u8()? as u64),
+            other => bail!("gom_reader: unknown number prefix 0x{other:02X}"),
+        }
+    }
+
+    /// Variable-width signed number. The `0xC0..=0xC7` prefix range is the
+    /// negative magnitude; `0xC8..=0xCF` is positive.
+    pub fn read_signed_number(&mut self) -> Result<i64> {
+        let b = self.read_u8()?;
+        if b == 0xD2 {
+            let len = self.read_u8()? as usize;
+            // Numeric-as-string form: ASCII digits of length `len`.
+            let start = self.pos;
+            let end = start
+                .checked_add(len)
+                .filter(|e| *e <= self.buf.len())
+                .ok_or_else(|| anyhow::anyhow!("gom_reader: signed string overrun"))?;
+            let s = std::str::from_utf8(&self.buf[start..end])?;
+            self.pos = end;
+            return Ok(s.parse::<i64>()?);
+        }
+        match b {
+            0x00..=0xBF => Ok(b as i64),
+            0xC0..=0xC7 => Ok(-(self.read_be((b - 0xBF) as usize)? as i64)),
+            0xC8..=0xCF => Ok(self.read_be((b - 0xC7) as usize)? as i64),
+            0xD0 => Ok(0),
+            other => bail!("gom_reader: unknown signed prefix 0x{other:02X}"),
+        }
+    }
+
+    fn read_f32(&mut self) -> Result<f32> {
+        let start = self.pos;
+        let end = start
+            .checked_add(4)
+            .filter(|e| *e <= self.buf.len())
+            .ok_or_else(|| anyhow::anyhow!("gom_reader: float overrun"))?;
+        let bytes: [u8; 4] = self.buf[start..end].try_into().unwrap();
+        self.pos = end;
+        Ok(f32::from_le_bytes(bytes))
+    }
+
+    fn read_string(&mut self) -> Result<String> {
+        let len = self.read_number()? as usize;
+        let start = self.pos;
+        let end = start
+            .checked_add(len)
+            .filter(|e| *e <= self.buf.len())
+            .ok_or_else(|| anyhow::anyhow!("gom_reader: string overrun"))?;
+        let s = String::from_utf8_lossy(&self.buf[start..end]).into_owned();
+        self.pos = end;
+        Ok(s)
+    }
+
+    /// Read the next type tag and dispatch to the matching value reader. This
+    /// is the inline `Load(reader, false)` of the reference: it consumes one
+    /// tag byte then the value body.
+    fn read_tagged(&mut self) -> Result<GomValue> {
+        let tag = self.read_u8()?;
+        self.read_value(tag)
+    }
+
+    /// Read a value of the given `tag` with the cursor positioned past `tag`.
+    pub fn read_value(&mut self, tag: u8) -> Result<GomValue> {
+        match tag {
+            0x00 => Ok(GomValue::Null),
+            tag::UINT64 => Ok(GomValue::U64(self.read_number()?)),
+            tag::INT64 => Ok(GomValue::I64(self.read_signed_number()?)),
+            tag::BOOL => Ok(GomValue::Bool(self.read_u8()? != 0)),
+            tag::FLOAT => Ok(GomValue::F32(self.read_f32()?)),
+            // Enum is one-based on the wire; correct to a zero-based index.
+            tag::ENUM => Ok(GomValue::Enum(self.read_number()? as i64 - 1)),
+            tag::STRING => Ok(GomValue::Str(self.read_string()?)),
+            tag::LIST => self.read_list(),
+            tag::MAP => self.read_map(),
+            tag::EMBEDDED => self.read_object(),
+            tag::CLASS_REF => Ok(GomValue::ClassRef(self.read_number()?)),
+            other => bail!("gom_reader: unsupported type tag 0x{other:02X}"),
+        }
+    }
+
+    /// `<elem_tag> <len> <len2> { <idx> <value> }*`
+    fn read_list(&mut self) -> Result<GomValue> {
+        let elem_tag = self.read_u8()?;
+        let len = self.read_number()?;
+        let len2 = self.read_number()?;
+        if len != len2 {
+            bail!("gom_reader: list length mismatch ({len} != {len2})");
+        }
+        let mut items = Vec::with_capacity(len.min(1 << 20) as usize);
+        for _ in 0..len {
+            let _idx = self.read_number()?;
+            items.push(self.read_value(elem_tag)?);
+        }
+        Ok(GomValue::List(items))
+    }
+
+    /// `<key_tag> <val_tag> <len> <len2> { <key> <value> }*`
+    fn read_map(&mut self) -> Result<GomValue> {
+        let key_tag = self.read_u8()?;
+        let val_tag = self.read_u8()?;
+        let len = self.read_number()?;
+        let len2 = self.read_number()?;
+        if len != len2 {
+            bail!("gom_reader: map length mismatch ({len} != {len2})");
+        }
+        let mut entries = Vec::with_capacity(len.min(1 << 20) as usize);
+        for _ in 0..len {
+            let key = self.read_value(key_tag)?;
+            let val = self.read_value(val_tag)?;
+            entries.push((key, val));
+        }
+        Ok(GomValue::Map(entries))
+    }
+
+    /// An embedded object: `<script_type_id> <num_fields> { <delta_id> <tag>
+    /// <value> }*`. Field ids are delta-coded; the running sum is retained per
+    /// field so callers can match by id low32.
+    fn read_object(&mut self) -> Result<GomValue> {
+        let _script_type_id = self.read_number()?;
+        let num_fields = self.read_number()?;
+        let mut fields = Vec::with_capacity(num_fields.min(1 << 16) as usize);
+        let mut field_id: u64 = 0;
+        for _ in 0..num_fields {
+            field_id = field_id.wrapping_add(self.read_number()?);
+            let value = self.read_tagged()?;
+            fields.push((field_id, value));
+        }
+        Ok(GomValue::Embedded(fields))
+    }
+}
+
+/// `cf 40 00 00` marks the start of a field id in a prototype payload (the
+/// `0xCF` is a number prefix for an 8-byte big-endian id).
+const FIELD_MARKER: [u8; 4] = [0xCF, 0x40, 0x00, 0x00];
+
+/// Decode the first top-level field value of a prototype singleton: locate its
+/// field marker, consume the field id, then read the tagged value. The
+/// itemization singletons each carry their table as the first field, so this
+/// yields the whole table (nested containers and embedded objects included).
+pub fn read_first_field(payload: &[u8]) -> Result<GomValue> {
+    let marker = payload
+        .windows(FIELD_MARKER.len())
+        .position(|w| w == FIELD_MARKER)
+        .ok_or_else(|| anyhow::anyhow!("gom_reader: no field marker in payload"))?;
+    let mut reader = Reader::new(payload, marker);
+    let _field_id = reader.read_number()?;
+    let tag = reader.read_u8()?;
+    reader.read_value(tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn number_literal_and_widths() {
+        // literal
+        assert_eq!(Reader::new(&[0x7F], 0).read_number().unwrap(), 0x7F);
+        // 0xC8 -> 1 following byte
+        assert_eq!(Reader::new(&[0xC8, 0xC9], 0).read_number().unwrap(), 0xC9);
+        // 0xC9 -> 2 following bytes, big-endian
+        assert_eq!(
+            Reader::new(&[0xC9, 0x03, 0xE8], 0).read_number().unwrap(),
+            1000
+        );
+    }
+
+    #[test]
+    fn signed_negative_range() {
+        // 0xC0 -> 1 byte, negated
+        assert_eq!(
+            Reader::new(&[0xC0, 0x05], 0).read_signed_number().unwrap(),
+            -5
+        );
+        // 0xC8 -> 1 byte, positive
+        assert_eq!(
+            Reader::new(&[0xC8, 0x05], 0).read_signed_number().unwrap(),
+            5
+        );
+        assert_eq!(Reader::new(&[0x00], 0).read_signed_number().unwrap(), 0);
+    }
+
+    #[test]
+    fn map_of_int_to_int() {
+        // Map<Int64,Int64> len 2: {0->0, 8->1}. read_value(MAP) reads the body
+        // from pos: key_tag=02 val_tag=02 len=02 len2=02 then (00,00)(08,01).
+        let buf = [0x02, 0x02, 0x02, 0x02, 0x00, 0x00, 0x08, 0x01];
+        let mut r = Reader::new(&buf, 0);
+        let v = r.read_value(tag::MAP).unwrap();
+        let m = v.as_map().unwrap();
+        assert_eq!(m.len(), 2);
+        assert_eq!(m[0].0.as_i64(), Some(0));
+        assert_eq!(m[1].0.as_i64(), Some(8));
+        assert_eq!(m[1].1.as_i64(), Some(1));
+    }
+
+    #[test]
+    fn list_reads_and_discards_index() {
+        // List<Int64> len 3: elem_tag=02 len=03 len2=03 then (idx,val)*
+        let buf = [0x02, 0x03, 0x03, 0x00, 0x0A, 0x01, 0x14, 0x02, 0x1E];
+        let mut r = Reader::new(&buf, 0);
+        let v = r.read_value(tag::LIST).unwrap();
+        let l = v.as_list().unwrap();
+        assert_eq!(l.len(), 3);
+        assert_eq!(l[0].as_i64(), Some(10));
+        assert_eq!(l[1].as_i64(), Some(20));
+        assert_eq!(l[2].as_i64(), Some(30));
+    }
+
+    #[test]
+    fn enum_is_zero_based() {
+        // raw 0x03 -> index 2
+        assert_eq!(
+            Reader::new(&[0x03], 0).read_value(tag::ENUM).unwrap(),
+            GomValue::Enum(2)
+        );
+    }
+}

--- a/kessel/src/lib.rs
+++ b/kessel/src/lib.rs
@@ -6,6 +6,7 @@ pub mod buckets_info;
 pub mod db;
 pub mod dds;
 pub mod gifts;
+pub mod gom_reader;
 pub mod gom_schema;
 pub mod grammar;
 pub mod gsf_stat_dictionary;

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -10,6 +10,7 @@ mod buckets_info;
 mod db;
 mod dds;
 mod gifts;
+mod gom_reader;
 mod gom_schema;
 mod grammar;
 mod gsf_stat_dictionary;
@@ -542,6 +543,14 @@ fn main() -> Result<()> {
     // Companion roster from npc.companion.* objects (name + category).
     let companion_count = db.populate_companions()?;
     println!("  Companions: {} rows", companion_count);
+
+    // Item itemization tables (rating, budget curve, modifier packages) from
+    // the itm* prototype singletons -- the inputs to computed item stats.
+    let (rating_rows, budget_rows, modpkg_rows) = db.populate_item_itemization()?;
+    println!(
+        "  Item itemization: {} rating, {} budget, {} modifier-package rows",
+        rating_rows, budget_rows, modpkg_rows
+    );
 
     // Eighth pass: aggregate NPCs and rewards across each mission's phase tree
     db.populate_mission_data()?;


### PR DESCRIPTION
## What

Three lookup tables that turn an item's `(level, quality, modifierSetID)` into computed stats -- SWTOR item stats are all-formula, not stored per item:

- `item_rating_table[item_level][quality] -> rating` (2,010 rows)
- `item_budget_table[quality][item_level][permille 0..999] -> value` (~800k rows)
- `item_modifier_packages[mod_id] -> (stat_index, stat_name, permille)` (3,635 rows)

```
rating = item_rating_table[level][quality]
stat   = item_budget_table[quality][level][ package.permille(stat) ]
```

## How

New `kessel/src/gom_reader.rs` -- a typed-value GOM reader mirroring the reference `GomBinaryReader` / `ScriptObjectReader` grammar: variable-width number codec (`0xC0-C7` negative, `0xC8-CF` positive, big-endian) + inline type tags (`01` UInt64 .. `08` Map, `09` EmbeddedClass, `0F` ClassRef). The stream is self-describing, so the reader needs no client DOM. `populate_item_itemization` in `db.rs` decodes the `itmRatingTablePrototype` / `itmBudgetedAttributesPrototype` / `itmModifierPackageTablePrototype` singletons; enum members resolve via the existing `STAT` / `itmQuality` dictionaries. The modifier-package stat split is selected by shape (the package object's sole map field) rather than a hardcoded field id, which drifts across patches.

## Verification

`cargo build` + `clippy -D warnings` + `235 tests` + `fmt --check` all green. Oracle-verified end-to-end against v22 (`cargo run -p kessel-discovery --bin verify_item_itemization`, read-only): `budget[artifact][89]` reproduces the known relic magnitudes **484** and **167**; example split `mod 453 = endurance 330 + mastery 370` permille.

## Follow-up

Per-item linkage (materializing each item's own `modifierSetID` onto these tables so a row says "this item gives N mastery") is a separate issue -- item object payloads are CF40-marker structured, unlike the clean singletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)