### PR TITLE
feat(gsf): land gsf_ships roster + gsf_loadout_slots taxonomy (#302)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -624,6 +624,39 @@ ship loadout trees from this table via `component_kind` / `art_path`.
 | `art_path` | TEXT | Component art-resource path (used to group components by ship/slot). |
 | `component_kind` | TEXT | Component category derived from the art path. |
 
+### gsf_ships
+
+The GSF premium starter-ship roster -- the 10 `itm.spvp.ships.premium.*` objects,
+five hull classes per faction. Pure relational decode (name + faction + class).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `fqn` | TEXT PK | Ship item FQN, e.g. `itm.spvp.ships.premium.imp_scout_01`. |
+| `game_id` | TEXT | The ship object's `objects.game_id`. |
+| `name` | TEXT | Display name (`strings` id1=0, en-us), e.g. `IL-5 Ocula`, `G-X1 Onslaught`. |
+| `faction` | TEXT | `empire` (`imp_` ships) or `republic` (`rep_` ships). |
+| `ship_class` | TEXT | `bomber`, `gunship`, `scout`, or `striker` (the `_NN` variant suffix is stripped; both `gunship_01` and `gunship_02` map to `gunship`). |
+
+### gsf_loadout_slots
+
+The GSF component-slot taxonomy, decoded from the `conSpec_scff_equip_*` slot-template
+singletons. One row per distinct component slot a template declares. Major templates
+carry the weapon/shield/engine slots; minor templates carry four of the
+armor/capacitor/magazine/reactor/sensor/thruster slots. ~59 rows.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `template_code` | TEXT | Template suffix after `conSpec_scff_equip_`, e.g. `maj_PPSHE`, `min_ACMR`. PK part 1. |
+| `slot_kind` | TEXT | `major` or `minor`. |
+| `slot_type` | TEXT | `PrimaryWeapon`, `SecondaryWeapon`, `ShieldProjector`, `Engine`, `AuxSystem` (major); `Armor`, `Capacitor`, `Magazine`, `Reactor`, `Sensor`, `Thruster` (minor). PK part 2. |
+| `slot_ordinal` | INTEGER | 1-based ordinal within the slot type (e.g. `PrimaryWeapon_1`, `PrimaryWeapon_2`). PK part 3. |
+
+**Ship -> template binding is NOT in the archive.** The `itm.spvp.ships.premium.*`
+payloads reference only shared item templates and the ship's appearance, not a
+loadout template -- the binding is client-side. A consumer maps a ship to its slot
+layout by `ship_class` (the well-defined GSF class -> layout convention), joining
+`gsf_ships.ship_class` to the appropriate `gsf_loadout_slots.template_code`.
+
 ---
 
 ## Item tables

--- a/kessel/src/db/ability.rs
+++ b/kessel/src/db/ability.rs
@@ -844,6 +844,129 @@ impl Database {
         Ok((component_rows, tier_rows))
     }
 
+    /// Populate `gsf_ships` -- the GSF premium starter-ship roster, the 10
+    /// `itm.spvp.ships.premium.*` objects with display name, faction, and class.
+    /// Pure relational pass (no byte decode); the ship -> loadout-template
+    /// binding is client-side and not stored in these payloads. Issue #115
+    /// lineage. Returns the row count.
+    pub fn populate_gsf_ships(&self) -> Result<u64> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut rows = 0u64;
+        {
+            // (fqn, game_id, name, string_id) for the 10 premium ships.
+            let ships: Vec<(String, String, Option<String>)> = {
+                let mut stmt = tx.prepare(
+                    "SELECT o.fqn, o.game_id, \
+                            (SELECT s.text FROM strings s \
+                              WHERE s.id2 = o.string_id AND s.locale = 'en-us' AND s.id1 = 0 \
+                              LIMIT 1) AS name \
+                       FROM objects o \
+                      WHERE o.is_canonical = 1 \
+                        AND o.fqn LIKE 'itm.spvp.ships.premium.%'",
+                )?;
+                let ships: Vec<(String, String, Option<String>)> = stmt
+                    .query_map([], |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, String>(1)?,
+                            r.get::<_, Option<String>>(2)?,
+                        ))
+                    })?
+                    .filter_map(|r| r.ok())
+                    .collect();
+                ships
+            };
+
+            let mut insert = tx.prepare_cached(
+                "INSERT OR REPLACE INTO gsf_ships \
+                   (fqn, game_id, name, faction, ship_class) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for (fqn, game_id, name) in ships {
+                // Segment after 'itm.spvp.ships.premium.', e.g. 'imp_gunship_02'.
+                let seg = fqn.rsplit('.').next().unwrap_or("").to_string();
+                let (faction, rest) = if let Some(r) = seg.strip_prefix("imp_") {
+                    (Some("empire"), r)
+                } else if let Some(r) = seg.strip_prefix("rep_") {
+                    (Some("republic"), r)
+                } else {
+                    (None, seg.as_str())
+                };
+                // Class = `rest` minus a trailing `_NN` variant suffix.
+                let ship_class = rest
+                    .rsplit_once('_')
+                    .map(|(c, _)| c)
+                    .unwrap_or(rest)
+                    .to_string();
+                insert.execute(params![fqn, game_id, name, faction, ship_class,])?;
+                rows += 1;
+            }
+        }
+        tx.commit()?;
+        Ok(rows)
+    }
+
+    /// Populate `gsf_loadout_slots` from the `conSpec_scff_equip_*` slot-template
+    /// singletons. One row per distinct component slot a template declares.
+    /// Issue #115 lineage. Returns the row count.
+    pub fn populate_gsf_loadout_slots(&self) -> Result<u64> {
+        use crate::schema::gsf_loadout::decode_loadout_slots;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        // Load every loadout-template singleton payload.
+        let templates: Vec<(String, Vec<u8>)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT fqn, payload_b64 FROM singletons \
+                  WHERE fqn LIKE 'conSpec_scff_equip_%'",
+            )?;
+            let templates: Vec<(String, Vec<u8>)> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .filter_map(|(fqn, b64)| BASE64.decode(&b64).ok().map(|b| (fqn, b)))
+                .collect();
+            templates
+        };
+
+        let mut rows = 0u64;
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        {
+            let mut insert = tx.prepare_cached(
+                "INSERT OR REPLACE INTO gsf_loadout_slots \
+                   (template_code, slot_kind, slot_type, slot_ordinal) \
+                 VALUES (?1, ?2, ?3, ?4)",
+            )?;
+            for (fqn, payload) in templates {
+                let template_code = fqn
+                    .strip_prefix("conSpec_scff_equip_")
+                    .unwrap_or(&fqn)
+                    .to_string();
+                let slot_kind = if template_code.starts_with("maj_") {
+                    "major"
+                } else if template_code.starts_with("min_") {
+                    "minor"
+                } else {
+                    continue; // skip quickslot / other shapes (no slots)
+                };
+                for slot in decode_loadout_slots(&payload) {
+                    insert.execute(params![
+                        template_code,
+                        slot_kind,
+                        slot.slot_type,
+                        slot.slot_ordinal,
+                    ])?;
+                    rows += 1;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(rows)
+    }
+
     /// Resolve `gsf_requisition_costs.target_guid` to art_path + component_kind
     /// via the `data` singleton (#217). Each cost target_guid (8 bytes) is
     /// `<6-byte content_guid_tail><0x04><0x03>`. The 6-byte tail appears in
@@ -2626,6 +2749,29 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
             );
             CREATE INDEX IF NOT EXISTS idx_gsf_req_costs_target ON gsf_requisition_costs(target_game_id);
             CREATE INDEX IF NOT EXISTS idx_gsf_req_costs_kind ON gsf_requisition_costs(component_kind);
+            -- GSF premium starter-ship roster (#115 lineage). The 10
+            -- itm.spvp.ships.premium.* objects with display name, faction, and
+            -- class. The ship -> loadout-template binding is NOT in the archive
+            -- (client-side); consumers map it by ship_class.
+            CREATE TABLE IF NOT EXISTS gsf_ships (
+                fqn         TEXT PRIMARY KEY,
+                game_id     TEXT,
+                name        TEXT,
+                faction     TEXT,
+                ship_class  TEXT
+            );
+            -- GSF loadout slot templates (#115 lineage). Decoded from the
+            -- conSpec_scff_equip_* singletons; one row per distinct component
+            -- slot a template declares. Major templates carry the
+            -- weapon/shield/engine slots, minor templates the four
+            -- armor/capacitor/magazine/reactor/sensor/thruster-class slots.
+            CREATE TABLE IF NOT EXISTS gsf_loadout_slots (
+                template_code  TEXT NOT NULL,
+                slot_kind      TEXT NOT NULL CHECK (slot_kind IN ('major', 'minor')),
+                slot_type      TEXT NOT NULL,
+                slot_ordinal   INTEGER NOT NULL,
+                PRIMARY KEY (template_code, slot_type, slot_ordinal)
+            );
             -- Ability/talent -> effect block linkage (#173). One row per
             -- indexed CF E0 sub-record in the parent's payload. The parent
             -- self-reference is NOT included; this table is the structural

--- a/kessel/src/db/passes.rs
+++ b/kessel/src/db/passes.rs
@@ -362,6 +362,16 @@ pub fn run_passes(db: &Database, ctx: &PassCtx) -> Result<PassCounts> {
     let gsf_cost_targets = timed!("gsf_cost_targets", db.populate_gsf_cost_targets())?;
     println!("  GSF cost targets resolved: {} rows", gsf_cost_targets);
 
+    // GSF ship roster + loadout slot templates (#115 lineage). gsf_ships is the
+    // 10 premium starter ships; gsf_loadout_slots is the component-slot taxonomy
+    // decoded from the conSpec_scff_equip_* singletons.
+    let gsf_ships = timed!("gsf_ships", db.populate_gsf_ships())?;
+    let gsf_loadout_slots = timed!("gsf_loadout_slots", db.populate_gsf_loadout_slots())?;
+    println!(
+        "  GSF ships: {} rows, loadout slots: {} rows",
+        gsf_ships, gsf_loadout_slots
+    );
+
     // Twelfth-and-seven-eighths pass: ability/talent → effect block linkage
     // (issue #173). One row per indexed CF E0 sub-record in each abl.*/tal.*
     // payload. Unresolved block GUIDs (versioned-only ability category, #179)

--- a/kessel/src/schema/gsf_loadout.rs
+++ b/kessel/src/schema/gsf_loadout.rs
@@ -1,0 +1,135 @@
+//! Decoder for the GSF ship loadout slot-template singletons
+//! (`conSpec_scff_equip_*`).
+//!
+//! Each template declares the component slots a GSF ship configuration of that
+//! shape exposes. Major templates (`conSpec_scff_equip_maj_*`) carry the
+//! weapon/shield/engine slots; minor templates (`conSpec_scff_equip_min_*`)
+//! carry the four reactor/armor/sensor-class slots. The template-code suffix
+//! spells the composition (e.g. `maj_PPSHE` = 2x Primary + Secondary + Shield +
+//! Engine; `min_ACMR` = Armor/Capacitor/Magazine/Reactor).
+//!
+//! Wire format: the payload is a typed-value GOM stream; the slot names appear
+//! as length-prefixed ASCII strings of the form
+//! `conSlotEquipSCFF<SlotType>_<ordinal>`. Each slot is written twice (an
+//! available-list copy and a default copy), so the decoder dedupes on
+//! `(slot_type, ordinal)`. We scan for the fixed `conSlotEquipSCFF` marker
+//! rather than walking the full type-tag stream -- the marker is unambiguous
+//! and the surrounding framing carries no extra per-slot data.
+//!
+//! The ship -> template binding is NOT stored in the archive (the
+//! `itm.spvp.ships.premium.*` payloads reference only shared item templates and
+//! their appearance, not a loadout template); it is client-side and resolved by
+//! ship class downstream. Issue #115 lineage.
+
+/// One component slot within a loadout template.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadoutSlot {
+    /// Slot type token, e.g. `PrimaryWeapon`, `ShieldProjector`, `Armor`.
+    pub slot_type: String,
+    /// 1-based slot ordinal within its type (e.g. `PrimaryWeapon_1`,
+    /// `PrimaryWeapon_2`).
+    pub slot_ordinal: u32,
+}
+
+const MARKER: &[u8] = b"conSlotEquipSCFF";
+
+/// Decode the distinct component slots declared by a `conSpec_scff_equip_*`
+/// template payload. Returns slots in first-seen order, deduped on
+/// `(slot_type, ordinal)`.
+pub fn decode_loadout_slots(payload: &[u8]) -> Vec<LoadoutSlot> {
+    let mut out: Vec<LoadoutSlot> = Vec::new();
+    let mut i = 0usize;
+    while i + MARKER.len() <= payload.len() {
+        if &payload[i..i + MARKER.len()] != MARKER {
+            i += 1;
+            continue;
+        }
+        let mut j = i + MARKER.len();
+        // Slot type: leading ASCII alphabetic run.
+        let type_start = j;
+        while j < payload.len() && payload[j].is_ascii_alphabetic() {
+            j += 1;
+        }
+        // Expect the `_<ordinal>` suffix.
+        if j >= payload.len() || payload[j] != b'_' {
+            i += MARKER.len();
+            continue;
+        }
+        let slot_type = String::from_utf8_lossy(&payload[type_start..j]).into_owned();
+        j += 1; // skip '_'
+        let ord_start = j;
+        while j < payload.len() && payload[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j == ord_start {
+            i += MARKER.len();
+            continue;
+        }
+        let ordinal: u32 = String::from_utf8_lossy(&payload[ord_start..j])
+            .parse()
+            .unwrap_or(0);
+        if slot_type.is_empty() || ordinal == 0 {
+            i = j;
+            continue;
+        }
+        let slot = LoadoutSlot {
+            slot_type,
+            slot_ordinal: ordinal,
+        };
+        if !out.contains(&slot) {
+            out.push(slot);
+        }
+        i = j;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+    // Real `conSpec_scff_equip_maj_PPSHE` payload (spice-7.9.a-v1).
+    const PPSHE_B64: &str = "EA3PQAAAAzKB/wwIBQIEBEQCRQFGAUgBzARKXVnDCAUCBAREAEUCRgRIA8wD5FAnqggFBwQERAIAAEUCAABGAgAASAIAAAEFIQEIBQcEBEQCAABFAgAARgIAAEgCAADMAzJViUwIBQcEBEQCAABFAgAARgIAAEgCAADMAnnPaHMGHGNvblNwZWNfc2NmZl9lcXVpcF9tYWpfUFBTSEXMC9eSTkYIAgUFBQFEAkQDRQRIBUbMEnBQ4QAIBQcEBEQCAgIBAQICRQIBAQEDRgIBAQEFSAIBAQEEzAEGM5DQCAYCBQXSGGNvblNsb3RFcXVpcFNDRkZFbmdpbmVfMQXSH2NvblNsb3RFcXVpcFNDRkZQcmltYXJ5V2VhcG9uXzEB0h9jb25TbG90RXF1aXBTQ0ZGUHJpbWFyeVdlYXBvbl8yAtIhY29uU2xvdEVxdWlwU0NGRlNlY29uZGFyeVdlYXBvbl8xA9IhY29uU2xvdEVxdWlwU0NGRlNoaWVsZFByb2plY3Rvcl8xBAEIAgYFBQEfY29uU2xvdEVxdWlwU0NGRlByaW1hcnlXZWFwb25fMQIfY29uU2xvdEVxdWlwU0NGRlByaW1hcnlXZWFwb25fMgMhY29uU2xvdEVxdWlwU0NGRlNlY29uZGFyeVdlYXBvbl8xBCFjb25TbG90RXF1aXBTQ0ZGU2hpZWxkUHJvamVjdG9yXzEFGGNvblNsb3RFcXVpcFNDRkZFbmdpbmVfMcweFFd9pwIFzQOElU6auAgFAwQERABFAEYASAA=";
+
+    #[test]
+    fn decodes_ppshe_major_template() {
+        let payload = BASE64.decode(PPSHE_B64).expect("valid b64");
+        let slots = decode_loadout_slots(&payload);
+        let mut got: Vec<(String, u32)> = slots
+            .into_iter()
+            .map(|s| (s.slot_type, s.slot_ordinal))
+            .collect();
+        got.sort();
+        let mut want = vec![
+            ("Engine".to_string(), 1),
+            ("PrimaryWeapon".to_string(), 1),
+            ("PrimaryWeapon".to_string(), 2),
+            ("SecondaryWeapon".to_string(), 1),
+            ("ShieldProjector".to_string(), 1),
+        ];
+        want.sort();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn dedupes_repeated_slot_copies() {
+        // Two identical slot strings collapse to one row.
+        let mut p = Vec::new();
+        p.extend_from_slice(b"\x06conSlotEquipSCFFArmor_1");
+        p.extend_from_slice(b"\x06conSlotEquipSCFFArmor_1");
+        let slots = decode_loadout_slots(&p);
+        assert_eq!(
+            slots,
+            vec![LoadoutSlot {
+                slot_type: "Armor".to_string(),
+                slot_ordinal: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn ignores_payload_without_marker() {
+        assert!(decode_loadout_slots(b"no slots here").is_empty());
+    }
+}

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -7,6 +7,7 @@ pub mod epp;
 pub mod fxspec;
 pub mod gsf_ability;
 pub mod gsf_costs;
+pub mod gsf_loadout;
 pub mod gsf_talent;
 pub mod item;
 pub mod tag_table;


### PR DESCRIPTION
## Summary

The GSF loadout/slot structure was decoded in prior recon (the `decode_gsf_prototypes.rs` side-quest) but never integrated into the extraction pipeline -- the cost and crew tables landed, the loadout structure didn't. This change lands two pure in-archive captures so spice finally carries the GSF ship roster and the component-slot taxonomy. Decoder/pipeline change only; population lands on the next extraction.

## Acceptance criteria mapping

### 1. gsf_ships table -- the 10 premium starter ships
A relational pass (`populate_gsf_ships`) over `objects WHERE fqn LIKE 'itm.spvp.ships.premium.%' AND is_canonical = 1` resolves each ship's display name (correlated `strings` subquery, id1=0/en-us), derives `faction` from the `imp_`/`rep_` prefix, and derives `ship_class` by stripping the faction prefix and the trailing `_NN` variant suffix (so `imp_gunship_01` and `imp_gunship_02` both yield `gunship`). No byte decode needed.
Evidence: `kessel/src/db/ability.rs` `populate_gsf_ships`; table created in the schema block; `docs/schema.md` `gsf_ships` entry. Verified roster (10 rows): G-X1 Onslaught, K-52 Demolisher, VX-9 Mailoc, IL-5 Ocula, TZ-24 Gladiator (empire) + the republic mirror set.

### 2. gsf_loadout_slots table -- the component-slot taxonomy
`populate_gsf_loadout_slots` reads every `conSpec_scff_equip_%` payload from the `singletons` table (same base64 + decode idiom as `populate_gsf_requisition_costs`), runs the decoder, and inserts one row per distinct slot with `template_code`, `slot_kind` (major/minor from the `maj_`/`min_` prefix), `slot_type`, and `slot_ordinal`. The `quickslot` template (no slots) is skipped.
Evidence: `populate_gsf_loadout_slots` in `ability.rs`; `gsf_loadout_slots` CREATE TABLE; `docs/schema.md` entry. ~59 rows across the 14 templates.

### 3. Pure, unit-tested decoder
`schema/gsf_loadout.rs` exposes `decode_loadout_slots(&[u8]) -> Vec<LoadoutSlot>` -- it scans for the fixed `conSlotEquipSCFF` marker, parses `<SlotType>_<ordinal>`, and dedupes the available/default double-write on `(slot_type, ordinal)`. Three unit tests: the real `maj_PPSHE` payload decodes to exactly its 5 slots (Engine_1, PrimaryWeapon_1/2, SecondaryWeapon_1, ShieldProjector_1), repeated-copy dedup, and empty-on-no-marker.
Evidence: `#[cfg(test)] mod tests` in `schema/gsf_loadout.rs`; `cargo test -p kessel --lib gsf_loadout` -> 3 passed.

### 4. Wiring + docs, ship->template gap documented
Module registered in `schema/mod.rs`; both passes registered in `db/passes.rs` next to `gsf_requisition_costs`; both tables created in the schema block. `docs/schema.md` documents both tables and states explicitly that the ship->template binding is NOT in the archive (the ship payloads reference only shared item templates + appearance) -- it is client-side, mapped by `ship_class`.
Evidence: `schema/mod.rs`, `db/passes.rs`, `docs/schema.md` diffs.

### 5. Green
`cargo build --release -p kessel`, `cargo clippy -p kessel -- -D warnings`, and `cargo test -p kessel` (259 lib + the 3 new) all pass; `cargo fmt --check` is clean on `kessel/src`. The only fmt diffs in the tree are two pre-existing untracked `kessel-discovery/examples/*.rs` scratch files, not part of this change.
Evidence: build/clippy/test/fmt output this session; `git diff main..HEAD --stat` shows only the 5 files.

## Not done

No re-extraction was triggered, so the shipped DB does not yet carry the two tables -- they populate on the next extract (operator's call). The ship->template binding is left to consumers (by `ship_class`) because it genuinely is not in the archive; a synthetic class->template mapping table could be added later if a consumer wants it pre-joined. Per-component combat stats (the separate `0x0423`/`0x0424` question) remain out of scope -- not in the archive.