### PR TITLE
fix(gsf): oracle-verify the 6 guess-tier ability_stats prop_id labels (#299)

### DIFF
--- a/docs/probes/gsf-propid-verify.md
+++ b/docs/probes/gsf-propid-verify.md
@@ -1,0 +1,44 @@
+# GSF ability_stats prop_id verification (2026-06-16)
+
+Verified the six `guess`-tier `[ability_stats]` prop_id labels in
+`gsf_stat_dictionary.toml` against the **in-archive description-string oracle**:
+match each decoded f32 value to a number written in the ability's own
+`id1=1` description string. This is the same method that verified `0x0407`
+(`range_units`, value*100 = meters), `0x0410`, and `0x0439`. It anchors on
+**base** values from the game's own text — not community/internet numbers,
+which quote talented/crewed/effective values and cannot pin a base prop.
+
+Method: a decode -> adversarial-refute pipeline, one independent skeptic per
+proposal (`docs/probes/gsf-propid-verify.workflow.js`). Reproduce with:
+`Workflow({scriptPath: "docs/probes/gsf-propid-verify.workflow.js"})`.
+
+## Verdicts
+
+| prop | was | now | conf | basis |
+|------|-----|-----|------|-------|
+| `0x0421` | range_meters / m / guess | **range_units / 100m / verified** | fix | 9/9 text anchors: mine `1500m` (x4), seeker_mine `4000m`, emp_field `4500m`, face_target `15,000m`, running_interference/wingman `3000m`. value*100 = meters. |
+| `0x0423` | duration_seconds / s / guess | **unknown** | downgrade | duration tokens render blank; values 100/150/180/360/500 are a category enum, no unit anchorable. Not duration, not range, not damage. |
+| `0x0424` | weapon_class_marker / class / guess | **unknown** | downgrade | a missile (target_painter=50) shares it with the 9 lasers (=5); twin `0x0423` spans crew/engine/systems; no description anchors 5 or 50. |
+| `0x0401` | cast_time_seconds / s / guess | **unknown** | downgrade | rank-1 100% sentinel (6.46924 + -1.0); rank-2 is a real stat (30/45/60/75, ~value/3 seconds?) but every carrier ends in a blank duration token — unconfirmable. |
+| `0x0403` | scaling_factor / ratio / guess | scaling_factor / ratio / guess (note enriched) | keep | 53/55 rows are a vacuous 1.0 default; only drone weapons carry a real value (railgun 2.0 = "2 second cooldown"). Relabeling would falsely assert cooldown on the 53 defaults — needs a per-FQN override. |
+| `0x041a` | hard_cast_time_seconds / s / guess | **charge_time_seconds / s / guess** | refine | railgun 4.0 = "takes 4 seconds to charge" (only "4" in the string; 2s cooldown is on `0x0403`, 180 lifetime on `0x0402`). 1 of 3 string-confirmed. |
+
+## Key traps the oracle method must respect
+
+1. **Blank duration tokens** — numeric duration/cooldown values are
+   runtime-substituted and render blank ("for seconds" with no number). A
+   duration label therefore cannot be confirmed from static text, and absence
+   of a number is not absence of the stat.
+2. **Talented vs base** — community numbers bake in component/crew/upgrade
+   deltas (e.g. Power Dive 10s = base 15s + a `tal.spvp.*` -5s `0x40` delta).
+   Never anchor a base prop to a talented number.
+3. **Sentinels** — `-1.0` and `6.46924018859863` are non-data constants; exclude
+   them from any fit. (`6.46924018859863` is `0x0401`-local, not cross-prop.)
+
+## Effect
+
+Dictionary-only change. The shipped `spice-7.9-v1.sqlite` is unaffected until a
+re-extraction runs the populate functions against the updated dictionary.
+Consumer impact on re-extraction: `0x0421` rows change label
+`range_meters` -> `range_units` (and the value now means value*100 meters);
+`0x0423`/`0x0424`/`0x0401` rows become `unknown_0x...` / `unknown`.

--- a/docs/probes/gsf-propid-verify.workflow.js
+++ b/docs/probes/gsf-propid-verify.workflow.js
@@ -1,0 +1,117 @@
+export const meta = {
+  name: 'gsf-propid-verify',
+  description: 'Verify the 6 guess-tier GSF ability_stats prop_id labels against the in-archive description-string oracle, adversarially',
+  phases: [
+    { title: 'Decode', detail: 'one agent per guess prop_id: match decoded values to numbers in the ability description strings' },
+    { title: 'Refute', detail: 'independent skeptic per proposal: try to break the label via cross-ability consistency + known traps' },
+  ],
+}
+
+// The six guess-tier prop_ids in [ability_stats] of gsf_stat_dictionary.toml.
+// Current (suspect) labels + the leading hypothesis from value-pattern + strings spot-check.
+const PROPS = [
+  { prop: '0x0421', current: 'range_meters / m / guess',
+    hypothesis: 'range or radius in 100m UNITS (value*100 = meters), same convention as the already-VERIFIED 0x0407. Spot anchors: emp_field=45 -> "4500m radius", face_target=150 -> "15,000m", running_interference/wingman=30 -> "3000m". Likely fix: range_units / 100m / verified.' },
+  { prop: '0x0423', current: 'duration_seconds / s / guess',
+    hypothesis: 'NOT duration (duration tokens render BLANK in description text, and values 100/150/360/500 are not 6-24s buffs). Missile .on_fire values (100/150) look range-like (short/med=100, long=150); railguns .hit=500 and field abilities=360/180 do not fit range cleanly. May be split-semantic or partly unknowable. Determine the true meaning or recommend downgrade.' },
+  { prop: '0x0424', current: 'weapon_class_marker / class / guess',
+    hypothesis: 'Class-level constant, NOT per-component. 5.0 on all 9 lasers .damage, 50 on target_painter. Existing dict note argues a 5/50/100/400/500 hierarchy across the whole weapon namespace. Binary does not name it. Likely stays guess; confirm or refine.' },
+  { prop: '0x0401', current: 'cast_time_seconds / s / guess',
+    hypothesis: 'Messy. The value 6.46924018859863 recurs on ~20 unrelated abilities -- almost certainly a shared animation/default SENTINEL (like 0x0402 -1.0), NOT a real cast time. Rank-2 values (30/45/60/75) on systems abilities may be a different stat. Determine which rows are sentinel vs real.' },
+  { prop: '0x0403', current: 'scaling_factor / ratio / guess',
+    hypothesis: 'Almost all 1.0; outliers sentry_missile.missile=12, sentry_sniper.railgun=2. Possibly a count (shots/charges/ammo per activation). Confirm or downgrade.' },
+  { prop: '0x041a', current: 'hard_cast_time_seconds / s / guess',
+    hypothesis: 'Only 3 rows: sentry_missile.missile=2.5, sentry_sniper.railgun=4.0, consume_item=3.0. Plausible activation/arming time. Confirm against descriptions or keep guess.' },
+]
+
+const DECODE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['prop', 'proposed_label', 'proposed_unit', 'proposed_scale', 'confidence', 'recommendation', 'per_ability_evidence', 'consistency_holds', 'reasoning'],
+  properties: {
+    prop: { type: 'string' },
+    proposed_label: { type: 'string', description: 'snake_case label, e.g. range_units' },
+    proposed_unit: { type: 'string', description: 'e.g. 100m, s, pct, class, count, ratio' },
+    proposed_scale: { type: 'string', description: 'how the raw value maps to the real number, e.g. "value*100 = meters" or "raw seconds" or "none"' },
+    confidence: { type: 'string', enum: ['verified', 'guess', 'unknown'] },
+    recommendation: { type: 'string', enum: ['keep', 'fix', 'downgrade'] },
+    per_ability_evidence: {
+      type: 'array',
+      description: 'one entry per ability carrying this prop that you could check against its description string',
+      items: {
+        type: 'object', additionalProperties: false,
+        required: ['ability', 'value', 'matched_number', 'snippet'],
+        properties: {
+          ability: { type: 'string' },
+          value: { type: 'number' },
+          matched_number: { type: 'string', description: 'the number in the description text this value maps to, or "none" / "blank-token"' },
+          snippet: { type: 'string', description: 'short quote from the description string' },
+        },
+      },
+    },
+    consistency_holds: { type: 'boolean', description: 'does the proposed label+scale hold for EVERY ability carrying the prop' },
+    outliers: { type: 'array', items: { type: 'string' }, description: 'abilities where it does not hold' },
+    reasoning: { type: 'string' },
+  },
+}
+
+const REFUTE_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['prop', 'verdict', 'final_label', 'final_unit', 'final_confidence', 'refutation_notes'],
+  properties: {
+    prop: { type: 'string' },
+    verdict: { type: 'string', enum: ['confirmed', 'refined', 'refuted'] },
+    final_label: { type: 'string' },
+    final_unit: { type: 'string' },
+    final_scale: { type: 'string' },
+    final_confidence: { type: 'string', enum: ['verified', 'guess', 'unknown'] },
+    refutation_notes: { type: 'string', description: 'what you tried to break and whether it held; cite the abilities/values that decided it' },
+  },
+}
+
+const SPICE = '~/swtor/data/spice.sqlite'
+
+const METHOD = `
+You are decoding a SWTOR Galactic Starfighter (GSF) ability stat prop_id in the kessel spice database.
+
+THE ORACLE (primary, in-archive, BASE values -- trust this over the internet):
+The game's own ability description strings state the real base numbers. Match the decoded f32 value to a number written in the description text. This is exactly how prop_ids 0x0407 (range_units, value*100=meters), 0x0410, and 0x0439 were verified.
+
+QUERY the live DB (read-only) with sqlite3. Spice path: ${SPICE} (a symlink to the current 7.9 extraction).
+- Per-ability decoded values for your prop:
+  sqlite3 -column "${SPICE}" "SELECT substr(o.fqn,10) AS ability, g.value, g.rank FROM gsf_ability_stats g JOIN objects o ON o.game_id=g.ability_game_id AND o.is_canonical=1 WHERE printf('0x%04x',g.prop_id)='<PROP>' ORDER BY o.fqn,g.rank;"
+- Each ability's description string (the number-bearing text):
+  sqlite3 -column "${SPICE}" "SELECT substr(o.fqn,10) AS ability, s.text FROM gsf_ability_stats g JOIN objects o ON o.game_id=g.ability_game_id AND o.is_canonical=1 JOIN strings s ON s.id2=o.string_id AND s.locale='en-us' AND s.id1=1 WHERE printf('0x%04x',g.prop_id)='<PROP>' GROUP BY o.fqn;"
+  (id1=1 is the description; some abilities are .damage/.impact/.summon sub-objects whose own text is sparse -- check the parent or summon FQN if blank.)
+
+KNOWN TRAPS (do not fall for these):
+1. BLANK DURATION TOKENS: numeric duration/cooldown values are runtime-substituted and render BLANK in static text -- you will literally see "for seconds" / "over seconds" with NO number. So you CANNOT confirm a duration label from description text, and the absence of a number does NOT mean the value is zero. If the only fit would be a (blank) duration, that is NOT verification.
+2. TALENTED vs BASE: community/internet GSF numbers (Stasie, wikis) quote the TALENTED/upgraded/crewed value, not the base ability prop. Never anchor a base prop to an internet number without subtracting the relevant tal.spvp.* delta. The description string is base; prefer it.
+3. SENTINELS: recurring constants like -1.0 and 6.46924018859863 appearing across many unrelated abilities are uninit/animation markers, not real values. Exclude them from the fit.
+4. ALREADY-TAKEN meanings: 0x0402=cooldown_seconds (verified), 0x0407=range_units 100m (verified), 0x0410=chargeup, 0x0439=damage, 0x04f7/8/9=power_cost_ratio. Do not propose one of these.
+5. CONSISTENCY IS THE TEST: a label is only as good as its fit across EVERY ability carrying the prop. One clean anchor + three contradictions = not verified. Report outliers honestly.
+
+CONFIDENCE BAR:
+- verified: the value*scale matches an explicit number in the description text for multiple abilities, with no unexplained contradictions.
+- guess: a coherent pattern but no description-string number confirms it (or only structural argument).
+- unknown: no coherent meaning, or the current label is refuted and nothing replaces it -> recommend downgrade so populate emits unknown_0x<id>.
+`
+
+phase('Decode')
+const results = await pipeline(
+  PROPS,
+  (p) => agent(
+    `${METHOD}\n\nYOUR PROP: ${p.prop}\nCURRENT (suspect) dictionary label: ${p.current}\nLEADING HYPOTHESIS: ${p.hypothesis}\n\nQuery the DB, match values to description-string numbers, test consistency across all abilities, and return your structured proposal. Be honest: if it can't be verified from the strings, say guess or downgrade.`,
+    { label: `decode:${p.prop}`, phase: 'Decode', schema: DECODE_SCHEMA }
+  ),
+  (decoded, p) => {
+    if (!decoded) return null
+    return agent(
+      `${METHOD}\n\nA decoder proposed a label for GSF prop ${p.prop}. Your job is to REFUTE it. Re-run the queries yourself and adversarially test the proposal.\n\nPROPOSAL:\n${JSON.stringify(decoded, null, 2)}\n\nTry hard to break it: find an ability whose value contradicts the proposed scale/meaning; check whether the "match" is actually a blank-token coincidence; check whether a different stat fits better; verify no sentinel rows were counted as real. If it survives, confirm it (possibly refining label/unit/scale/confidence). If it dies, mark refuted and set final_confidence=unknown with a downgrade rationale. Default to the LOWER confidence when uncertain. Return the structured verdict.`,
+      { label: `refute:${p.prop}`, phase: 'Refute', schema: REFUTE_SCHEMA }
+    )
+  }
+)
+
+return { props: PROPS.map(p => p.prop), verdicts: results.filter(Boolean) }

--- a/kessel/gsf_stat_dictionary.toml
+++ b/kessel/gsf_stat_dictionary.toml
@@ -359,25 +359,33 @@ notes      = "barrel_roll = 30, power_dive = 15"
 label      = "scaling_factor"
 unit       = "ratio"
 confidence = "guess"
-notes      = "Always 1.0 in samples; meaning unverified"
+notes      = "53 of 55 rows are a vacuous 1.0 default (crew / shield / engine / mine / missile -- the prop is semantically empty there). The 2 real values are cooldown-gated drone weapons: drone.sentry_sniper.railgun=2.0 matches its summon text '...has a 2 second cooldown' exactly (and is distinct from 0x0402=180 lifetime and 0x041a=4.0 charge on the same ability); drone.sentry_missile.missile=12.0 is unconfirmable (blank text). So on those 2 abilities 0x0403 reads as a weapon cooldown in seconds -- but relabeling the prop to weapon_cooldown_seconds would FALSELY assert '1 second cooldown' on the 53 default rows, so the generic label is kept pending a per-FQN override that scopes the real meaning to the drone weapons. Finding 2026-06-16 (oracle pass)."
 
-[ability_stats.0x0401]
-label      = "cast_time_seconds"
-unit       = "s"
-confidence = "guess"
-notes      = "Range observed -1.0..75.0; -1.0 likely passive marker"
+# 0x0401 (GSF) -- DOWNGRADED to unknown 2026-06-16 (was guess 'cast_time_seconds').
+# Rank-1 (38 rows) is 100% sentinel: 20x 6.46924018859863 + 18x -1.0, zero real
+# values (6.46924018859863 occurs ONLY on 0x0401, never cross-prop -- it is a
+# 0x0401-local animation/uninit constant, not a shared marker). Rank-2 (13 rows) IS a
+# distinct real stat (30/45/60/75 on systems abilities, confirmed != cooldown 0x0402)
+# that resembles value/3 = duration seconds (60->20s, 45->15s, 75->25s, 30->10s) but is
+# UNCONFIRMABLE: every rank-2 carrier ends in a blank duration token, no description
+# number matches value or value/3. No entry -> populate emits unknown_0x0401. The
+# rank-2 real stat is a tracked follow-up (anchor needs a non-blank duration source).
 
 [ability_stats.0x0421]
-label      = "range_meters"
-unit       = "m"
-confidence = "guess"
-notes      = "Range observed 15..150"
+label      = "range_units"
+unit       = "100m"
+confidence = "verified"
+notes      = "Effect/proximity/trigger range in 100m units (value*100 = meters), same convention as verified 0x0407 -- but 0x0421 is the effect range and 0x0407 the weapon range, and no ability carries both. Text-anchored across 9 abilities (description-string oracle, verified 2026-06-16): mine.{concussion,interdiction,ion,seismic}_mine 15 -> 'explode if an enemy gets within 1500m' (4x convergence on the proximity-trigger number, not the larger blast radius); seeker_mine 40 -> 'within 4000m'; emp_field 45 -> '4500m radius'; face_target 150 -> 'within 15,000m' (decisive comma-formatted anchor); running_interference / wingman 30 -> 'within 3000m'. The 50.0 cluster (single-target crew debuffs, ion_burst / plasma_lance, remote_slicing) prints no range number -> 5000m plausible, unconfirmable, never contradictory. Lone outlier: shield_projector 0x0421=30 -> 3000m while its text prints a 5500m heal radius (55 is carried by no prop on that ability) -- scale-consistent, not a contradiction. Was 'range_meters' (off by 100x); corrected via adversarial oracle refutation."
 
-[ability_stats.0x0423]
-label      = "duration_seconds"
-unit       = "s"
-confidence = "guess"
-notes      = "Range observed 100..500"
+# 0x0423 -- DOWNGRADED to unknown 2026-06-16 (was guess 'duration_seconds', off).
+# Refuted via the description-string oracle: duration tokens render BLANK in static
+# text and 100-500 are absurd as seconds (railgun .hit / missile .on_fire are
+# instantaneous). Not range either (same value 100 across short- and medium-range
+# missiles; no 0x0407 co-occurs) and not damage (20/21 values absent from their own
+# description text; the lone thermite 150 -> '150% vs hull' is a flagged coincidence).
+# Behaves as a category enum (missiles=100, emp/proton/thermite torpedo class=150,
+# concentrated_fire=180, sustained field/buff=360, all railguns=500) but no in-archive
+# number names a unit. No entry here -> populate emits unknown_0x0423.
 
 
 # --- 2026-05-20 expansion (#117 corpus-anchored ability decodes) ---
@@ -392,9 +400,9 @@ notes      = "Range observed 100..500"
 # CF-content-guid byte sequences misread as f32 records. The decoder now
 # rejects those windows (see src/schema/gsf_ability.rs).
 #
-# 2 real-but-unlabelable prop_ids (0x0407 drone-only, 0x0424 laser-only)
-# carry FQN-class context but the binary does not name them; downstream
-# consumers can route by FQN prefix.
+# 0x0407 (drone-weapon range) is now VERIFIED as range_units/100m (below).
+# 0x0424 is NOT laser-only: a missile (target_painter.impact=50) shares it with
+# the 9 lasers (=5.0). See its downgrade note below.
 
 [ability_stats.0x0410]
 label      = "chargeup_time_seconds"
@@ -427,10 +435,10 @@ confidence = "verified"
 notes      = "Weapon power-pool cost per shot. Compound record `CC 08 4B DA B5 F9 04 <f32>`. Values: railgun.{ion,plasma,slug}.chargeup 0.12, secondary.ion_burst.on_fire 0.30, secondary.plama_lance.on_fire 0.60. Structural twin to talents 0x52 weapon_power_draw_pct (railgun -10%) and 0x56 weapon_power_cost_pct (laser/secondary -10%)"
 
 [ability_stats.0x041a]
-label      = "hard_cast_time_seconds"
+label      = "charge_time_seconds"
 unit       = "s"
 confidence = "guess"
-notes      = "Sentry drone arming + item-consume cast time: drone.sentry_missile.missile 2.5s, drone.sentry_sniper.railgun 4.0s, itemgrant.consume_item 3.0s. Same prop_id and semantic as the ground-ability dictionary entry for 0x041a (hard_cast_time_seconds). Confidence: guess pending ground-truth -- the values are plausible for the activity but the semantic is borrowed from the ground dictionary rather than corpus-confirmed for GSF"
+notes      = "Charge / arming time in raw seconds. 3 rows: drone.sentry_sniper.railgun=4.0 matches its summon text '...takes 4 seconds to charge...' exactly (the only '4' in the string; the 2s cooldown sits on 0x0403, the 180 lifetime on 0x0402 -- every other text number is claimed by another prop, leaving 0x041a holding the charge time); drone.sentry_missile.missile=2.5 and itemgrant.consume_item=3.0 are plausible but unconfirmed (no matching number in their text -- consume_item is not really a 'charge', the lone weak fit). Renamed from hard_cast_time_seconds 2026-06-16 -- 'seconds to charge' is the in-archive wording. Guess: 1 of 3 string-confirmed."
 
 [ability_stats.0x0407]
 label      = "range_units"
@@ -438,11 +446,20 @@ unit       = "100m"
 confidence = "verified"
 notes      = "Drone-weapon range in 100m units (value * 100 = meters). Anchored against in-corpus description strings: drone.sentry_missile.missile = 70 matches sentry_missile.summon description 'range of 7000m'; drone.sentry_sniper.railgun = 100 matches sentry_sniper.summon description '10000m range'. Same 100m-unit convention as 0x0421 (e.g. drone.sentry_interdiction.interdiction_field value 30 = 3000m radius per its summon description)"
 
-[ability_stats.0x0424]
-label      = "weapon_class_marker"
-unit       = "class"
-confidence = "guess"
-notes      = "Position-0 property in the flat block of direct-fire damage/impact sub-abilities. Class-level constant -- NOT per-component variance. GSF values: 5.0 on all 9 abl.spvp.laser.<comp>.damage rows, 50.0 on abl.spvp.missile.target_painter.impact. Wider corpus shows a hierarchy of values for the same prop_id across the legacy space-combat namespace: 100.0 on abl.space_combat.freeflight.primaryweapons.* (heavy primaries), 400.0 on abl.space_combat.player.torpedo, 500.0 on abl.space_combat.freeflight.chargeupweapons.*_onhit. The pattern (5/50/100/400/500) tracks weapon power tier within the SWTOR weapon namespace. CB-token blocks following the property block are IDENTICAL bytes across standard/heavy/quad lasers, confirming the .damage payload carries no per-component variance -- per-laser damage/range/arc lives in a separate scFF*Prototype singleton (out of scope for #117; tracked under #115 / scFFComponentsPrototype). Label is 'guess' because the binary does not name the field; the structural argument is class-marker, not in-game-validated"
+# 0x0424 -- DOWNGRADED to unknown 2026-06-16 (was guess 'weapon_class_marker').
+# 10 rows: 5.0 on all 9 abl.spvp.laser.<comp>.damage, 50.0 on missile.target_painter.impact.
+# The 'weapon class marker' label is refuted by cross-prop evidence: (1) a MISSILE shares
+# the prop with the lasers, so its presence does not isolate a weapon class and 50-vs-5 does
+# not encode one class; (2) the twin prop 0x0423 carries 100/150/180/360/500 across
+# crew.active.* / engine.* / systems.* / railgun / missile -- a generic per-ability quantity
+# spanning NON-weapon abilities, and 0x0423 vs 0x0424 are mutually exclusive on the weapon
+# damage leaves (lasers->0x0424=5; rocket_pod/target_tracker->0x0423=100; target_painter->
+# 0x0424=50), reading as one measured field split across two ids, not a class enum;
+# (3) no id1=1 description string exists for any carrier or its parent, so the oracle cannot
+# anchor a unit/scale for 5 or 50. The earlier structural note (5/50/100/400/500 hierarchy
+# across the space_combat namespace; identical CB-token blocks across lasers; per-laser
+# stats live in a scFF*Prototype singleton, #115) remains useful context but does not name
+# the field. No entry -> populate emits unknown_0x0424. Re-anchor needs the scFF* singleton."
 
 
 # abl.* (ground ability) `0x04xx` prop_id (u16) labels for ability_stats.raw_props.


### PR DESCRIPTION
## Summary

Six `[ability_stats]` prop_ids in `gsf_stat_dictionary.toml` carried unverified `guess` labels (two flagged suspect by huttspawn). This change verifies all six against the **in-archive description-string oracle** — matching each decoded f32 value to a number written in the ability's own `id1=1` description text — the same method that verified `0x0407`/`0x0410`/`0x0439`. It deliberately does *not* use community/internet GSF numbers, which quote talented/crewed values and cannot pin a base prop. Each verdict came out of a decode → adversarial-refute pipeline (`docs/probes/gsf-propid-verify.workflow.js`), one independent skeptic per proposal. Dictionary-only; the shipped spice is unaffected until a re-extraction.

## Acceptance criteria mapping

### 1. `0x0421` corrected and text-anchored across multiple abilities
The label was `range_meters` (unit `m`); the values 15/30/40/45/50/150 are 100× too small to be meters. The description strings resolve it: `face_target`=150 → "within 15,000m", `emp_field`=45 → "4500m radius", four mines=15 → "within 1500m", `seeker_mine`=40 → "4000m", `running_interference`/`wingman`=30 → "3000m". That is 9 explicit-text anchors all obeying `value*100 = meters`, so the entry is now `range_units` / `100m` / verified — matching the already-verified `0x0407` convention (and distinct from it: `0x0421` is effect/trigger range, `0x0407` weapon range; no ability carries both).
Evidence: `kessel/gsf_stat_dictionary.toml` `0x0421` entry; `docs/probes/gsf-propid-verify.md` verdict row; refutation in the workflow result (the lone `shield_projector` outlier is scale-consistent, not contradictory).

### 2. `0x0423` resolved with the duration label refuted
Refuted three ways: GSF duration tokens render blank in static text (so "duration_seconds" is unconfirmable by construction), 100–500s are absurd against the actual 4–6s effect windows, and `.hit`/`.on_fire` carriers are instantaneous. A literal-substring check found 20/21 values absent from their own description. The values behave as a category enum (missiles=100, torpedo class=150, fields=360, railguns=500) but no in-archive number names a unit, so the entry is removed and `populate` now emits `unknown_0x0423`.
Evidence: the `0x0423` downgrade comment in the TOML; the refutation notes captured in `docs/probes/gsf-propid-verify.md`.

### 3. `0x0424` and `0x0401` verified/refined/downgraded with evidence
`0x0424` ("weapon_class_marker") is refuted: a missile (`target_painter`=50) shares the prop with the 9 lasers (=5), the twin prop `0x0423` spans crew/engine/systems abilities, and no description anchors 5 or 50 — downgraded to `unknown`. `0x0401` ("cast_time_seconds") is refuted: rank-1 is 100% sentinel (`6.46924018859863` + `-1.0`), and rank-2 is a real stat (30/45/60/75) but every carrier ends in a blank duration token, so it cannot be anchored — downgraded to `unknown`. Neither is left asserting a wrong meaning.
Evidence: the `0x0424` and `0x0401` downgrade comments in the TOML; verdict rows in the evidence doc.

### 4. `0x0403`/`0x041a` reviewed without introducing false assertions
`0x0403` is mostly a vacuous `1.0` default (53/55 rows); only drone weapons carry a real value (`railgun`=2.0 matches "2 second cooldown"). Relabeling to `weapon_cooldown_seconds` would falsely assert a 1-second cooldown on the 53 default rows, so the label is kept and the note records the finding plus the per-FQN-override path. `0x041a` is renamed `hard_cast_time_seconds` → `charge_time_seconds` (the railgun text literally reads "takes 4 seconds to charge", and every other number on that ability is claimed by another prop), at the same `guess` confidence — a strictly better-anchored label with no new false assertion (the `consume_item` weak fit is noted).
Evidence: the `0x0403` and `0x041a` entries in the TOML with their enriched notes.

### 5. Adversarial verification + green build, no re-extraction
Every proposal was checked by a second independent agent prompted to refute it (re-running the queries, testing for blank-token coincidences, sentinel contamination, and better-fitting stats); the workflow script is committed for reproducibility. `cargo build --release -p kessel`, `cargo test -p kessel`, and `cargo clippy -p kessel -- -D warnings` are green; `fmt` is clean on tracked files (the only fmt diffs are pre-existing untracked discovery scratch files). The change is dictionary-only — no extraction was run, so `spice-7.9-v1` is untouched.
Evidence: build/test/clippy output this session; `git diff main..HEAD --stat` shows only the TOML + two `docs/probes/` files.

## Not done

No re-extraction was triggered, so the shipped DB still has the old labels until a rebuild — intentional (re-extraction is ~3.6 GB and the operator's call). The `0x0403` per-FQN override that would scope `weapon_cooldown_seconds` to just the drone weapons, the `0x0401` rank-2 stat (real but blank-token-gated), and re-anchoring `0x0424` from the `scFF*Prototype` singleton (#115) are left as tracked follow-ups, not attempted here.