### PR TITLE
feat(gsf): persist gsf_ability_stats.payload_ordinal (#309 foundation)

### DIFF
--- a/kessel/src/db/ability.rs
+++ b/kessel/src/db/ability.rs
@@ -323,8 +323,8 @@ impl Database {
         let tx = conn.unchecked_transaction()?;
         let mut stmt = tx.prepare_cached(
             "INSERT OR REPLACE INTO gsf_ability_stats \
-             (ability_game_id, label, unit, rank, value, confidence, prop_id) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+             (ability_game_id, label, unit, rank, value, confidence, prop_id, payload_ordinal) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         )?;
 
         let mut count: u64 = 0;
@@ -347,6 +347,7 @@ impl Database {
                     rec.value as f64,
                     label.confidence,
                     rec.prop_id as i64,
+                    rec.ordinal as i64,
                 ])?;
                 count += 1;
             }
@@ -2716,6 +2717,7 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
                 value           REAL NOT NULL,
                 confidence      TEXT NOT NULL,
                 prop_id         INTEGER NOT NULL,  -- raw u16 for forensics
+                payload_ordinal INTEGER,           -- 0-based payload emission order of this record; the index a <<N>> description template anchors to (distinct from per-label `rank`). #309.
                 PRIMARY KEY (ability_game_id, label, rank),
                 FOREIGN KEY (ability_game_id) REFERENCES objects(game_id)
             );


### PR DESCRIPTION
## Summary

The GSF ability-stat decoder computes `GsfAbilityStatRecord.ordinal` (0-based payload emission order) but `populate_gsf_ability_stats` discarded it, persisting only per-label `rank`. This adds a nullable `payload_ordinal` column and writes `rec.ordinal` to it. It is the index a SWTOR `<<N>>` description template anchors to -- the first concrete requirement of #309 (description-anchored stat labeling).

## Acceptance criteria mapping

### 1. Persist the decoder ordinal
`gsf_ability_stats` gains `payload_ordinal INTEGER` (nullable, additive); the populate INSERT now binds `rec.ordinal`. The PK `(ability_game_id, label, rank)` is unchanged, so this is purely additive metadata.
Evidence: `kessel/src/db/ability.rs` CREATE TABLE + populate_gsf_ability_stats.

### 2. Green
`cargo build --release -p kessel`, `cargo clippy -p kessel -- -D warnings`, `cargo test -p kessel` all pass; fmt clean.

## Not done

The `<<N>>` -> payload_ordinal anchoring and literal-number anchoring (the labeling logic itself) are the remainder of #309 and depend on #307 (`text_raw`, PR #311). This PR ships only the ordinal foundation. Lands on next re-extract.