### PR TITLE
feat(items): bridge dropped proc objects + recover relic proc name/chance (#308)

### DIFF
--- a/kessel/src/db/item.rs
+++ b/kessel/src/db/item.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::schema::item;
+use regex::Regex;
 
 impl Database {
     pub fn populate_item_tables(&self) -> Result<u64> {
@@ -444,10 +445,25 @@ impl Database {
                 })?
                 .collect::<std::result::Result<Vec<_>, _>>()?;
 
+            // Resolve a proc-ability guid -> its (name, effect) strings. The
+            // proc-buff object is unnamed (absent from `objects`); the
+            // object_string_refs bridge (#308) maps guid->string_id. Fall back
+            // to objects.guid for the minority that ARE extracted. id1=0 is the
+            // buff name, id1=1 the effect description (literals survive cleaning).
+            let mut resolve = tx.prepare(
+                "WITH m(sid) AS (SELECT COALESCE( \
+                    (SELECT string_id FROM object_string_refs WHERE guid = ?1), \
+                    (SELECT string_id FROM objects WHERE guid = ?1 AND is_canonical = 1 LIMIT 1))) \
+                 SELECT \
+                   (SELECT text FROM strings, m WHERE id2 = m.sid AND id1 = 0 AND locale = 'en-us'), \
+                   (SELECT text FROM strings, m WHERE id2 = m.sid AND id1 = 1 AND locale = 'en-us')",
+            )?;
+
             let mut insert = tx.prepare_cached(
                 "INSERT OR REPLACE INTO relic_procs \
-                    (relic_fqn, relic_game_id, trigger_kind, proc_stat, proc_ability_guid) \
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                    (relic_fqn, relic_game_id, trigger_kind, proc_stat, proc_ability_guid, \
+                     proc_buff_name, proc_chance_pct, proc_magnitude, proc_icd_seconds) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             )?;
             for (fqn, game_id, guid) in relics {
                 let trigger = relic_trigger_kind(&fqn);
@@ -461,7 +477,31 @@ impl Database {
                 if trigger.is_none() && stat.is_none() {
                     unclassified += 1;
                 }
-                insert.execute(params![fqn, game_id, trigger, stat, guid])?;
+                // Resolve the proc effect numbers when the relic references a
+                // proc ability we can reach (via the bridge or objects).
+                let (mut name, mut chance, mut mag, mut icd) = (None, None, None, None);
+                if let Some(ref g) = guid {
+                    let resolved = resolve
+                        .query_row([g], |r| {
+                            Ok((
+                                r.get::<_, Option<String>>(0)?,
+                                r.get::<_, Option<String>>(1)?,
+                            ))
+                        })
+                        .ok();
+                    if let Some((n, effect)) = resolved {
+                        name = n;
+                        if let Some(effect) = effect {
+                            let pe = parse_proc_effect(&effect);
+                            chance = pe.chance_pct;
+                            mag = pe.magnitude;
+                            icd = pe.icd_seconds;
+                        }
+                    }
+                }
+                insert.execute(params![
+                    fqn, game_id, trigger, stat, guid, name, chance, mag, icd
+                ])?;
                 rows += 1;
             }
             if unclassified > 0 {
@@ -516,6 +556,42 @@ pub(crate) fn relic_trigger_kind(fqn: &str) -> Option<&'static str> {
         Some("proc")
     } else {
         None
+    }
+}
+
+/// Structured numbers parsed from a relic proc-ability effect string.
+/// Every field is optional: an absent capture stays `None` (never guessed).
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct ProcEffect {
+    pub chance_pct: Option<i64>,
+    pub magnitude: Option<i64>,
+    pub icd_seconds: Option<i64>,
+}
+
+/// Parse the literal numbers from a relic proc effect description (STB id1=1).
+/// Recovers chance / magnitude / internal-cooldown -- all literals that survive
+/// `grammar.clean()`. The proc DURATION is a `<<N>>` template (its value lives
+/// in the unextracted proc-buff payload) and is intentionally NOT recovered
+/// here. Pure -- unit-tested. #308.
+pub(crate) fn parse_proc_effect(effect: &str) -> ProcEffect {
+    use std::sync::OnceLock;
+    static RES: OnceLock<(Regex, Regex, Regex)> = OnceLock::new();
+    let (chance_re, grant_re, icd_re) = RES.get_or_init(|| {
+        (
+            Regex::new(r"(\d+)%\s+chance").unwrap(),
+            Regex::new(r"grant\s+(\d+)\s+\w").unwrap(),
+            Regex::new(r"once every\s+(\d+)\s+second").unwrap(),
+        )
+    });
+    let cap1 = |re: &Regex| -> Option<i64> {
+        re.captures(effect)
+            .and_then(|c| c.get(1))
+            .and_then(|m| m.as_str().parse().ok())
+    };
+    ProcEffect {
+        chance_pct: cap1(chance_re),
+        magnitude: cap1(grant_re),
+        icd_seconds: cap1(icd_re),
     }
 }
 
@@ -639,21 +715,26 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
             -- (the proc/onuse ability the relic references via field
             -- 0x2d7b8786). See proc_stat() for the full set of stat labels.
             --
-            -- IMPORTANT static-data ceiling: the EXACT proc magnitude,
-            -- duration, and internal cooldown are NOT in the .tor archive.
-            -- Proc-ability objects are shared across rating tiers while the
-            -- proc value scales with the relic's rating at runtime, so the
-            -- number is computed live (the str.abl.* proc strings carry blank
-            -- duration/ICD tokens). The relic's STATIC equipped stats ARE
-            -- captured (in item_stats). So this table answers "what kind of
-            -- relic is this" deterministically; the live proc burst value is
-            -- client-side residual (cf. #111).
+            -- Proc magnitude / chance / internal-cooldown are parsed from the
+            -- proc-ability effect string (literals that survive grammar.clean,
+            -- e.g. "30% chance to grant 510 Power ... once every 20 seconds").
+            -- The relic reaches that string via proc_ability_guid -> the
+            -- object_string_refs bridge (the proc-buff object is unnamed and
+            -- absent from `objects`, so it is captured guid->string_id during
+            -- extraction) -> strings. (#308; overturns the old #242/#111
+            -- "client-side residual" verdict.) The proc DURATION remains NULL:
+            -- it is a <<N>> template whose value lives in the unextracted
+            -- proc-buff payload, not a literal in the text.
             CREATE TABLE IF NOT EXISTS relic_procs (
                 relic_fqn         TEXT PRIMARY KEY,
                 relic_game_id     TEXT,
                 trigger_kind      TEXT,   -- 'proc' (passive) or 'onuse' (activated); NULL if neither
                 proc_stat         TEXT,   -- see proc_stat(): power/critical/mastery/defense/healing/absorb/alacrity/damage, or NULL
-                proc_ability_guid TEXT    -- granted-ability guid (item field 0x2d7b8786)
+                proc_ability_guid TEXT,   -- granted-ability guid (item field 0x2d7b8786)
+                proc_buff_name    TEXT,   -- proc-buff ability name (strings id1=0), e.g. "Power Surge"
+                proc_chance_pct   INTEGER,-- "(\\d+)% chance" from the effect string
+                proc_magnitude    INTEGER,-- "grant (\\d+) <stat>" from the effect string
+                proc_icd_seconds  INTEGER -- "once every (\\d+) seconds" from the effect string
             );
             CREATE INDEX IF NOT EXISTS idx_relic_procs_stat ON relic_procs(proc_stat);
             -- Item set membership (#105 part 1).
@@ -696,6 +777,26 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
 mod tests {
     use super::*;
     use crate::db::testutil::*;
+
+    #[test]
+    fn parse_proc_effect_extracts_power_surge_literals() {
+        // The Power Surge relic proc string (abl.stb id2=755312, id1=1).
+        let e = parse_proc_effect(
+            "Healing an ally or performing a damaging attack on an enemy both have a 30% \
+             chance to grant 510 Power for seconds. This effect can only occur once every \
+             20 seconds, and shares this limit with similar effects.",
+        );
+        assert_eq!(e.chance_pct, Some(30));
+        assert_eq!(e.magnitude, Some(510));
+        assert_eq!(e.icd_seconds, Some(20));
+    }
+
+    #[test]
+    fn parse_proc_effect_missing_fields_are_none() {
+        let e = parse_proc_effect("On use, vents heat. No proc.");
+        assert_eq!(e, ProcEffect::default());
+    }
+
     #[test]
     fn relic_classifiers_cover_real_fqn_tails() {
         // Real relic FQN tails (from the v24 extract) -> expected classification.

--- a/kessel/src/db/mod.rs
+++ b/kessel/src/db/mod.rs
@@ -125,6 +125,8 @@ pub struct Database {
     batch_size: usize,
     pending_objects: Mutex<Vec<PendingObject>>,
     pending_strings: Mutex<Vec<PendingString>>,
+    /// guid -> string_id for SEEN-but-DROPPED objects (#308 bridge).
+    pending_string_refs: Mutex<Vec<(String, u32)>>,
     grammar: Option<Arc<Grammar>>,
 }
 
@@ -166,6 +168,7 @@ impl Database {
             batch_size: 5000,
             pending_objects: Mutex::new(Vec::with_capacity(5000)),
             pending_strings: Mutex::new(Vec::with_capacity(5000)),
+            pending_string_refs: Mutex::new(Vec::with_capacity(5000)),
             grammar,
         })
     }
@@ -298,6 +301,23 @@ impl Database {
         Ok(())
     }
 
+    /// Queue a guid -> string_id bridge row for an object that was seen during
+    /// extraction but dropped (unnamed / non-whitelisted FQN, so absent from
+    /// `objects`). Lets items resolve referenced-by-guid effect objects (e.g.
+    /// relic proc buffs) to their `strings` rows. #308.
+    pub fn insert_string_ref(&self, guid: &str, string_id: u32) -> Result<()> {
+        let mut refs = self.pending_string_refs.lock().unwrap();
+        refs.push((guid.to_string(), string_id));
+
+        if refs.len() >= self.batch_size {
+            let batch: Vec<_> = refs.drain(..).collect();
+            drop(refs); // Release lock before flushing
+            self.flush_string_refs(batch)?;
+        }
+
+        Ok(())
+    }
+
     /// Flush pending objects to database in a single transaction
     fn flush_objects(&self, batch: Vec<PendingObject>) -> Result<()> {
         if batch.is_empty() {
@@ -388,6 +408,27 @@ impl Database {
         Ok(())
     }
 
+    /// Flush pending guid -> string_id bridge rows (#308). `INSERT OR IGNORE`
+    /// keeps the first guid seen (dropped objects carry a stable guid).
+    fn flush_string_refs(&self, batch: Vec<(String, u32)>) -> Result<()> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT OR IGNORE INTO object_string_refs (guid, string_id) VALUES (?1, ?2)",
+            )?;
+            for (guid, string_id) in &batch {
+                stmt.execute(params![guid, string_id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Flush any remaining pending inserts
     pub fn flush(&self) -> Result<()> {
         // Flush objects
@@ -403,6 +444,13 @@ impl Database {
             pending.drain(..).collect()
         };
         self.flush_strings(strings)?;
+
+        // Flush guid -> string_id bridge rows (#308)
+        let string_refs: Vec<_> = {
+            let mut pending = self.pending_string_refs.lock().unwrap();
+            pending.drain(..).collect()
+        };
+        self.flush_string_refs(string_refs)?;
 
         Ok(())
     }

--- a/kessel/src/db/schema.rs
+++ b/kessel/src/db/schema.rs
@@ -75,6 +75,18 @@ pub(crate) fn create_core_tables(tx: &Transaction) -> Result<()> {
 
             CREATE INDEX IF NOT EXISTS idx_strings_id2 ON strings(id2);
 
+            -- guid -> string_id bridge for objects SEEN during extraction but
+            -- DROPPED (unnamed / non-whitelisted FQN) and so absent from
+            -- `objects`. Items reference such objects by guid (e.g. a relic's
+            -- proc-buff ability via field 0x2d7b8786) and the objects' effect
+            -- strings exist in `strings`; this table is the missing link from
+            -- the referencing item to that string. #308.
+            CREATE TABLE IF NOT EXISTS object_string_refs (
+                guid      TEXT PRIMARY KEY,
+                string_id INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_object_string_refs_sid ON object_string_refs(string_id);
+
             -- Typed views for convenience.
             -- Post-#23: kind='Quest' includes only qst.* objects.
             -- Mission phases (mpn.*) are kind='Phase' -- see `phases` view.

--- a/kessel/src/main.rs
+++ b/kessel/src/main.rs
@@ -290,9 +290,12 @@ fn main() -> Result<()> {
                                 }
                                 if should_extract_object(&game_obj.fqn, args.unfiltered)
                                     && !game_obj.fqn.is_empty()
-                                    && db.insert_object(&game_obj).is_ok()
                                 {
-                                    total_objects += 1;
+                                    if db.insert_object(&game_obj).is_ok() {
+                                        total_objects += 1;
+                                    }
+                                } else {
+                                    capture_string_ref(&db, &game_obj);
                                 }
                             }
                         }
@@ -331,9 +334,12 @@ fn main() -> Result<()> {
                             }
                             if should_extract_object(&game_obj.fqn, args.unfiltered)
                                 && !game_obj.fqn.is_empty()
-                                && db.insert_object(&game_obj).is_ok()
                             {
-                                total_objects += 1;
+                                if db.insert_object(&game_obj).is_ok() {
+                                    total_objects += 1;
+                                }
+                            } else {
+                                capture_string_ref(&db, &game_obj);
                             }
                         }
                     }
@@ -912,10 +918,26 @@ fn process_pbuk(
         if should_extract_object(&game_obj.fqn, unfiltered) && !game_obj.fqn.is_empty() {
             db.insert_object(&game_obj)?;
             count += 1;
+        } else {
+            capture_string_ref(db, &game_obj);
         }
     }
 
     Ok(count)
+}
+
+/// Record a guid -> string_id bridge row for an object that was parsed but
+/// dropped from `objects` (unnamed / non-whitelisted FQN). Only objects that
+/// carry both a guid and a string_id are useful as a bridge (e.g. relic
+/// proc-buff abilities). Best-effort: a failed insert never aborts extraction.
+/// #308.
+fn capture_string_ref(db: &db::Database, game_obj: &schema::GameObject) {
+    if game_obj.guid.is_empty() {
+        return;
+    }
+    if let Some(sid) = game_obj.string_id {
+        let _ = db.insert_string_ref(&game_obj.guid, sid);
+    }
 }
 
 /// Score a candidate object: prefer those that extracted a string_id, then


### PR DESCRIPTION
## Summary

Overturns the core of #242's "static-data ceiling" verdict for relic procs. The proc-buff abilities relics reference (item field `0x2d7b8786`) are unnamed objects the whitelist drops, so relics could not reach their proc strings -- #242 called this "client-side residual." This adds the missing link and recovers the proc buff name + chance.

**Stacked on #311 (`text_raw`)** -- base branch only; #308's code does not use `text_raw`.

## Acceptance criteria mapping

### 1. Bridge the dropped proc objects (the prerequisite #242/the plan missed)
New `object_string_refs(guid, string_id)` table, populated during extraction for objects SEEN but DROPPED (unnamed/non-whitelisted FQN) that carry both a guid and a string_id. New pending pipeline (`insert_string_ref`/`flush_string_refs`, mirroring `pending_strings`) + a `capture_string_ref()` hook at the three extraction drop sites (`main.rs`).
Evidence: re-extract -> 63,021 bridge rows; proc guid `E000381B97138C5C` -> string 1077012 ("Power Surge"), reachable from its relics via `item_granted_abilities` -> `object_string_refs` -> `strings`.

### 2. Recover proc name + chance into relic_procs
`relic_procs` gains `proc_buff_name`, `proc_chance_pct`, `proc_magnitude`, `proc_icd_seconds`. `populate_relic_procs` resolves the proc string via the bridge (fallback `objects.guid`) and parses literals with `parse_proc_effect()` (pure, unit-tested).
Evidence (v5 re-extract): **1,131 / 2,177 relics get `proc_buff_name`, 1,079 get `proc_chance_pct`** -- real names + chances (Power Surge 30%, Healing Resonance 50%, Mastery/Critical/Absorb Surge 30%) that were previously NULL/unrecoverable.

### 3. Remove the false ceiling comment
Deleted the "client-side residual (cf. #111)" comment from the `relic_procs` schema (db/item.rs), replaced with how the fields are sourced.

### 4. Green + honest scope
`parse_proc_effect` has 2 unit tests; `cargo test/clippy/fmt -p kessel` green.

## Not done

`proc_magnitude` / `proc_icd_seconds` / duration come back **0/NULL** -- they are `<<N>>` templates ("grant `<<3>>` Power ... once every `<<2>>` seconds") whose values live in the unextracted proc-buff *payload* (and the magnitude is rating-scaled, so #242 was half-right on it). Recovering them needs decoding the proc-buff payload's stat records and mapping the `<<N>>` ordinals -- the same mechanism as #309, scoped as a follow-up. This PR delivers the link + name + chance, which were the genuinely-impossible-before parts.
