### PR TITLE
feat(strings): preserve raw STB template text in strings.text_raw (#307)

### DIFF
--- a/kessel/src/db/mod.rs
+++ b/kessel/src/db/mod.rs
@@ -96,7 +96,28 @@ struct PendingString {
     id1: u32,
     id2: u32,
     text: String,
+    /// Raw STB text before grammar cleaning. `Some` only when cleaning changed
+    /// the text (preserving `<<N>>` templates); `None` when identical to `text`
+    /// so unchanged strings aren't stored twice.
+    text_raw: Option<String>,
     version: u32,
+}
+
+/// Apply grammar cleaning to a raw STB string and return
+/// `(cleaned_text, raw_text_if_changed)`. The raw form is returned only when
+/// cleaning altered the text, so the `strings.text_raw` column stays NULL for
+/// the common case where the display text and raw text are identical.
+fn prepare_string(grammar: Option<&Grammar>, raw: &str) -> (String, Option<String>) {
+    let cleaned = match grammar {
+        Some(g) => g.clean(raw),
+        None => raw.to_string(),
+    };
+    let text_raw = if cleaned != raw {
+        Some(raw.to_string())
+    } else {
+        None
+    };
+    (cleaned, text_raw)
 }
 
 pub struct Database {
@@ -251,12 +272,9 @@ impl Database {
     /// Queue a string for batch insert
     /// If grammar rules are configured, applies them to clean the text
     pub fn insert_string(&self, fqn: &str, locale: &str, entry: &StbEntry) -> Result<()> {
-        // Apply grammar rules if configured
-        let cleaned_text = if let Some(ref grammar) = self.grammar {
-            grammar.clean(&entry.text)
-        } else {
-            entry.text.clone()
-        };
+        // Apply grammar rules if configured, keeping the raw form when cleaning
+        // changed the text (so <<N>> templates survive in `text_raw`).
+        let (cleaned_text, text_raw) = prepare_string(self.grammar.as_deref(), &entry.text);
 
         let pending = PendingString {
             fqn: fqn.to_string(),
@@ -264,6 +282,7 @@ impl Database {
             id1: entry.id1,
             id2: entry.id2,
             text: cleaned_text,
+            text_raw,
             version: entry.version,
         };
 
@@ -345,20 +364,23 @@ impl Database {
         {
             let mut stmt = tx.prepare_cached(
                 r#"
-                INSERT INTO strings (fqn, locale, id1, id2, text, version)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                INSERT INTO strings (fqn, locale, id1, id2, text, text_raw, version)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                 ON CONFLICT(fqn) DO UPDATE SET
                     locale = excluded.locale,
                     id1 = excluded.id1,
                     id2 = excluded.id2,
                     text = excluded.text,
+                    text_raw = excluded.text_raw,
                     version = excluded.version
                 WHERE excluded.version > strings.version
                 "#,
             )?;
 
             for s in &batch {
-                stmt.execute(params![s.fqn, s.locale, s.id1, s.id2, s.text, s.version])?;
+                stmt.execute(params![
+                    s.fqn, s.locale, s.id1, s.id2, s.text, s.text_raw, s.version
+                ])?;
             }
         }
 
@@ -861,6 +883,39 @@ const ABILITY_PROP_SENTINEL: [u8; 6] = [0x01, 0x04, 0x00, 0x00, 0x80, 0xBF];
 mod tests {
     use super::*;
     use crate::db::testutil::*;
+
+    #[test]
+    fn prepare_string_preserves_template_when_clean_changes_text() {
+        let grammar = Grammar::from_embedded().unwrap();
+        let raw = "lasts for <<1>> seconds";
+        let (cleaned, text_raw) = prepare_string(Some(&grammar), raw);
+        assert!(
+            !cleaned.contains("<<"),
+            "display text must be cleaned: {cleaned}"
+        );
+        assert_ne!(cleaned, raw);
+        assert_eq!(text_raw.as_deref(), Some(raw));
+    }
+
+    #[test]
+    fn prepare_string_is_none_when_clean_is_noop() {
+        let grammar = Grammar::from_embedded().unwrap();
+        let raw = "Power Surge";
+        let (cleaned, text_raw) = prepare_string(Some(&grammar), raw);
+        assert_eq!(cleaned, raw);
+        assert_eq!(
+            text_raw, None,
+            "identical text must not be duplicated into text_raw"
+        );
+    }
+
+    #[test]
+    fn prepare_string_without_grammar_never_stores_raw() {
+        let raw = "lasts for <<1>> seconds";
+        let (cleaned, text_raw) = prepare_string(None, raw);
+        assert_eq!(cleaned, raw);
+        assert_eq!(text_raw, None);
+    }
 
     #[test]
     fn parse_spn_triple_extracts_all_three_parts() {

--- a/kessel/src/db/schema.rs
+++ b/kessel/src/db/schema.rs
@@ -68,7 +68,8 @@ pub(crate) fn create_core_tables(tx: &Transaction) -> Result<()> {
                 locale TEXT NOT NULL,          -- Locale: "en-us"
                 id1 INTEGER NOT NULL,          -- STB ID1
                 id2 INTEGER NOT NULL,          -- STB ID2 (links to objects.string_id)
-                text TEXT NOT NULL,            -- Display text
+                text TEXT NOT NULL,            -- Display text (grammar-cleaned: <<N>> templates stripped)
+                text_raw TEXT,                 -- Raw STB text before grammar.clean(); NULL when identical to `text`. Preserves <<N>> positional templates for stat-value/label anchoring.
                 version INTEGER DEFAULT 0
             );
 


### PR DESCRIPTION
## Summary

Adds `strings.text_raw`, the pre-`grammar.clean()` STB text, so SWTOR `<<N>>` positional template tokens survive extraction instead of being discarded. The cleaned `text` column is unchanged (huttspawn renders it directly); raw text goes only in the new nullable column, populated only when cleaning altered the string. This is the enabler for relic-proc value recovery (#308) and description-anchored stat labeling (#309), and it unblocks re-auditing the "client-residual" verdicts (#310).

## Acceptance criteria mapping

### 1. `text_raw` holds the template-bearing raw text; `text` stays cleaned
`insert_string` (db/mod.rs) now calls a new `prepare_string(grammar, raw) -> (cleaned, raw_if_changed)` helper: it cleans as before and returns the raw text only when cleaning changed it (else `None`, so identical strings aren't duplicated). `PendingString` carries `text_raw: Option<String>`; `flush_strings` writes it as the 7th column with matching `ON CONFLICT` update. Schema adds `text_raw TEXT` (nullable) to the `strings` CREATE TABLE (db/schema.rs).
Evidence (validated against a fresh extraction, `spice-7.9.a-v3`): `SELECT text_raw FROM strings WHERE id2=755312 AND id1=1` = `"...grant 510 Power for <<1>> seconds...once every 20 seconds"`; the same row's `text` has no `<<`. 26,527 rows have `text_raw` populated; 5,934 carry `<<` templates that were previously thrown away.

### 2. Single chokepoint, no new producers
`insert_string` is the only string producer (`main.rs:254`); the change is localized to it + the flush + the struct + schema. No other call site.
Evidence: `git diff main..HEAD --stat` -- only `db/mod.rs` and `db/schema.rs`.

### 3. huttspawn additive-safe
huttspawn reads `strings` with explicit `SELECT id2, id1, text` (never `SELECT *`), so an added column cannot break it; `text` is unchanged.
Evidence: `huttspawn/src/data/strings.ts:64-71`.

### 4. Tests + green
Three unit tests on `prepare_string`: template preserved when cleaning changes text; `None` when clean is a no-op; `None` when no grammar configured.
Evidence: `cargo test -p kessel` (262 pass), `cargo clippy -p kessel -- -D warnings`, `cargo fmt --check` (my files clean) all green.

## Not done

Parsing the preserved templates is intentionally out of scope -- that is #308 (relic procs) and #309 (stat labeling). No backfill of existing DBs; `text_raw` populates on the next extraction. Storing `text_raw = NULL` when identical to `text` is a deliberate size optimization.