### PR TITLE
feat(compare): kessel-compare -- cross-patch changelog tool (imports smugglr-core)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 members = ["kessel", "kessel-discovery"]
 default-members = ["kessel"]
+# kessel-compare is a standalone local tooling crate (patch-changelog diff) with a
+# sibling-repo path dep on smugglr-core. Excluded so it never enters the kessel
+# crate's build or CI; build it on demand from its own directory.
+exclude = ["kessel-compare"]
 resolver = "2"
 
 [workspace.package]

--- a/kessel-compare/.gitignore
+++ b/kessel-compare/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/kessel-compare/Cargo.toml
+++ b/kessel-compare/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kessel-compare"
+version = "0.1.0"
+edition = "2021"
+description = "Cross-patch diff for kessel spice databases -- the SWTOR patch changelog. Imports smugglr-core's content-hash diff engine, re-keyed on kessel's stable_id (game_id shifts every patch)."
+
+# Excluded from the kessel workspace (see root Cargo.toml [workspace.exclude]):
+# this is a local tooling crate with a sibling-repo path dep on smugglr-core, so it
+# must not enter the kessel crate's build/CI. Build it standalone:
+#   cd kessel-compare && cargo build --release
+
+[dependencies]
+# smugglr's pure diff engine (classify_diff / RowMeta / TableDiff). default-features
+# off so we don't pull tokio/rusqlite/reqwest -- we only need the content-hash diff,
+# not the sync/transport layer. Path is relative to the sibling rafters-studio repo.
+smugglr-core = { path = "../../../rafters-studio/smugglr/crates/smugglr-core", default-features = false }
+rusqlite = { version = "0.31", features = ["bundled"] }
+anyhow = "1"

--- a/kessel-compare/src/main.rs
+++ b/kessel-compare/src/main.rs
@@ -1,0 +1,143 @@
+//! kessel-compare: the SWTOR patch changelog.
+//!
+//! Diffs two kessel spice databases (old patch vs new) and reports what changed
+//! per object kind -- new quests, retuned abilities/talents, added items, etc.
+//!
+//! Why a custom tool instead of `smugglr diff`: every kessel table's primary key
+//! embeds `game_id = sha256(fqn:guid)`, and the GUID *shifts on every patch* -- so a
+//! PK-keyed diff would report every object as removed+added. kessel carries the
+//! cross-patch primitives for exactly this: `stable_id = sha256(fqn)` (survives a
+//! patch) and `payload_hash = sha256(payload)` (the content-change signal). We feed
+//! smugglr's pure `classify_diff` a metadata map keyed by `stable_id` with
+//! `content_hash = payload_hash`, so its content-hash engine partitions correctly:
+//!   - in new, not old        -> ADDED
+//!   - in old, not new        -> REMOVED
+//!   - same stable_id, payload differs -> CHANGED
+//!
+//! Usage: kessel-compare <old.sqlite> <new.sqlite>
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OpenFlags};
+use smugglr_core::datasource::RowMeta;
+use smugglr_core::diff::classify_diff;
+
+struct ObjInfo {
+    kind: String,
+    fqn: String,
+}
+
+/// Load every canonical object as (stable_id -> content metadata) for smugglr's
+/// diff, plus (stable_id -> kind/fqn) for reporting.
+fn load(path: &str) -> Result<(HashMap<String, RowMeta>, HashMap<String, ObjInfo>)> {
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("open {path}"))?;
+    let mut stmt = conn.prepare(
+        "SELECT stable_id, kind, fqn, payload_hash FROM objects WHERE is_canonical = 1",
+    )?;
+    let mut meta = HashMap::new();
+    let mut info = HashMap::new();
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, String>(3)?,
+        ))
+    })?;
+    for row in rows {
+        let (stable_id, kind, fqn, payload_hash) = row?;
+        meta.insert(
+            stable_id.clone(),
+            RowMeta {
+                pk_value: stable_id.clone(),
+                updated_at: None, // no timestamps in spice -> content-hash decides
+                content_hash: payload_hash,
+            },
+        );
+        info.insert(stable_id, ObjInfo { kind, fqn });
+    }
+    Ok((meta, info))
+}
+
+#[derive(Default)]
+struct KindDelta {
+    added: Vec<String>,
+    changed: Vec<String>,
+    removed: Vec<String>,
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: kessel-compare <old.sqlite> <new.sqlite>");
+        std::process::exit(2);
+    }
+    let (old_meta, old_info) = load(&args[1])?;
+    let (new_meta, new_info) = load(&args[2])?;
+
+    // local = new, remote = old. smugglr's pure classifier, keyed by stable_id.
+    let diff = classify_diff(&new_meta, &old_meta, "objects");
+
+    let mut by_kind: BTreeMap<String, KindDelta> = BTreeMap::new();
+    for sid in &diff.local_only {
+        if let Some(o) = new_info.get(sid) {
+            by_kind.entry(o.kind.clone()).or_default().added.push(o.fqn.clone());
+        }
+    }
+    for sid in &diff.content_differs {
+        if let Some(o) = new_info.get(sid) {
+            by_kind.entry(o.kind.clone()).or_default().changed.push(o.fqn.clone());
+        }
+    }
+    for sid in &diff.remote_only {
+        if let Some(o) = old_info.get(sid) {
+            by_kind.entry(o.kind.clone()).or_default().removed.push(o.fqn.clone());
+        }
+    }
+
+    println!("kessel patch diff: {} -> {}", args[1], args[2]);
+    println!(
+        "objects: {} old, {} new  |  +{} added  ~{} changed  -{} removed\n",
+        old_meta.len(),
+        new_meta.len(),
+        diff.local_only.len(),
+        diff.content_differs.len(),
+        diff.remote_only.len(),
+    );
+
+    for (kind, d) in &by_kind {
+        if d.added.is_empty() && d.changed.is_empty() && d.removed.is_empty() {
+            continue;
+        }
+        println!(
+            "== {kind} ==  +{} added  ~{} changed  -{} removed",
+            d.added.len(),
+            d.changed.len(),
+            d.removed.len()
+        );
+        print_sample("added", &d.added);
+        print_sample("changed", &d.changed);
+        print_sample("removed", &d.removed);
+        println!();
+    }
+    Ok(())
+}
+
+/// Print up to 15 fqns for a bucket (full lists get long on a big patch).
+fn print_sample(label: &str, fqns: &[String]) {
+    if fqns.is_empty() {
+        return;
+    }
+    let mut sorted = fqns.to_vec();
+    sorted.sort();
+    let shown = sorted.len().min(15);
+    println!("   {label} ({}):", fqns.len());
+    for f in &sorted[..shown] {
+        println!("     {f}");
+    }
+    if fqns.len() > shown {
+        println!("     ... and {} more", fqns.len() - shown);
+    }
+}


### PR DESCRIPTION
Diffs two kessel spice DBs to produce the SWTOR **patch changelog** (new quests / changed abilities+talents / added items / removed), grouped by object kind. Built outside the workflow first; PRing it properly now.

**The .tor quirk:** every kessel table PK embeds `game_id=sha256(fqn:guid)`; the GUID **shifts every patch**, so a PK-keyed diff reports everything as removed+added. Cross-patch primitives: `stable_id=sha256(fqn)` (survives) + `payload_hash` (content). The tool feeds **smugglr-core's pure `classify_diff`** a map keyed by `stable_id` with `content_hash=payload_hash` -> local_only=added, remote_only=removed, content_differs=changed.

- Imports `smugglr-core` (default-features=false -> diff engine only).
- **Standalone crate, EXCLUDED from the kessel workspace** (sibling path dep must not enter kessel CI). `cd kessel-compare && cargo build --release`.
- Verified on a synthetic patch. Ready for 7.9 vs the retained 7.8.1.c v25 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)