### PR TITLE
feat(db): description_values landing table + corpus pass (#324)

### DIFF
--- a/kessel/src/db/description_values.rs
+++ b/kessel/src/db/description_values.rs
@@ -1,0 +1,144 @@
+//! Corpus description-anchoring pass (#324, epic #322): parse every canonical
+//! object's `id1=1` description and write the typed numeric facts to
+//! `description_values`, keyed by object. Domain-agnostic landing surface that
+//! the per-domain promotions (#325/#326) read from.
+
+use super::*;
+use crate::schema::description_anchor::{parse_description, FactKind};
+
+impl Database {
+    /// Parse id1=1 descriptions for canonical named objects and write their
+    /// `AnchoredFact`s to `description_values`. Returns (objects_with_facts,
+    /// total_facts).
+    pub fn populate_description_values(&self) -> Result<(u64, u64)> {
+        // (game_id, fqn, string_id, description text). en-us, id1=1, prefer the
+        // raw pre-grammar text so `<<N>>` templates survive.
+        let conn = self.conn.lock().unwrap();
+
+        let rows: Vec<(String, String, i64, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT o.game_id, o.fqn, o.string_id, COALESCE(s.text_raw, s.text) \
+                 FROM objects o \
+                 JOIN strings s ON s.id2 = o.string_id AND s.id1 = 1 AND s.locale = 'en-us' \
+                 WHERE o.is_canonical = 1 AND o.string_id IS NOT NULL",
+            )?;
+            let collected: Vec<(String, String, i64, String)> = stmt
+                .query_map([], |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, i64>(2)?,
+                        r.get::<_, String>(3)?,
+                    ))
+                })?
+                .filter_map(|r| r.ok())
+                .collect();
+            collected
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR REPLACE INTO description_values \
+             (object_game_id, fqn, string_id, seq, kind, value, label, token_ordinal) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        )?;
+
+        let (mut objects, mut facts) = (0u64, 0u64);
+        for (game_id, fqn, string_id, text) in &rows {
+            let mut parsed = parse_description(text);
+            if parsed.is_empty() {
+                continue;
+            }
+            // parse_description emits stat-phrase matches before number-unit
+            // matches; sort by source offset so `seq` is true reading order.
+            parsed.sort_by_key(|f| f.at);
+            objects += 1;
+            for (seq, fact) in parsed.iter().enumerate() {
+                let (kind, value, token_ordinal): (&str, Option<f64>, Option<i64>) = match fact.kind
+                {
+                    FactKind::Percent => ("percent", Some(fact.value), None),
+                    FactKind::DurationSeconds => ("duration_seconds", Some(fact.value), None),
+                    FactKind::RangeMeters => ("range_meters", Some(fact.value), None),
+                    FactKind::Count => ("count", Some(fact.value), None),
+                    FactKind::Magnitude => ("magnitude", Some(fact.value), None),
+                    FactKind::Template(n) => ("template", None, Some(i64::from(n))),
+                };
+                stmt.execute(params![
+                    game_id,
+                    fqn,
+                    string_id,
+                    seq as i64,
+                    kind,
+                    value,
+                    fact.label,
+                    token_ordinal,
+                ])?;
+                facts += 1;
+            }
+        }
+
+        drop(stmt);
+        tx.commit()?;
+        Ok((objects, facts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::temp_db_path;
+
+    #[test]
+    fn writes_expected_facts_for_known_object() {
+        let path = temp_db_path("description_values");
+        let db = Database::with_grammar(&path, None).unwrap();
+        db.init_schema().unwrap();
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO objects (game_id, stable_id, payload_hash, guid, fqn, kind, string_id, is_canonical, json) \
+                 VALUES ('g1', 'sid', 'ph', 'guid', 'abl.test.x', 'Ability', 555, 1, '{}')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO strings (fqn, locale, id1, id2, text, text_raw) VALUES \
+                 ('str.abl.test.x', 'en-us', 1, 555, \
+                  'grant 510 Power for seconds. once every 20 seconds.', \
+                  'grant 510 Power for <<1>> seconds. This effect can only occur once every 20 seconds.')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let (objects, facts) = db.populate_description_values().unwrap();
+        assert_eq!(objects, 1);
+        assert!(facts >= 3);
+
+        let conn = db.conn.lock().unwrap();
+        let mag: f64 = conn
+            .query_row(
+                "SELECT value FROM description_values WHERE object_game_id='g1' AND kind='magnitude' AND label='power'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(mag, 510.0);
+        let icd: f64 = conn
+            .query_row(
+                "SELECT value FROM description_values WHERE object_game_id='g1' AND kind='duration_seconds' AND value=20.0",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(icd, 20.0);
+        let ord: i64 = conn
+            .query_row(
+                "SELECT token_ordinal FROM description_values WHERE object_game_id='g1' AND kind='template'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ord, 1);
+    }
+}

--- a/kessel/src/db/mod.rs
+++ b/kessel/src/db/mod.rs
@@ -14,6 +14,7 @@ pub(crate) use crate::stb::StbEntry;
 mod ability;
 mod cnv;
 mod conquest;
+mod description_values;
 mod item;
 mod npc;
 pub mod passes;

--- a/kessel/src/db/passes.rs
+++ b/kessel/src/db/passes.rs
@@ -265,6 +265,15 @@ pub fn run_passes(db: &Database, ctx: &PassCtx) -> Result<PassCounts> {
         desc_tok_abilities, desc_tok_total
     );
 
+    // Description-anchoring corpus pass (#324): typed numeric facts (durations,
+    // percentages, ranges, counts, magnitudes, <<N>> templates) parsed from
+    // every canonical object's id1=1 description into description_values.
+    let (dv_objects, dv_facts) = timed!("description_values", db.populate_description_values())?;
+    println!(
+        "  Description values: {} facts from {} objects",
+        dv_facts, dv_objects
+    );
+
     // EPP appearance specs + FX specs (#183). UTF-16-LE XML files. epp
     // carries appearance action lists + fxSpec refs; fxspec carries node
     // class lists. The two tables JOIN via appearance_specs.fx_spec_refs

--- a/kessel/src/db/schema.rs
+++ b/kessel/src/db/schema.rs
@@ -87,6 +87,27 @@ pub(crate) fn create_core_tables(tx: &Transaction) -> Result<()> {
             );
             CREATE INDEX IF NOT EXISTS idx_object_string_refs_sid ON object_string_refs(string_id);
 
+            -- Typed numeric facts parsed from each object's id1=1 description
+            -- string (description-anchoring epic #322/#324). Domain-agnostic
+            -- landing surface: the displayed values (durations, percentages,
+            -- ranges, counts, named-stat magnitudes) are literals in the
+            -- localized text; `<<N>>` template tokens are recorded with their
+            -- ordinal (value filled later from the payload_ordinal substrate or
+            -- left runtime). One row per parsed fact, in source order.
+            CREATE TABLE IF NOT EXISTS description_values (
+                object_game_id TEXT NOT NULL,    -- objects.game_id of the described object
+                fqn            TEXT NOT NULL,     -- denormalized for query convenience
+                string_id      INTEGER NOT NULL,  -- strings.id2 (id1=1) parsed from
+                seq            INTEGER NOT NULL,   -- 0-based order of the fact in the description
+                kind           TEXT NOT NULL,     -- percent|duration_seconds|range_meters|count|magnitude|template
+                value          REAL,              -- normalized literal value; NULL for template
+                label          TEXT,              -- stat/unit word ("power","seconds","chance")
+                token_ordinal  INTEGER,           -- N for a <<N>> template fact, else NULL
+                PRIMARY KEY (object_game_id, string_id, seq)
+            );
+            CREATE INDEX IF NOT EXISTS idx_description_values_fqn ON description_values(fqn);
+            CREATE INDEX IF NOT EXISTS idx_description_values_kind ON description_values(kind);
+
             -- Typed views for convenience.
             -- Post-#23: kind='Quest' includes only qst.* objects.
             -- Mission phases (mpn.*) are kind='Phase' -- see `phases` view.

--- a/kessel/src/schema/description_anchor.rs
+++ b/kessel/src/schema/description_anchor.rs
@@ -7,12 +7,6 @@
 //! literals (and `<<N>>` template ordinals) into typed [`AnchoredFact`]s; the
 //! populate pass (#324) and the per-domain promotions (#325/#326) anchor them
 //! to records. Pure and deterministic -- no DB, no I/O.
-//!
-//! Enabler module: the public API below is consumed by the `description_values`
-//! populate pass (#324). Until that lands there is no in-crate caller, so the
-//! binary target would flag the API as dead -- allow it here and drop the allow
-//! when #324 wires the consumer.
-#![allow(dead_code)]
 
 use regex::Regex;
 use std::sync::OnceLock;


### PR DESCRIPTION
## Summary

Implements #324 (epic #322): the `description_values` landing table + corpus populate pass. Runs the #323 parser over every canonical object's `id1=1` description and writes the typed numeric facts keyed by object -- the domain-agnostic substrate the GSF/ability promotions (#325/#326) read from. Also drops the `dead_code` allow on `description_anchor` (now it has a consumer).

## Acceptance criteria mapping

### 1. `description_values` table + `populate_description_values`
New table `description_values(object_game_id, fqn, string_id, seq, kind, value, label, token_ordinal)` PK `(object_game_id, string_id, seq)` (`db/schema.rs`). `populate_description_values` joins `objects` (canonical, string_id NOT NULL) to `strings` (`id2=string_id`, `id1=1`, en-us), reads `COALESCE(text_raw, text)`, calls `parse_description`, and writes one row per fact.
Evidence: `kessel/src/db/description_values.rs`; registered in `db/passes.rs` after `ability_desc_tokens`.

### 2. Source order is true reading order
`parse_description` emits stat-phrase matches before number-unit matches, so the pass sorts facts by `AnchoredFact.at` (byte offset) before assigning `seq` -- `seq` is the real left-to-right order, and the `at` field is no longer dead.
Evidence: the `parsed.sort_by_key(|f| f.at)` in the populate.

### 3. Idempotent, batched, registered
INSERT OR REPLACE keyed by the PK (re-run yields identical rows); one transaction via `unchecked_transaction` + `prepare_cached` (the `populate_talent_details` pattern). Template facts store `token_ordinal=N`, `value=NULL`.
Evidence: unit test `writes_expected_facts_for_known_object` asserts magnitude 510 (power), duration 20, and template ordinal 1 from the Power-Surge-style oracle string.

### 4. Corpus behaviour (post-extract)
Re-extract: `description_values` populated corpus-wide; kind distribution (percent/duration/range/count/magnitude/template) all present; existing tables (objects/strings/ability_stats/item_stats) unchanged.

### 5. Green
`cargo test -p kessel` (new test passes), clippy `-D warnings`, fmt clean. Per-category simplify gate recorded.

## Not done
No promotion into typed stat tables -- that is #325 (GSF) and #326 (ability_desc_tokens values), which consume this table. No FR/DE (the multi-locale issue #329).
