### PR TITLE
feat(abilities): decode <<N>> description-token types (#309 anchoring)

### DIFF
--- a/kessel-discovery/examples/probe_specparams.rs
+++ b/kessel-discovery/examples/probe_specparams.rs
@@ -52,11 +52,19 @@ fn dump(v: &GomValue, path: &str, depth: usize) {
             println!("  {path} = f32 {f}{flag}");
         }
         GomValue::I64(n) | GomValue::Enum(n) => {
-            let flag = if *n == 3 || *n == 200 { "  <== ORACLE" } else { "" };
+            let flag = if *n == 3 || *n == 200 {
+                "  <== ORACLE"
+            } else {
+                ""
+            };
             println!("  {path} = int {n}{flag}");
         }
         GomValue::U64(n) => {
-            let flag = if *n == 3 || *n == 200 { "  <== ORACLE" } else { "" };
+            let flag = if *n == 3 || *n == 200 {
+                "  <== ORACLE"
+            } else {
+                ""
+            };
             println!("  {path} = u64 {n}{flag}");
         }
         _ => {}
@@ -92,7 +100,10 @@ fn main() -> Result<()> {
         println!("  text_raw: {}", raw.as_deref().unwrap_or("(none)"));
         match read_object_fields(&payload) {
             Ok(obj) => {
-                if let Some(list) = obj.embedded_field(SPECPARAM_LIST).and_then(GomValue::as_list) {
+                if let Some(list) = obj
+                    .embedded_field(SPECPARAM_LIST)
+                    .and_then(GomValue::as_list)
+                {
                     for (i, entry) in list.iter().enumerate() {
                         let val = entry.embedded_field(SPECPARAM_VALUE);
                         println!("  SpecParam[{i}] (<<{}>>) = {val:?}", i + 1);

--- a/kessel-discovery/examples/probe_specparams.rs
+++ b/kessel-discovery/examples/probe_specparams.rs
@@ -1,0 +1,111 @@
+//! Locate the SpecParam list in an ability payload: the array the `<<N>>`
+//! description tokens index. Oracle: abl.agent.evasion reads "by 200% for
+//! <<1>> seconds" -- so the payload must contain 200 and 3 (its in-game
+//! duration) somewhere structured. Dumps the GOM field tree and flags those.
+//!
+//! Read-only. cargo run -p kessel-discovery --example probe_specparams
+
+use anyhow::Result;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use kessel::gom_reader::{read_object_fields, GomValue};
+use rusqlite::{Connection, OpenFlags};
+
+const DB: &str = "/Users/seansilvius/swtor/data/spice-7.9.a-v5.sqlite";
+const FQNS: &[&str] = &[
+    "abl.agent.evasion",
+    "abl.agent.corrosive_dart",
+    "abl.agent.diagnostic_scan",
+    "abl.sith_warrior.enrage",
+];
+
+/// SpecParam list field + per-entry value field (located via the evasion oracle).
+const SPECPARAM_LIST: u32 = 0x384b_793a;
+const SPECPARAM_VALUE: u32 = 0x384b_7939;
+
+fn dump(v: &GomValue, path: &str, depth: usize) {
+    if depth > 6 {
+        return;
+    }
+    match v {
+        GomValue::Embedded(fields) => {
+            for (id, val) in fields {
+                let p = format!("{path}.{:08x}", *id as u32);
+                dump(val, &p, depth + 1);
+            }
+        }
+        GomValue::List(items) => {
+            for (i, item) in items.iter().enumerate() {
+                dump(item, &format!("{path}[{i}]"), depth + 1);
+            }
+        }
+        GomValue::Map(entries) => {
+            for (k, val) in entries {
+                dump(val, &format!("{path}{{{k:?}}}"), depth + 1);
+            }
+        }
+        GomValue::F32(f) => {
+            let flag = if (*f - 3.0).abs() < 0.01 || (*f - 200.0).abs() < 0.01 {
+                "  <== ORACLE"
+            } else {
+                ""
+            };
+            println!("  {path} = f32 {f}{flag}");
+        }
+        GomValue::I64(n) | GomValue::Enum(n) => {
+            let flag = if *n == 3 || *n == 200 { "  <== ORACLE" } else { "" };
+            println!("  {path} = int {n}{flag}");
+        }
+        GomValue::U64(n) => {
+            let flag = if *n == 3 || *n == 200 { "  <== ORACLE" } else { "" };
+            println!("  {path} = u64 {n}{flag}");
+        }
+        _ => {}
+    }
+}
+
+fn main() -> Result<()> {
+    let conn = Connection::open_with_flags(DB, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+    for fqn in FQNS {
+        let b64: Option<String> = conn
+            .query_row(
+                "SELECT json_extract(json,'$.payload_b64') FROM objects WHERE fqn=?1 AND is_canonical=1",
+                [fqn],
+                |r| r.get(0),
+            )
+            .ok()
+            .flatten();
+        let Some(b64) = b64 else {
+            println!("== {fqn}: no payload ==");
+            continue;
+        };
+        let raw: Option<String> = conn
+            .query_row(
+                "SELECT s.text_raw FROM objects o JOIN strings s ON s.id2=o.string_id \
+                 AND s.id1=1 AND s.locale='en-us' WHERE o.fqn=?1 AND o.is_canonical=1",
+                [fqn],
+                |r| r.get(0),
+            )
+            .ok()
+            .flatten();
+        let payload = BASE64.decode(&b64)?;
+        println!("\n== {fqn} ==");
+        println!("  text_raw: {}", raw.as_deref().unwrap_or("(none)"));
+        match read_object_fields(&payload) {
+            Ok(obj) => {
+                if let Some(list) = obj.embedded_field(SPECPARAM_LIST).and_then(GomValue::as_list) {
+                    for (i, entry) in list.iter().enumerate() {
+                        let val = entry.embedded_field(SPECPARAM_VALUE);
+                        println!("  SpecParam[{i}] (<<{}>>) = {val:?}", i + 1);
+                    }
+                } else {
+                    println!("  (no SpecParam list field {SPECPARAM_LIST:08x})");
+                }
+            }
+            Err(e) => println!("  decode err: {e}"),
+        }
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn unused() {}

--- a/kessel/src/db/ability.rs
+++ b/kessel/src/db/ability.rs
@@ -357,6 +357,54 @@ impl Database {
         Ok(count)
     }
 
+    /// Populate `ability_desc_tokens` -- the type of each `<<N>>` token in every
+    /// ability's description, decoded from the payload SpecParam list (#309).
+    /// Returns (abilities_with_tokens, total_tokens).
+    pub fn populate_ability_desc_tokens(&self) -> Result<(u64, u64)> {
+        use crate::schema::desc_tokens::decode_desc_tokens;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let conn = self.conn.lock().unwrap();
+        let payloads: Vec<(String, Option<String>)> = {
+            let mut stmt = conn.prepare(
+                "SELECT fqn, json_extract(json, '$.payload_b64') \
+                 FROM objects WHERE fqn LIKE 'abl.%' AND is_canonical = 1",
+            )?;
+            let rows: Vec<(String, Option<String>)> = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            rows
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR REPLACE INTO ability_desc_tokens \
+             (ability_fqn, token_index, token_type) VALUES (?1, ?2, ?3)",
+        )?;
+        let (mut abilities, mut tokens) = (0u64, 0u64);
+        for (fqn, payload_b64) in &payloads {
+            let Some(b64) = payload_b64 else { continue };
+            let Ok(payload) = BASE64.decode(b64) else {
+                continue;
+            };
+            let decoded = decode_desc_tokens(&payload);
+            if decoded.is_empty() {
+                continue;
+            }
+            abilities += 1;
+            for t in decoded {
+                stmt.execute(params![fqn, t.index as i64, t.token_type])?;
+                tokens += 1;
+            }
+        }
+        drop(stmt);
+        tx.commit()?;
+        Ok((abilities, tokens))
+    }
+
     /// Populate `disciplines` and `discipline_abilities` from `abl.{class}.skill.{discipline}.*` FQNs.
     ///
     /// Discipline FQN structure:
@@ -2721,6 +2769,21 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
             );
             CREATE INDEX IF NOT EXISTS idx_gsf_ability_stats_label
                 ON gsf_ability_stats(label);
+            -- Ability description tokens (#309). One row per <<N>> token in an
+            -- ability's description, naming WHAT the token represents
+            -- (damage / healing / duration / rank / absorption / bindpoint /
+            -- stat), decoded from the payload SpecParam list via the client.gom
+            -- ablDescriptionTokenType enum. token_index is 0-based (<<1>> -> 0).
+            -- The numeric value for damage/healing tokens is runtime-scaled and
+            -- not stored here; this table resolves the durable token MEANING.
+            CREATE TABLE IF NOT EXISTS ability_desc_tokens (
+                ability_fqn TEXT NOT NULL,
+                token_index INTEGER NOT NULL,
+                token_type  TEXT NOT NULL,
+                PRIMARY KEY (ability_fqn, token_index)
+            );
+            CREATE INDEX IF NOT EXISTS idx_ability_desc_tokens_type
+                ON ability_desc_tokens(token_type);
             -- Talent typed columns (#140) -- 7 props from Talent schema.
             CREATE TABLE IF NOT EXISTS talent_details (
                 fqn               TEXT PRIMARY KEY,

--- a/kessel/src/db/passes.rs
+++ b/kessel/src/db/passes.rs
@@ -256,6 +256,15 @@ pub fn run_passes(db: &Database, ctx: &PassCtx) -> Result<PassCounts> {
     let gsf_ability_stats_count = timed!("gsf_ability_stats", db.populate_gsf_ability_stats())?;
     println!("  GSF ability stats: {}", gsf_ability_stats_count);
 
+    // Ability description tokens (#309): the type of each <<N>> token in an
+    // ability's description, from the payload SpecParam list.
+    let (desc_tok_abilities, desc_tok_total) =
+        timed!("ability_desc_tokens", db.populate_ability_desc_tokens())?;
+    println!(
+        "  Ability description tokens: {} abilities, {} tokens",
+        desc_tok_abilities, desc_tok_total
+    );
+
     // EPP appearance specs + FX specs (#183). UTF-16-LE XML files. epp
     // carries appearance action lists + fxSpec refs; fxspec carries node
     // class lists. The two tables JOIN via appearance_specs.fx_spec_refs

--- a/kessel/src/schema/desc_tokens.rs
+++ b/kessel/src/schema/desc_tokens.rs
@@ -1,0 +1,95 @@
+//! Decode an ability's description-token list -- the `<<N>>` positional tokens
+//! in its description text.
+//!
+//! SWTOR ability descriptions interpolate values via `<<1>>`, `<<2>>` ...
+//! tokens. Each token is declared in the ability payload's SpecParam list: an
+//! ordered array (GOM field low32 `0x384b793a`) whose entries each carry a
+//! token-type field (low32 `0x384b7939`) holding an `ablDescriptionTokenType`
+//! enum value -- Rank / Damage / Healing / Duration / Bindpoint / Absorption /
+//! Stat. `<<N>>` indexes entry `N-1`.
+//!
+//! This names WHAT each token represents (the description structure). The
+//! numeric VALUE for Damage/Healing tokens is level/stat-scaled and computed at
+//! runtime (a coefficient in the effect graph, not a static literal); Duration
+//! and Rank tokens are fixed but live in the referenced effect. So this decoder
+//! resolves token *meaning*, the durable static signal.
+//!
+//! Validated against the in-game oracle: abl.agent.evasion `<<1>>` = Duration;
+//! abl.agent.corrosive_dart `<<1>>` = Damage, `<<2>>` = Duration;
+//! abl.agent.diagnostic_scan `<<1>>` = Healing.
+//!
+//! GOM field ids drift across patches; the two ids below are current as of the
+//! 7.9 schema and matched directly (same convention as the granted-ability
+//! field 0x2d7b8786 elsewhere). If a future patch yields zero tokens corpus
+//! wide, re-derive them with `kessel-discovery/examples/probe_specparams`.
+
+use crate::gom_reader::{read_object_fields, GomValue};
+use crate::gom_schema;
+
+/// SpecParam list field (the ordered `<<N>>` token array).
+const SPECPARAM_LIST_FIELD: u32 = 0x384b_793a;
+/// Per-entry token-type field (an `ablDescriptionTokenType` enum value).
+const TOKEN_TYPE_FIELD: u32 = 0x384b_7939;
+/// The client.gom enum naming the token types.
+const TOKEN_TYPE_ENUM: &str = "ablDescriptionTokenType";
+
+/// One `<<N>>` description token: its 0-based index (`<<1>>` -> 0) and type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DescToken {
+    pub index: u32,
+    /// Lowercased token type with the `ablDescriptionTokenType` prefix stripped
+    /// (`damage`, `healing`, `duration`, `rank`, `absorption`, `bindpoint`,
+    /// `stat`), or `unknown_<n>` for an enum value the embedded dictionary
+    /// doesn't name.
+    pub token_type: String,
+}
+
+/// Decode the `<<N>>` description-token types from an ability GOM payload.
+/// Returns an empty vec for payloads with no SpecParam list (most non-ability
+/// objects, and abilities whose descriptions take no parameters).
+pub fn decode_desc_tokens(payload: &[u8]) -> Vec<DescToken> {
+    let Ok(obj) = read_object_fields(payload) else {
+        return Vec::new();
+    };
+    let Some(list) = obj
+        .embedded_field(SPECPARAM_LIST_FIELD)
+        .and_then(GomValue::as_list)
+    else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(list.len());
+    for (i, entry) in list.iter().enumerate() {
+        let Some(type_idx) = entry.embedded_field(TOKEN_TYPE_FIELD).and_then(GomValue::as_i64)
+        else {
+            continue;
+        };
+        let token_type = gom_schema::enum_member(TOKEN_TYPE_ENUM, type_idx)
+            .map(strip_token_prefix)
+            .unwrap_or_else(|| format!("unknown_{type_idx}"));
+        out.push(DescToken {
+            index: i as u32,
+            token_type,
+        });
+    }
+    out
+}
+
+/// `ablDescriptionTokenTypeDuration` -> `duration`.
+fn strip_token_prefix(member: &str) -> String {
+    member
+        .strip_prefix("ablDescriptionTokenType")
+        .unwrap_or(member)
+        .to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_prefix_lowercases() {
+        assert_eq!(strip_token_prefix("ablDescriptionTokenTypeDuration"), "duration");
+        assert_eq!(strip_token_prefix("ablDescriptionTokenTypeDamage"), "damage");
+        assert_eq!(strip_token_prefix("weird"), "weird");
+    }
+}

--- a/kessel/src/schema/desc_tokens.rs
+++ b/kessel/src/schema/desc_tokens.rs
@@ -59,7 +59,9 @@ pub fn decode_desc_tokens(payload: &[u8]) -> Vec<DescToken> {
     };
     let mut out = Vec::with_capacity(list.len());
     for (i, entry) in list.iter().enumerate() {
-        let Some(type_idx) = entry.embedded_field(TOKEN_TYPE_FIELD).and_then(GomValue::as_i64)
+        let Some(type_idx) = entry
+            .embedded_field(TOKEN_TYPE_FIELD)
+            .and_then(GomValue::as_i64)
         else {
             continue;
         };
@@ -88,8 +90,14 @@ mod tests {
 
     #[test]
     fn strip_prefix_lowercases() {
-        assert_eq!(strip_token_prefix("ablDescriptionTokenTypeDuration"), "duration");
-        assert_eq!(strip_token_prefix("ablDescriptionTokenTypeDamage"), "damage");
+        assert_eq!(
+            strip_token_prefix("ablDescriptionTokenTypeDuration"),
+            "duration"
+        );
+        assert_eq!(
+            strip_token_prefix("ablDescriptionTokenTypeDamage"),
+            "damage"
+        );
         assert_eq!(strip_token_prefix("weird"), "weird");
     }
 }

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -1,6 +1,7 @@
 //! Schema definitions for SWTOR game objects
 
 pub mod appearance;
+pub mod desc_tokens;
 pub mod discipline;
 pub mod effect_block;
 pub mod epp;


### PR DESCRIPTION
## Summary

Implements #309's description anchoring. SWTOR ability descriptions interpolate values via `<<1>>`, `<<2>>` … tokens; this decodes what each token represents and stores it in a new `ability_desc_tokens` table. Resolves the long-standing "what does `<<N>>` mean" gap across the whole ability corpus, using the client.gom enum (not guesswork).

## Acceptance criteria mapping

### 1. Decode the `<<N>>` token types from the payload
Each ability's `<<N>>` tokens are declared in its payload **SpecParam list** (GOM field low32 `0x384b793a`); each entry carries a token-type field (`0x384b7939`) holding an `ablDescriptionTokenType` enum value. `schema/desc_tokens.rs::decode_desc_tokens` walks the list with `gom_reader` and resolves the type via `gom_schema::enum_member("ablDescriptionTokenType", …)` -> `rank/damage/healing/duration/bindpoint/absorption/stat`. `<<N>>` maps to entry `N-1`.
Evidence: `kessel/src/schema/desc_tokens.rs`; located via `kessel-discovery/examples/probe_specparams.rs`.

### 2. Populate a table across all abilities
`populate_ability_desc_tokens` (db/ability.rs) fills `ability_desc_tokens(ability_fqn, token_index, token_type)` over every `abl.*` object; registered as a pass.
Evidence (v6 re-extract): **1,753 abilities, 2,353 tokens** (duration 1,119 / damage 882 / healing 323 / absorption 29).

### 3. Validated against the in-game oracle
Evidence (v6): `abl.agent.evasion` token 0 = `duration` ("...for `<<1>>` seconds"); `abl.agent.corrosive_dart` token 0 = `damage`, token 1 = `duration` ("deals `<<1>>` ... over `<<2>>` seconds"); `abl.agent.diagnostic_scan` token 0 = `healing`. All exact.

### 4. Green
`schema/desc_tokens.rs` unit test + `cargo build/clippy/test -p kessel` green.

## Not done

The numeric **value** of damage/healing tokens is intentionally not stored: it is level/stat-scaled and computed at runtime (a coefficient in the effect graph, not a static literal) -- the same genuine ceiling as relic proc magnitude (#308). Duration/rank values are fixed but live in the referenced effect; surfacing them is a follow-up. This PR resolves the durable token *meaning*. The two GOM field ids are current as of the 7.9 schema and matched directly (same convention as field `0x2d7b8786` elsewhere); they drift across patches -- re-derive with `probe_specparams` if a future patch yields zero tokens. Builds conceptually on #312 (`payload_ordinal`) and #307 (`text_raw` preserves the tokens); no code dependency, base is main.
