### PR TITLE
feat(quest): decode real activity_type/difficulty/rewards/episode enums (closes #269, closes #271)

### DIFF
--- a/kessel/src/db/quest.rs
+++ b/kessel/src/db/quest.rs
@@ -252,10 +252,36 @@ impl Database {
                 let string_for_hash = |hi32: &str| -> Option<String> {
                     prop_by_hash(hi32)?.as_str().map(String::from)
                 };
-                let activity = enum_member("qstActivityType");
-                let difficulty = enum_member("qstDifficulty");
-                let rewards = enum_member("qstRewardsVisibility");
-                let episode = enum_member("qstEpisodeSeason");
+                // Enum properties are keyed by hash, not name, in the decoded
+                // output -- so the name-based `enum_member` lookup never matched
+                // (all four columns landed empty across every quest). Resolve by
+                // the canonical `__<HI32>` suffix instead, the same path the
+                // tracking-flag / *_code columns already use successfully (#269).
+                // The walker either emits the member name directly, or a raw
+                // enum index (it mislabels some enum kinds as int8) -- handle
+                // both, resolving the index against the schema's member list.
+                let enum_by_hash = |hi32: &str, enum_name: &str| -> Option<String> {
+                    let v = prop_by_hash(hi32)?;
+                    if let Some(name) = v.get("name").and_then(|n| n.as_str()) {
+                        return Some(name.to_string());
+                    }
+                    let idx = v.as_i64()?;
+                    if idx < 0 {
+                        return None;
+                    }
+                    crate::gom_schema::enum_for_name(enum_name)
+                        .and_then(|e| e.members.get(idx as usize).cloned())
+                };
+                // Hashes are the first 8 hex of each property id and match the
+                // Quest class property_refs (e.g. 4000004EB58CE5FC).
+                let activity = enum_by_hash("B58CE5FC", "qstActivityType")
+                    .or_else(|| enum_member("qstActivityType"));
+                let difficulty = enum_by_hash("B0E9BAF2", "qstDifficulty")
+                    .or_else(|| enum_member("qstDifficulty"));
+                let rewards = enum_by_hash("1D4649A2", "qstRewardsVisibility")
+                    .or_else(|| enum_member("qstRewardsVisibility"));
+                let episode = enum_by_hash("D3680699", "qstEpisodeSeason")
+                    .or_else(|| enum_member("qstEpisodeSeason"));
                 // Level: per-property level field may be int8 stored as
                 // an int value (not a wrapped struct). Try direct decode.
                 let level = int_value("Level").or_else(|| int_value("level"));
@@ -2105,6 +2131,64 @@ mod tests {
             .unwrap();
         assert_eq!(activity.as_deref(), Some(expected_member.as_str()));
     }
+    #[test]
+    fn populate_quest_details_typed_resolves_heroic_activity_by_hash() {
+        // Locks in the #271 subsumption: a quest whose qstActivityType enum
+        // decodes to index 2 must classify as the Heroic member, resolved via
+        // the canonical hash path (B58CE5FC) -- not the FQN/name (the heroic
+        // signal is the payload enum, not the title).
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+        let expected = crate::gom_schema::enum_for_name("qstActivityType")
+            .and_then(|e| e.members.get(2).cloned());
+        let Some(expected) = expected else {
+            return; // schema lacks the enum -> nothing to assert
+        };
+        assert!(
+            expected.contains("Heroic"),
+            "member index 2 should be the Heroic activity type, got {expected}"
+        );
+        let path = temp_db_path("quest_typed_heroic");
+        let db = Database::with_grammar(&path, None).unwrap();
+        db.init_schema().unwrap();
+
+        // CF40 marker for hash B58CE5FC + enum_ref tag (0x05) + index 2.
+        let hi32: u32 = 0xB58C_E5FC;
+        let mut payload = vec![0u8; 4];
+        payload.push(0xCF);
+        payload.push(0x40);
+        payload.extend_from_slice(&[0u8; 2]);
+        payload.push(0x40);
+        payload.extend_from_slice(&hi32.to_be_bytes());
+        payload.push(0x05);
+        payload.push(0x02);
+        let payload_b64 = BASE64.encode(&payload);
+        {
+            let conn = db.conn.lock().unwrap();
+            let json = format!(r#"{{"payload_b64":"{payload_b64}"}}"#);
+            conn.execute(
+                "INSERT INTO objects (game_id, stable_id, payload_hash, guid, fqn, kind, json, is_canonical) \
+                 VALUES ('qh1', 'sid', 'ph', 'g', 'qst.test.heroic', 'Quest', ?1, 1)",
+                params![json],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO quest_details (fqn, mission_type) VALUES ('qst.test.heroic', 'side')",
+                [],
+            )
+            .unwrap();
+        }
+        db.populate_quest_details_typed().unwrap();
+        let conn = db.conn.lock().unwrap();
+        let activity: Option<String> = conn
+            .query_row(
+                "SELECT activity_type FROM quest_details WHERE fqn = 'qst.test.heroic'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(activity.as_deref(), Some(expected.as_str()));
+    }
+
     #[test]
     fn quest_objectives_table_exists_after_init() {
         let path = temp_db_path("quest_obj_table");


### PR DESCRIPTION
Closes #269. Closes #271.

## What

The four `qst*` enum columns in `quest_details` — `activity_type`, `difficulty`, `rewards_visibility`, `episode_season` — were **empty on all 1,514 quests**. `populate_quest_details_typed` resolved them via a **name-based** `enum_member` lookup, but the schema-aware walker keys decoded properties by **hash**, not name, so the lookup never matched. (The hash-keyed columns `primary_tracking_flag` / `*_code` populate fine — 1514 / 1512 — which proves the mechanism; only the enums were misrouted.)

Fix: resolve each enum by its canonical `__<HI32>` suffix — the same path the working columns use:

| enum | hash | members |
|---|---|---|
| `qstActivityType` | `B58CE5FC` | None / Uprising / **Heroic** / Flashpoint / Operation / Warzone |
| `qstDifficulty` | `B0E9BAF2` | NoExp / ChainStep / Easy / Normal / Hard / VeryHard |
| `qstRewardsVisibility` | `1D4649A2` | Show / Minimized / Hide |
| `qstEpisodeSeason` | `D3680699` | None / One / Two / Three |

The walker emits either the member name or a raw enum index (it mislabels some enum kinds as int8) — both handled, resolving the index against the schema member list. Name-based lookup kept as a harmless fallback.

## Closes #271 (heroic classification) — subsumed, not separately implemented

The heroic signal is the **`qstActivityType_Heroic` enum member in the payload**, not the FQN or display name — a `[HEROIC` name scan returns **0** in v24, so #271's original FQN/name-fallback premise was wrong. Decoding `activity_type` correctly *is* the heroic classifier. (`mission_type='heroic'` was stuck at 2; `activity_type` now surfaces the real Heroic set.)

## Acceptance criteria

- [x] `activity_type`/`difficulty`/`rewards_visibility`/`episode_season` decode to real members (was 0% filled) — `db/quest.rs::populate_quest_details_typed`, hash-routed
- [x] #271: heroic surfaced via `qstActivityType_Heroic`
- [ ] **Complete when:** real members on ≥90% of quests that carry the field — confirming via full extraction; distribution to be posted here before merge

## Verification

- `cargo test -p kessel` — 245 pass (incl. new index-2 → Heroic resolution test)
- `cargo clippy -p kessel -- -D warnings`, `cargo fmt --check` — clean
- Mechanism proven on real v24: hash-keyed columns fill 1514/1512; full re-extraction running to post the `activity_type`/`difficulty` distribution.

## Tests

- `populate_quest_details_typed_decodes_real_enum_value` — enum index 0 → first member
- `populate_quest_details_typed_resolves_heroic_activity_by_hash` — `qstActivityType` index 2 → `qstActivityType_Heroic`, by hash (locks in the #271 subsumption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)