### PR TITLE
feat(gsf): per-FQN ability_stat_overrides; 0x0403 drone-weapon cooldown (#301 part 1)

### DIFF
--- a/kessel-discovery/examples/probe_specparams.rs
+++ b/kessel-discovery/examples/probe_specparams.rs
@@ -10,7 +10,7 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use kessel::gom_reader::{read_object_fields, GomValue};
 use rusqlite::{Connection, OpenFlags};
 
-const DB: &str = "/Users/seansilvius/swtor/data/spice-7.9.a-v5.sqlite";
+const DB: &str = "/Users/seansilvius/swtor/data/spice-7.9.a-v7.sqlite";
 const FQNS: &[&str] = &[
     "abl.agent.evasion",
     "abl.agent.corrosive_dart",
@@ -20,56 +20,6 @@ const FQNS: &[&str] = &[
 
 /// SpecParam list field + per-entry value field (located via the evasion oracle).
 const SPECPARAM_LIST: u32 = 0x384b_793a;
-const SPECPARAM_VALUE: u32 = 0x384b_7939;
-
-fn dump(v: &GomValue, path: &str, depth: usize) {
-    if depth > 6 {
-        return;
-    }
-    match v {
-        GomValue::Embedded(fields) => {
-            for (id, val) in fields {
-                let p = format!("{path}.{:08x}", *id as u32);
-                dump(val, &p, depth + 1);
-            }
-        }
-        GomValue::List(items) => {
-            for (i, item) in items.iter().enumerate() {
-                dump(item, &format!("{path}[{i}]"), depth + 1);
-            }
-        }
-        GomValue::Map(entries) => {
-            for (k, val) in entries {
-                dump(val, &format!("{path}{{{k:?}}}"), depth + 1);
-            }
-        }
-        GomValue::F32(f) => {
-            let flag = if (*f - 3.0).abs() < 0.01 || (*f - 200.0).abs() < 0.01 {
-                "  <== ORACLE"
-            } else {
-                ""
-            };
-            println!("  {path} = f32 {f}{flag}");
-        }
-        GomValue::I64(n) | GomValue::Enum(n) => {
-            let flag = if *n == 3 || *n == 200 {
-                "  <== ORACLE"
-            } else {
-                ""
-            };
-            println!("  {path} = int {n}{flag}");
-        }
-        GomValue::U64(n) => {
-            let flag = if *n == 3 || *n == 200 {
-                "  <== ORACLE"
-            } else {
-                ""
-            };
-            println!("  {path} = u64 {n}{flag}");
-        }
-        _ => {}
-    }
-}
 
 fn main() -> Result<()> {
     let conn = Connection::open_with_flags(DB, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
@@ -105,8 +55,14 @@ fn main() -> Result<()> {
                     .and_then(GomValue::as_list)
                 {
                     for (i, entry) in list.iter().enumerate() {
-                        let val = entry.embedded_field(SPECPARAM_VALUE);
-                        println!("  SpecParam[{i}] (<<{}>>) = {val:?}", i + 1);
+                        println!("  SpecParam[{i}] (<<{}>>):", i + 1);
+                        if let GomValue::Embedded(fields) = entry {
+                            for (id, v) in fields {
+                                println!("      field {:08x} = {v:?}", *id as u32);
+                            }
+                        } else {
+                            println!("      {entry:?}");
+                        }
                     }
                 } else {
                     println!("  (no SpecParam list field {SPECPARAM_LIST:08x})");
@@ -117,6 +73,3 @@ fn main() -> Result<()> {
     }
     Ok(())
 }
-
-#[allow(dead_code)]
-fn unused() {}

--- a/kessel/gsf_stat_dictionary.toml
+++ b/kessel/gsf_stat_dictionary.toml
@@ -529,3 +529,27 @@ notes      = "Class-context-dependent; animation/effect timing"
 label      = "scaling_coefficient"
 unit       = "ratio"
 confidence = "guess"
+
+
+# --- abl.spvp.* prop_id FQN-prefix overrides (#301) ---
+# Some prop_ids carry context-dependent semantics: the default label is right
+# for the common case, but a specific ability family repurposes the slot. When
+# the ability FQN starts with `fqn_prefix`, the populate function replaces the
+# default `ability_stats` label with the override below (matched by SHAPE/FQN,
+# not a single value -- ids drift across patches).
+
+[[ability_stat_overrides]]
+fqn_prefix = "abl.spvp.drone.sentry_sniper.railgun"
+prop_id    = "0x0403"
+label      = "weapon_cooldown_seconds"
+unit       = "s"
+confidence = "verified"
+notes      = "0x0403=2.0 matches the sentry-sniper summon text '...has a 2 second cooldown' exactly (distinct from 0x0402=180 drone lifetime and 0x041a=4.0 charge time). The default 0x0403 label is the vacuous `scaling_factor` (1.0 on 53 non-weapon abilities); this override scopes the real weapon-cooldown meaning to the cooldown-gated drone weapon."
+
+[[ability_stat_overrides]]
+fqn_prefix = "abl.spvp.drone.sentry_missile.missile"
+prop_id    = "0x0403"
+label      = "weapon_cooldown_seconds"
+unit       = "s"
+confidence = "guess"
+notes      = "0x0403=12.0; same compound-record family as the sentry_sniper railgun's 0x0403 cooldown, but the 12s value is unconfirmed by any description number -- guess. Both drone weapons are the only abilities whose 0x0403 carries a non-1.0 value."

--- a/kessel/src/db/ability.rs
+++ b/kessel/src/db/ability.rs
@@ -300,11 +300,11 @@ impl Database {
         )?;
 
         let mut count: u64 = 0;
-        for (game_id, _fqn, payload) in &payloads {
+        for (game_id, fqn, payload) in &payloads {
             let mut rank_per_label: std::collections::HashMap<String, i64> =
                 std::collections::HashMap::new();
             for rec in decode_gsf_ability_stats(payload) {
-                let label = dict.ability_label(rec.prop_id);
+                let label = dict.ability_label_for(rec.prop_id, fqn);
                 let rank = rank_per_label.entry(label.label.clone()).or_insert(0);
                 *rank += 1;
                 stmt.execute(params![

--- a/kessel/src/gsf_stat_dictionary.rs
+++ b/kessel/src/gsf_stat_dictionary.rs
@@ -30,12 +30,24 @@ pub struct StatDictionary {
     /// the parent talent (e.g. 0x40 is normally `cooldown_delta_seconds` but
     /// `minor_sensors.com_range.*` repurposes it as `comm_range_units`).
     pub talent_stat_overrides: Vec<TalentStatOverride>,
+    /// FQN-prefix overrides for `abl.spvp.*` prop_ids whose meaning depends on
+    /// the ability (e.g. 0x0403 is a vacuous `scaling_factor` default for most
+    /// abilities but a real `weapon_cooldown_seconds` on cooldown-gated drone
+    /// weapons). #301.
+    pub ability_stat_overrides: Vec<AbilityStatOverride>,
 }
 
 #[derive(Debug, Clone)]
 pub struct TalentStatOverride {
     pub fqn_prefix: String,
     pub stat_id: u8,
+    pub label: StatLabel,
+}
+
+#[derive(Debug, Clone)]
+pub struct AbilityStatOverride {
+    pub fqn_prefix: String,
+    pub prop_id: u16,
     pub label: StatLabel,
 }
 
@@ -55,6 +67,19 @@ impl StatDictionary {
             ground_ability_props: HashMap<String, Entry>,
             #[serde(default)]
             talent_stat_overrides: Vec<OverrideEntry>,
+            #[serde(default)]
+            ability_stat_overrides: Vec<AbilityOverrideEntry>,
+        }
+        #[derive(serde::Deserialize)]
+        struct AbilityOverrideEntry {
+            fqn_prefix: String,
+            prop_id: String,
+            label: String,
+            unit: String,
+            confidence: String,
+            #[serde(default)]
+            #[allow(dead_code)]
+            notes: Option<String>,
         }
         #[derive(serde::Deserialize)]
         struct Entry {
@@ -140,11 +165,27 @@ impl StatDictionary {
         // sibling if any future entries overlap.
         talent_stat_overrides.sort_by_key(|ov| std::cmp::Reverse(ov.fqn_prefix.len()));
 
+        let mut ability_stat_overrides = Vec::with_capacity(file.ability_stat_overrides.len());
+        for entry in file.ability_stat_overrides {
+            let prop_id = parse_hex(&entry.prop_id)? as u16;
+            ability_stat_overrides.push(AbilityStatOverride {
+                fqn_prefix: entry.fqn_prefix,
+                prop_id,
+                label: StatLabel {
+                    label: entry.label,
+                    unit: entry.unit,
+                    confidence: entry.confidence,
+                },
+            });
+        }
+        ability_stat_overrides.sort_by_key(|ov| std::cmp::Reverse(ov.fqn_prefix.len()));
+
         Ok(Self {
             talent_stats,
             ability_stats,
             ground_ability_props,
             talent_stat_overrides,
+            ability_stat_overrides,
         })
     }
 
@@ -187,6 +228,20 @@ impl StatDictionary {
             })
     }
 
+    /// FQN-aware label lookup for `abl.spvp.*`. Consults `ability_stat_overrides`
+    /// first (so a prop_id whose meaning is FQN-dependent -- e.g. 0x0403 acting
+    /// as a real weapon cooldown on drone weapons rather than the vacuous
+    /// scaling_factor default -- ships with the right label) then falls back to
+    /// the default `ability_label` mapping. #301.
+    pub fn ability_label_for(&self, prop_id: u16, fqn: &str) -> StatLabel {
+        for ov in &self.ability_stat_overrides {
+            if ov.prop_id == prop_id && fqn.starts_with(&ov.fqn_prefix) {
+                return ov.label.clone();
+            }
+        }
+        self.ability_label(prop_id)
+    }
+
     /// Look up a label for an `abl.*` (ground) prop_id.
     pub fn ground_ability_label(&self, prop_id: u16) -> StatLabel {
         self.ground_ability_props
@@ -219,6 +274,34 @@ mod tests {
         assert_eq!(label.label, "cooldown_delta_seconds");
         assert_eq!(label.unit, "s");
         assert_eq!(label.confidence, "verified");
+    }
+
+    #[test]
+    fn ability_0x0403_override_only_on_drone_weapons() {
+        let dict = StatDictionary::from_embedded().unwrap();
+        // Drone weapons: 0x0403 is the weapon cooldown.
+        assert_eq!(
+            dict.ability_label_for(0x0403, "abl.spvp.drone.sentry_sniper.railgun")
+                .label,
+            "weapon_cooldown_seconds"
+        );
+        assert_eq!(
+            dict.ability_label_for(0x0403, "abl.spvp.drone.sentry_missile.missile")
+                .label,
+            "weapon_cooldown_seconds"
+        );
+        // Everything else keeps the default vacuous scaling_factor.
+        assert_eq!(
+            dict.ability_label_for(0x0403, "abl.spvp.shield.distortion_field")
+                .label,
+            "scaling_factor"
+        );
+        // A non-overridden prop_id is unaffected by FQN.
+        assert_eq!(
+            dict.ability_label_for(0x0402, "abl.spvp.drone.sentry_sniper.railgun")
+                .label,
+            "cooldown_seconds"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #301 part 1: a per-FQN `ability_stat_overrides` mechanism for `abl.spvp.*` prop_ids whose meaning depends on the ability, and the first override -- 0x0403 as the drone-weapon cooldown.

## Acceptance criteria mapping

### 1. ability_stat_overrides mechanism
`StatDictionary` gains `ability_stat_overrides: Vec<AbilityStatOverride>` + `ability_label_for(prop_id, fqn)` (mirroring the existing talent_stat_overrides / talent_label_for). `populate_gsf_ability_stats` passes the fqn (available from the #316 `object_payloads` helper) so a context-overloaded prop ships the right label.
Evidence: `kessel/src/gsf_stat_dictionary.rs`, `kessel/src/db/ability.rs`.

### 2. 0x0403 drone-weapon cooldown override
Two TOML entries scope `weapon_cooldown_seconds` to `abl.spvp.drone.sentry_sniper.railgun` (2.0, verified vs the summon text "2 second cooldown") and `abl.spvp.drone.sentry_missile.missile` (12.0, guess), leaving the vacuous `scaling_factor` default on the 53 non-weapon abilities (relabeling all of them would falsely assert a 1-second cooldown).
Evidence (re-extract): 53 `scaling_factor` + 2 `weapon_cooldown_seconds`; `gsf_ability_stats` unchanged at 303.

### 3. Green
5 dictionary tests (incl. the override-only-on-drone-weapons case); build/clippy/fmt/test -p kessel green.

## Not done (the rest of #301 -- blocked, not skipped)

- **0x0401 rank-2:** the value (30/45/60/75) does NOT match the abilities' durations (blaster_overcharge=60 but lasts ~12s), so it cannot be confidently labeled. Its true meaning needs the `<<N>>` VALUE decode (see below) -- stays unknown.
- **0x0424 re-anchor from scFF*:** needs the `scFFComponentsPrototype` stat singleton, which is NOT in the extracted singletons (only cost prototypes are). Blocked until/unless that singleton is located.

Both, plus #308's proc duration/ICD, are blocked on the same wall: the `<<N>>` displayed value = `SpecParam coefficient x effAction-base`, and the effAction base value is not decoded (reflection 019ee74e). Filing that as the real unblock.
