### PR TITLE
feat(cnv): conversation_dialogue -- ordered dialogue script (#285)

### DIFF
--- a/kessel-discovery/examples/probe_cnv_tree.rs
+++ b/kessel-discovery/examples/probe_cnv_tree.rs
@@ -1,0 +1,612 @@
+//! Spike #284: map the cnv NODE dialogue-graph layout BY SHAPE.
+//!
+//! For a set of target cnv FQNs, locate their PROT node payload, decode the
+//! GOM object stream, and dump the structure so we can characterize:
+//!   (a) the dialogue-line property (line-id u32 BE + str.cnv ref),
+//!   (b) the speaker/actor ref property,
+//!   (c) player-OPTION vs NPC-line marker,
+//!   (d) the branch-target link between option and next node.
+//!
+//! Usage:
+//!   probe_cnv_tree -i ~/swtor/assets -H ~/swtor/data/hashes_filename.txt \
+//!       cnv.alliance.nar_shaddaa.misc.public_taxi ...
+
+use anyhow::Result;
+use kessel::gom_reader::{read_object_fields, GomValue, Reader};
+use kessel::hash::HashDictionary;
+use kessel::myp::Archive;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+const FIELD_MARKER: [u8; 4] = [0xCF, 0x40, 0x00, 0x00];
+
+/// Walk the payload as a FLAT sequence of top-level `<field_id><tag><value>`
+/// triples, starting at the first CF40 marker. Returns (field_id, byte_offset,
+/// value) for each top-level field. This is the node payload's real shape: a
+/// serialized object's field list, NOT a single wrapped object.
+fn walk_top_fields(payload: &[u8]) -> Vec<(u64, usize, Result<GomValue>)> {
+    let mut out = Vec::new();
+    let start = match payload.windows(4).position(|w| w == FIELD_MARKER) {
+        Some(s) => s,
+        None => return out,
+    };
+    let mut reader = Reader::new(payload, start);
+    loop {
+        let off = reader.pos();
+        let field_id = match reader.read_number() {
+            Ok(v) => v,
+            Err(_) => break,
+        };
+        let tag = match reader.read_tag() {
+            Ok(t) => t,
+            Err(_) => break,
+        };
+        let val = reader.read_value(tag);
+        let failed = val.is_err();
+        out.push((field_id, off, val));
+        if failed {
+            break;
+        }
+        if reader.pos() >= payload.len() {
+            break;
+        }
+        // Realign to the next CF40 marker if the stream has interstitial bytes.
+        let p = reader.pos();
+        if payload.get(p..p + 4) != Some(&FIELD_MARKER) {
+            match payload[p..].windows(4).position(|w| w == FIELD_MARKER) {
+                Some(rel) => reader = Reader::new(payload, p + rel),
+                None => break,
+            }
+        }
+    }
+    out
+}
+
+/// Summarize a GomValue compactly for one-line printing.
+fn summ(v: &GomValue) -> String {
+    match v {
+        GomValue::Null => "null".into(),
+        GomValue::U64(x) => format!("u64({x})"),
+        GomValue::I64(x) => format!("i64({x})"),
+        GomValue::Bool(b) => format!("bool({b})"),
+        GomValue::F32(f) => format!("f32({f})"),
+        GomValue::Enum(e) => format!("enum({e})"),
+        GomValue::Str(s) => {
+            let s = if s.len() > 60 { &s[..60] } else { s };
+            format!("str({s:?})")
+        }
+        GomValue::List(l) => format!("list[{}]", l.len()),
+        GomValue::Map(m) => format!("map[{}]", m.len()),
+        GomValue::Embedded(f) => format!("obj{{{} fields}}", f.len()),
+        GomValue::ClassRef(r) => format!("classref(0x{r:016X})"),
+    }
+}
+
+/// Recursive structured dump with field-id low32 labels and depth guard.
+fn dump(v: &GomValue, depth: usize, indent: usize) {
+    let pad = "  ".repeat(indent);
+    match v {
+        GomValue::Embedded(fields) => {
+            for (id, fv) in fields {
+                let low = *id as u32;
+                println!("{pad}.{low:08X} = {}", summ(fv));
+                if depth > 0 && matches!(fv, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_))
+                {
+                    dump(fv, depth - 1, indent + 1);
+                }
+            }
+        }
+        GomValue::List(items) => {
+            for (i, it) in items.iter().enumerate() {
+                if i >= 40 {
+                    println!("{pad}... ({} more)", items.len() - 40);
+                    break;
+                }
+                println!("{pad}[{i}] = {}", summ(it));
+                if depth > 0 && matches!(it, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)) {
+                    dump(it, depth - 1, indent + 1);
+                }
+            }
+        }
+        GomValue::Map(m) => {
+            for (i, (k, val)) in m.iter().enumerate() {
+                if i >= 40 {
+                    println!("{pad}... ({} more)", m.len() - 40);
+                    break;
+                }
+                println!("{pad}{} => {}", summ(k), summ(val));
+                if depth > 0 && matches!(val, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)) {
+                    dump(val, depth - 1, indent + 1);
+                }
+            }
+        }
+        _ => println!("{pad}{}", summ(v)),
+    }
+}
+
+/// Find all field-id low32 fingerprints present in an embedded object (sorted).
+fn field_ids(v: &GomValue) -> Vec<u32> {
+    match v {
+        GomValue::Embedded(f) => {
+            let mut ids: Vec<u32> = f.iter().map(|(id, _)| *id as u32).collect();
+            ids.sort_unstable();
+            ids
+        }
+        _ => vec![],
+    }
+}
+
+/// Count absolute 5CE87488 markers as a hint for the expected node count.
+fn node_count_hint(payload: &[u8]) -> usize {
+    let m: [u8; 9] = [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
+    (0..payload.len().saturating_sub(9))
+        .filter(|&w| payload[w..w + 9] == m)
+        .count()
+}
+
+fn hexdump(bytes: &[u8], base: usize) {
+    for i in (0..bytes.len()).step_by(16) {
+        let chunk = &bytes[i..(i + 16).min(bytes.len())];
+        let hex: String = chunk.iter().map(|b| format!("{b:02X} ")).collect();
+        let asc: String = chunk
+            .iter()
+            .map(|&b| if (32..127).contains(&b) { b as char } else { '.' })
+            .collect();
+        println!("  {:06x}  {hex:<48}  {asc}", base + i);
+    }
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut input_dir = PathBuf::from(".");
+    let mut hash_path: Option<PathBuf> = None;
+    let mut targets: Vec<String> = Vec::new();
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-i" => {
+                input_dir = PathBuf::from(&args[i + 1]);
+                i += 2;
+            }
+            "-H" => {
+                hash_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            other => {
+                targets.push(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let hash_path = hash_path.unwrap_or_else(|| input_dir.join("hashes_filename.txt"));
+    let mut hashes = HashDictionary::new();
+    hashes.load(&hash_path)?;
+    let proto_hashes: HashSet<u64> = hashes
+        .paths_matching("/resources/systemgenerated/prototypes/")
+        .into_iter()
+        .map(|(h, _)| h)
+        .collect();
+    let target_set: HashSet<String> = targets.iter().cloned().collect();
+
+    let tor_files: Vec<_> = std::fs::read_dir(&input_dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "tor").unwrap_or(false))
+        .collect();
+
+    let mut found: HashSet<String> = HashSet::new();
+    for tor_path in &tor_files {
+        if found.len() == target_set.len() {
+            break;
+        }
+        let mut archive = match Archive::open(tor_path) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+        let entries: Vec<_> = match archive.entries() {
+            Ok(e) => e.cloned().collect(),
+            Err(_) => continue,
+        };
+        for entry in &entries {
+            if !proto_hashes.contains(&entry.filename_hash) || entry.compressed_size == 0 {
+                continue;
+            }
+            let data = match archive.read_entry(entry) {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            if data.len() < 0x18 || &data[0..4] != b"PROT" {
+                continue;
+            }
+            let mut e = 0x14;
+            while e < data.len() && data[e] != 0 {
+                e += 1;
+            }
+            let node_fqn = String::from_utf8_lossy(&data[0x14..e]).into_owned();
+            if !target_set.contains(&node_fqn) || found.contains(&node_fqn) {
+                continue;
+            }
+            found.insert(node_fqn.clone());
+            let path = hashes.get(entry.filename_hash).cloned().unwrap_or_default();
+
+            println!("\n\n############################################################");
+            println!("# {node_fqn}");
+            println!("#   path={path}  payload={} bytes (PROT total {})", data.len() - e, data.len());
+            println!("############################################################");
+
+            let payload = &data[e..];
+
+            // --- raw marker census: every CF40-prefixed field id and its tag ---
+            println!("\n--- CF40 field-marker census (offset, then bytes after CF40) ---");
+            let mut occ = 0u32;
+            let mut marker_offs: Vec<usize> = Vec::new();
+            for w in 0..payload.len().saturating_sub(4) {
+                if payload[w..w + 4] == FIELD_MARKER {
+                    marker_offs.push(w);
+                }
+            }
+            println!("  {} CF40 markers in payload", marker_offs.len());
+
+            // --- 5CE87488 dialogue-line marker census (the prior-research hash) ---
+            // The dialogue line value carries '02 cc 11' + line-id u32 BE.
+            // Search raw payload for the byte pattern 02 CC 11 and print context.
+            println!("\n--- '02 CC 11' line-marker census (line-id follows as u32 BE) ---");
+            let mut line_hits = 0u32;
+            let mut line_ids: Vec<u32> = Vec::new();
+            for w in 0..payload.len().saturating_sub(7) {
+                if payload[w] == 0x02 && payload[w + 1] == 0xCC && payload[w + 2] == 0x11 {
+                    let id = u32::from_be_bytes([
+                        payload[w + 3],
+                        payload[w + 4],
+                        payload[w + 5],
+                        payload[w + 6],
+                    ]);
+                    line_ids.push(id);
+                    if line_hits < 30 {
+                        println!("  @0x{w:05x}: line_id={id} (0x{id:08X})  ctx={:02X?}", &payload[w.saturating_sub(8)..(w + 12).min(payload.len())]);
+                    }
+                    line_hits += 1;
+                }
+            }
+            println!("  TOTAL '02 CC 11' hits: {line_hits}");
+            println!("  line_ids in payload byte order (first 40): {:?}", &line_ids[..line_ids.len().min(40)]);
+
+            let _ = occ;
+            // --- BRUTE-FORCE: find the node LIST (a List whose elements are
+            // Embedded objects, each beginning with field 5CE87488). Scan every
+            // offset, try read_value(LIST=07); keep the decode that yields the
+            // most Embedded elements whose first field id low32 == 5CE87488. ---
+            {
+                let want = node_count_hint(payload);
+                println!("\n--- BRUTE-FORCE node-list search (expect ~{want} node objs) ---");
+                let mut best: Option<(usize, GomValue, usize)> = None;
+                for off in 0..payload.len().saturating_sub(2) {
+                    let mut r = Reader::new(payload, off);
+                    if let Ok(v @ GomValue::List(_)) = r.read_value(0x07) {
+                        if let GomValue::List(items) = &v {
+                            let n = items
+                                .iter()
+                                .filter(|e| matches!(e, GomValue::Embedded(f) if f.first().map(|(id,_)| *id as u32)==Some(0x5CE87488)))
+                                .count();
+                            if n >= 1 && best.as_ref().map(|(_, _, bn)| n > *bn).unwrap_or(true) {
+                                best = Some((off, v.clone(), n));
+                            }
+                        }
+                    }
+                }
+                if let Some((off, v, n)) = best {
+                    println!("  best node-list @0x{off:05x}: {n} line-node elements");
+                    if let GomValue::List(items) = &v {
+                        // Dump first 3 node objects fully and any with >1 transition.
+                        for (i, e) in items.iter().enumerate().take(3) {
+                            println!("  --- node-list element [{i}] ---");
+                            dump(e, 6, 3);
+                        }
+                    }
+                } else {
+                    println!("  (no node list found via brute force)");
+                }
+            }
+
+            // --- attempt full single-object decode (read_object_fields) ---
+            println!("\n--- FULL OBJECT DECODE attempt (read_object_fields) ---");
+            match read_object_fields(payload) {
+                Ok(root) => {
+                    println!("  OK -- top structure (depth 3):");
+                    dump(&root, 3, 2);
+                }
+                Err(e) => println!("  FAILED: {e}"),
+            }
+
+            // --- flat top-level field walk ---
+            println!("\n--- TOP-LEVEL FIELD WALK (flat <id><tag><value> sequence) ---");
+            let fields = walk_top_fields(payload);
+            println!("  decoded {} top-level fields", fields.len());
+
+            // Field-id low32 histogram
+            use std::collections::BTreeMap;
+            let mut hist: BTreeMap<u32, u32> = BTreeMap::new();
+            for (id, _, v) in &fields {
+                if v.is_ok() {
+                    *hist.entry(*id as u32).or_default() += 1;
+                }
+            }
+            println!("\n--- top-level field-id low32 histogram ---");
+            for (id, cnt) in &hist {
+                println!("  .{id:08X}  x{cnt}");
+            }
+
+            // Ordered field sequence (id low32 + compact value) -- reveals node
+            // boundaries (a repeating field id that starts each dialogue node).
+            println!("\n--- ORDERED top-level field sequence ---");
+            for (i, (id, off, v)) in fields.iter().enumerate() {
+                let low = *id as u32;
+                let s = match v {
+                    Ok(val) => summ(val),
+                    Err(e) => format!("ERR {e}"),
+                };
+                println!("  [{i:>3}] @0x{off:05x} .{low:08X} = {s}");
+            }
+
+            // Dump the FIRST 8 fields fully and any node-list fields.
+            println!("\n--- first 12 top-level fields (id, offset, value) ---");
+            for (id, off, v) in fields.iter().take(12) {
+                let low = *id as u32;
+                match v {
+                    Ok(val) => {
+                        println!("  @0x{off:05x} .{low:08X} (full 0x{id:016X}) = {}", summ(val));
+                        if matches!(val, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)) {
+                            dump(val, 2, 3);
+                        }
+                    }
+                    Err(e) => println!("  @0x{off:05x} .{low:08X} = ERR {e}"),
+                }
+            }
+
+            // Characterize node-record lists: any field that is a List of Embedded.
+            println!("\n--- node-record fingerprint analysis (lists of embedded objs) ---");
+            for (id, _, v) in &fields {
+                if let Ok(val) = v {
+                    characterize_field(*id as u32, val);
+                }
+            }
+
+            // --- PER-NODE OBJECT DECODE ---
+            // Each dialogue node is an Embedded object whose FIRST field uses the
+            // absolute 8-byte id 0x40000011_5CE87488 (the line-id field). Locate
+            // each such absolute id in the payload, back up to the object header
+            // (<script_type><nfields>), and decode the whole node object so we
+            // see the line-id, str.cnv ref, speaker, options and branch links.
+            println!("\n--- PER-NODE OBJECT DECODE (first 6 nodes) ---");
+            let abs_marker: [u8; 9] =
+                [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
+            let mut node_positions: Vec<usize> = Vec::new();
+            for w in 0..payload.len().saturating_sub(9) {
+                if payload[w..w + 9] == abs_marker {
+                    node_positions.push(w);
+                }
+            }
+            println!("  {} node objects (absolute 5CE87488 markers)", node_positions.len());
+            let mut decoded_nodes = 0;
+            for (ni, &mpos) in node_positions.iter().enumerate() {
+                let node_cap: usize = std::env::var("NODE_CAP").ok().and_then(|s| s.parse().ok()).unwrap_or(6);
+                if decoded_nodes >= node_cap {
+                    break;
+                }
+                // Back up to find the object header: try offsets 1..=10 bytes
+                // before the absolute id, decode as object, keep the one whose
+                // first field id low32 == 5CE87488.
+                let mut best: Option<GomValue> = None;
+                for back in 1..=12usize {
+                    if mpos < back {
+                        continue;
+                    }
+                    let cand = mpos - back;
+                    let mut r = Reader::new(payload, cand);
+                    if let Ok(v) = r.read_value(0x09) {
+                        if let GomValue::Embedded(f) = &v {
+                            if f.first().map(|(id, _)| *id as u32) == Some(0x5CE87488) {
+                                best = Some(v);
+                                break;
+                            }
+                        }
+                    }
+                }
+                println!("\n  === NODE {ni} @0x{mpos:05x} ===");
+                if let Some(v) = best {
+                    dump(&v, 5, 4);
+                }
+                // Manual delta-field walk from the line marker to the next node:
+                // start a Reader at the absolute id, treat it as the running
+                // field-id, and decode <tag><value> then <delta_id><tag><value>*
+                // until the next node position (or a decode error).
+                let end = node_positions.get(ni + 1).copied().unwrap_or(payload.len());
+                println!("    [manual delta-field walk to next node @0x{end:05x}]");
+                let mut r = Reader::new(payload, mpos);
+                let mut fid: u64 = match r.read_number() {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                // first field id is the absolute value just read
+                loop {
+                    let tag = match r.read_tag() {
+                        Ok(t) => t,
+                        Err(_) => break,
+                    };
+                    let off = r.pos();
+                    let val = match r.read_value(tag) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            println!("      .{:08X} tag={tag:02X} DECODE-ERR {e} @0x{off:05x}", fid as u32);
+                            break;
+                        }
+                    };
+                    println!("      .{:08X} (tag {tag:02X}) = {}", fid as u32, summ(&val));
+                    if matches!(val, GomValue::List(_) | GomValue::Map(_) | GomValue::Embedded(_)) {
+                        dump(&val, 3, 5);
+                    }
+                    if r.pos() >= end {
+                        break;
+                    }
+                    // next field: read delta id
+                    let d = match r.read_number() {
+                        Ok(v) => v,
+                        Err(_) => break,
+                    };
+                    fid = fid.wrapping_add(d);
+                }
+                // Per-node CF E0 GUID census (speaker/branch refs) within this
+                // node's byte range, and the node-type enum F03749AA.
+                let e0: Vec<String> = (mpos..end.saturating_sub(8))
+                    .filter(|&w| payload[w] == 0xCF && payload[w + 1] == 0xE0)
+                    .map(|w| {
+                        let g = u64::from_be_bytes(payload[w + 1..w + 9].try_into().unwrap());
+                        format!("{g:016X}")
+                    })
+                    .collect();
+                println!("    [node E0 GUID refs: {e0:?}]");
+                // node-type enum F03749AA: raw bytes 05 <val+1>. Search the node
+                // for the absolute field marker cf40 0005 F03749AA.
+                // (Simpler: report whether the 9EB734DC option-fingerprint field
+                // appears in this node's range, and any ASCII transition labels.)
+                let has_9eb = (mpos..end.saturating_sub(4)).any(|w| {
+                    payload[w] == 0x9E && payload[w + 1] == 0xB7 && payload[w + 2] == 0x34 && payload[w + 3] == 0xDC
+                });
+                // transition label strings (06 <len> ascii) that look like To_*/branch labels
+                let mut labels: Vec<String> = Vec::new();
+                let mut w = mpos;
+                while w + 2 < end {
+                    if payload[w] == 0x06 {
+                        let len = payload[w + 1] as usize;
+                        if len > 2 && len < 60 && w + 2 + len <= end {
+                            let s = &payload[w + 2..w + 2 + len];
+                            if s.iter().all(|&b| (0x20..0x7F).contains(&b)) {
+                                let st = String::from_utf8_lossy(s).into_owned();
+                                if !st.starts_with("str.") && !labels.contains(&st) {
+                                    labels.push(st);
+                                }
+                            }
+                        }
+                    }
+                    w += 1;
+                }
+                println!("    [node has_9EB734DC={has_9eb}  labels={labels:?}]");
+                decoded_nodes += 1;
+            }
+
+            // The dialogue line node: find which top-level field (or nested obj)
+            // contains the .5CE87488 sub-field, and dump 3 full samples plus the
+            // node objects that surround line markers.
+            println!("\n--- LINE-NODE samples (objects containing .5CE87488) ---");
+            let mut shown = 0;
+            for (id, off, v) in &fields {
+                if let Ok(val) = v {
+                    if contains_field(val, 0x5CE87488) && shown < 4 {
+                        println!("  >>> top-field @0x{off:05x} .{:08X} contains a 5CE87488 line node:", *id as u32);
+                        dump(val, 4, 3);
+                        shown += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    for t in &targets {
+        if !found.contains(t) {
+            println!("\n!!! NOT FOUND: {t}");
+        }
+    }
+    Ok(())
+}
+
+/// True if this value or any nested object/list/map contains an embedded field
+/// whose id low32 == `want`.
+fn contains_field(v: &GomValue, want: u32) -> bool {
+    match v {
+        GomValue::Embedded(fields) => fields
+            .iter()
+            .any(|(id, fv)| (*id as u32) == want || contains_field(fv, want)),
+        GomValue::List(items) => items.iter().any(|x| contains_field(x, want)),
+        GomValue::Map(m) => m.iter().any(|(_, val)| contains_field(val, want)),
+        _ => false,
+    }
+}
+
+/// For a single top-level field value, if it is (or nests) a List of Embedded
+/// objects, report distinct field-id fingerprints with counts + one sample.
+fn characterize_field(top_id: u32, v: &GomValue) {
+    if let GomValue::List(items) = v {
+        let emb: Vec<&GomValue> = items
+            .iter()
+            .filter(|x| matches!(x, GomValue::Embedded(_)))
+            .collect();
+        if emb.len() >= 2 {
+            println!("  top-field .{top_id:08X} -> list of {} embedded objects", emb.len());
+            let mut seen: Vec<(Vec<u32>, usize)> = Vec::new();
+            for e in &emb {
+                let fp = field_ids(e);
+                if let Some(s) = seen.iter_mut().find(|(f, _)| *f == fp) {
+                    s.1 += 1;
+                } else {
+                    seen.push((fp, 1));
+                }
+            }
+            for (fp, cnt) in &seen {
+                let fps: Vec<String> = fp.iter().map(|x| format!("{x:08X}")).collect();
+                println!("      {cnt:>4}x fingerprint [{}]", fps.join(" "));
+            }
+        }
+    }
+}
+
+/// Walk the tree; for every List whose elements are Embedded objects, tally the
+/// distinct field-id fingerprints (the node-type fingerprints).
+#[allow(dead_code)]
+fn characterize(v: &GomValue, depth: usize) {
+    match v {
+        GomValue::Embedded(fields) => {
+            for (id, fv) in fields {
+                if let GomValue::List(items) = fv {
+                    let emb: Vec<&GomValue> =
+                        items.iter().filter(|x| matches!(x, GomValue::Embedded(_))).collect();
+                    if !emb.is_empty() {
+                        let low = *id as u32;
+                        println!("  field .{low:08X} -> list of {} embedded objects", emb.len());
+                        // distinct fingerprints
+                        let mut seen: Vec<(Vec<u32>, usize)> = Vec::new();
+                        for e in &emb {
+                            let fp = field_ids(e);
+                            if let Some(s) = seen.iter_mut().find(|(f, _)| *f == fp) {
+                                s.1 += 1;
+                            } else {
+                                seen.push((fp, 1));
+                            }
+                        }
+                        for (fp, cnt) in &seen {
+                            let fps: Vec<String> = fp.iter().map(|x| format!("{x:08X}")).collect();
+                            println!("      {cnt:>4}x fingerprint [{}]", fps.join(" "));
+                        }
+                        // dump first 2 of each fingerprint fully
+                        for (fp, _) in &seen {
+                            if let Some(sample) = emb.iter().find(|e| &field_ids(e) == fp) {
+                                println!("      --- sample for fingerprint [{}] ---", fp.iter().map(|x| format!("{x:08X}")).collect::<Vec<_>>().join(" "));
+                                dump(sample, 2, 4);
+                            }
+                        }
+                    }
+                }
+                if depth < 4 {
+                    characterize(fv, depth + 1);
+                }
+            }
+        }
+        GomValue::List(items) => {
+            for it in items.iter().take(3) {
+                if depth < 4 {
+                    characterize(it, depth + 1);
+                }
+            }
+        }
+        _ => {}
+    }
+}

--- a/kessel-discovery/examples/probe_cnv_tree.rs
+++ b/kessel-discovery/examples/probe_cnv_tree.rs
@@ -90,7 +90,11 @@ fn dump(v: &GomValue, depth: usize, indent: usize) {
             for (id, fv) in fields {
                 let low = *id as u32;
                 println!("{pad}.{low:08X} = {}", summ(fv));
-                if depth > 0 && matches!(fv, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_))
+                if depth > 0
+                    && matches!(
+                        fv,
+                        GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)
+                    )
                 {
                     dump(fv, depth - 1, indent + 1);
                 }
@@ -103,7 +107,12 @@ fn dump(v: &GomValue, depth: usize, indent: usize) {
                     break;
                 }
                 println!("{pad}[{i}] = {}", summ(it));
-                if depth > 0 && matches!(it, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)) {
+                if depth > 0
+                    && matches!(
+                        it,
+                        GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)
+                    )
+                {
                     dump(it, depth - 1, indent + 1);
                 }
             }
@@ -115,7 +124,12 @@ fn dump(v: &GomValue, depth: usize, indent: usize) {
                     break;
                 }
                 println!("{pad}{} => {}", summ(k), summ(val));
-                if depth > 0 && matches!(val, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)) {
+                if depth > 0
+                    && matches!(
+                        val,
+                        GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)
+                    )
+                {
                     dump(val, depth - 1, indent + 1);
                 }
             }
@@ -150,7 +164,13 @@ fn hexdump(bytes: &[u8], base: usize) {
         let hex: String = chunk.iter().map(|b| format!("{b:02X} ")).collect();
         let asc: String = chunk
             .iter()
-            .map(|&b| if (32..127).contains(&b) { b as char } else { '.' })
+            .map(|&b| {
+                if (32..127).contains(&b) {
+                    b as char
+                } else {
+                    '.'
+                }
+            })
             .collect();
         println!("  {:06x}  {hex:<48}  {asc}", base + i);
     }
@@ -231,7 +251,11 @@ fn main() -> Result<()> {
 
             println!("\n\n############################################################");
             println!("# {node_fqn}");
-            println!("#   path={path}  payload={} bytes (PROT total {})", data.len() - e, data.len());
+            println!(
+                "#   path={path}  payload={} bytes (PROT total {})",
+                data.len() - e,
+                data.len()
+            );
             println!("############################################################");
 
             let payload = &data[e..];
@@ -263,13 +287,19 @@ fn main() -> Result<()> {
                     ]);
                     line_ids.push(id);
                     if line_hits < 30 {
-                        println!("  @0x{w:05x}: line_id={id} (0x{id:08X})  ctx={:02X?}", &payload[w.saturating_sub(8)..(w + 12).min(payload.len())]);
+                        println!(
+                            "  @0x{w:05x}: line_id={id} (0x{id:08X})  ctx={:02X?}",
+                            &payload[w.saturating_sub(8)..(w + 12).min(payload.len())]
+                        );
                     }
                     line_hits += 1;
                 }
             }
             println!("  TOTAL '02 CC 11' hits: {line_hits}");
-            println!("  line_ids in payload byte order (first 40): {:?}", &line_ids[..line_ids.len().min(40)]);
+            println!(
+                "  line_ids in payload byte order (first 40): {:?}",
+                &line_ids[..line_ids.len().min(40)]
+            );
 
             let _ = occ;
             // --- BRUTE-FORCE: find the node LIST (a List whose elements are
@@ -354,8 +384,14 @@ fn main() -> Result<()> {
                 let low = *id as u32;
                 match v {
                     Ok(val) => {
-                        println!("  @0x{off:05x} .{low:08X} (full 0x{id:016X}) = {}", summ(val));
-                        if matches!(val, GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)) {
+                        println!(
+                            "  @0x{off:05x} .{low:08X} (full 0x{id:016X}) = {}",
+                            summ(val)
+                        );
+                        if matches!(
+                            val,
+                            GomValue::Embedded(_) | GomValue::List(_) | GomValue::Map(_)
+                        ) {
                             dump(val, 2, 3);
                         }
                     }
@@ -378,18 +414,23 @@ fn main() -> Result<()> {
             // (<script_type><nfields>), and decode the whole node object so we
             // see the line-id, str.cnv ref, speaker, options and branch links.
             println!("\n--- PER-NODE OBJECT DECODE (first 6 nodes) ---");
-            let abs_marker: [u8; 9] =
-                [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
+            let abs_marker: [u8; 9] = [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
             let mut node_positions: Vec<usize> = Vec::new();
             for w in 0..payload.len().saturating_sub(9) {
                 if payload[w..w + 9] == abs_marker {
                     node_positions.push(w);
                 }
             }
-            println!("  {} node objects (absolute 5CE87488 markers)", node_positions.len());
+            println!(
+                "  {} node objects (absolute 5CE87488 markers)",
+                node_positions.len()
+            );
             let mut decoded_nodes = 0;
             for (ni, &mpos) in node_positions.iter().enumerate() {
-                let node_cap: usize = std::env::var("NODE_CAP").ok().and_then(|s| s.parse().ok()).unwrap_or(6);
+                let node_cap: usize = std::env::var("NODE_CAP")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(6);
                 if decoded_nodes >= node_cap {
                     break;
                 }
@@ -437,12 +478,18 @@ fn main() -> Result<()> {
                     let val = match r.read_value(tag) {
                         Ok(v) => v,
                         Err(e) => {
-                            println!("      .{:08X} tag={tag:02X} DECODE-ERR {e} @0x{off:05x}", fid as u32);
+                            println!(
+                                "      .{:08X} tag={tag:02X} DECODE-ERR {e} @0x{off:05x}",
+                                fid as u32
+                            );
                             break;
                         }
                     };
                     println!("      .{:08X} (tag {tag:02X}) = {}", fid as u32, summ(&val));
-                    if matches!(val, GomValue::List(_) | GomValue::Map(_) | GomValue::Embedded(_)) {
+                    if matches!(
+                        val,
+                        GomValue::List(_) | GomValue::Map(_) | GomValue::Embedded(_)
+                    ) {
                         dump(&val, 3, 5);
                     }
                     if r.pos() >= end {
@@ -470,7 +517,10 @@ fn main() -> Result<()> {
                 // (Simpler: report whether the 9EB734DC option-fingerprint field
                 // appears in this node's range, and any ASCII transition labels.)
                 let has_9eb = (mpos..end.saturating_sub(4)).any(|w| {
-                    payload[w] == 0x9E && payload[w + 1] == 0xB7 && payload[w + 2] == 0x34 && payload[w + 3] == 0xDC
+                    payload[w] == 0x9E
+                        && payload[w + 1] == 0xB7
+                        && payload[w + 2] == 0x34
+                        && payload[w + 3] == 0xDC
                 });
                 // transition label strings (06 <len> ascii) that look like To_*/branch labels
                 let mut labels: Vec<String> = Vec::new();
@@ -502,7 +552,10 @@ fn main() -> Result<()> {
             for (id, off, v) in &fields {
                 if let Ok(val) = v {
                     if contains_field(val, 0x5CE87488) && shown < 4 {
-                        println!("  >>> top-field @0x{off:05x} .{:08X} contains a 5CE87488 line node:", *id as u32);
+                        println!(
+                            "  >>> top-field @0x{off:05x} .{:08X} contains a 5CE87488 line node:",
+                            *id as u32
+                        );
                         dump(val, 4, 3);
                         shown += 1;
                     }
@@ -541,7 +594,10 @@ fn characterize_field(top_id: u32, v: &GomValue) {
             .filter(|x| matches!(x, GomValue::Embedded(_)))
             .collect();
         if emb.len() >= 2 {
-            println!("  top-field .{top_id:08X} -> list of {} embedded objects", emb.len());
+            println!(
+                "  top-field .{top_id:08X} -> list of {} embedded objects",
+                emb.len()
+            );
             let mut seen: Vec<(Vec<u32>, usize)> = Vec::new();
             for e in &emb {
                 let fp = field_ids(e);
@@ -567,11 +623,16 @@ fn characterize(v: &GomValue, depth: usize) {
         GomValue::Embedded(fields) => {
             for (id, fv) in fields {
                 if let GomValue::List(items) = fv {
-                    let emb: Vec<&GomValue> =
-                        items.iter().filter(|x| matches!(x, GomValue::Embedded(_))).collect();
+                    let emb: Vec<&GomValue> = items
+                        .iter()
+                        .filter(|x| matches!(x, GomValue::Embedded(_)))
+                        .collect();
                     if !emb.is_empty() {
                         let low = *id as u32;
-                        println!("  field .{low:08X} -> list of {} embedded objects", emb.len());
+                        println!(
+                            "  field .{low:08X} -> list of {} embedded objects",
+                            emb.len()
+                        );
                         // distinct fingerprints
                         let mut seen: Vec<(Vec<u32>, usize)> = Vec::new();
                         for e in &emb {
@@ -589,7 +650,13 @@ fn characterize(v: &GomValue, depth: usize) {
                         // dump first 2 of each fingerprint fully
                         for (fp, _) in &seen {
                             if let Some(sample) = emb.iter().find(|e| &field_ids(e) == fp) {
-                                println!("      --- sample for fingerprint [{}] ---", fp.iter().map(|x| format!("{x:08X}")).collect::<Vec<_>>().join(" "));
+                                println!(
+                                    "      --- sample for fingerprint [{}] ---",
+                                    fp.iter()
+                                        .map(|x| format!("{x:08X}"))
+                                        .collect::<Vec<_>>()
+                                        .join(" ")
+                                );
                                 dump(sample, 2, 4);
                             }
                         }

--- a/kessel/src/db/cnv.rs
+++ b/kessel/src/db/cnv.rs
@@ -435,6 +435,62 @@ impl Database {
         self.flush()?;
         Ok(rows_inserted)
     }
+
+    /// Populate `conversation_dialogue` (#285): the ordered dialogue script of
+    /// every conversation, decoded from its NODE payload's line-node markers in
+    /// byte order. Returns (conversations_with_dialogue, total_lines).
+    pub fn populate_conversation_dialogue(&self) -> Result<(u64, u64)> {
+        use crate::schema::conversation_tree::decode_dialogue_lines;
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
+        let conn = self.conn.lock().unwrap();
+
+        let convs: Vec<(String, String)> = {
+            let mut stmt = conn.prepare(
+                "SELECT fqn, json_extract(json, '$.payload_b64') \
+                 FROM objects WHERE kind = 'Conversation' AND is_canonical = 1",
+            )?;
+            let rows: Vec<(String, String)> = stmt
+                .query_map([], |r| {
+                    Ok((r.get::<_, String>(0)?, r.get::<_, Option<String>>(1)?))
+                })?
+                .filter_map(|r| r.ok())
+                .filter_map(|(fqn, b64)| b64.map(|b| (fqn, b)))
+                .collect();
+            rows
+        };
+
+        let tx = conn.unchecked_transaction()?;
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR REPLACE INTO conversation_dialogue \
+             (cnv_fqn, seq, line_id, line_ref) VALUES (?1, ?2, ?3, ?4)",
+        )?;
+
+        let (mut conversations, mut lines) = (0u64, 0u64);
+        for (fqn, b64) in &convs {
+            let Ok(payload) = BASE64.decode(b64) else {
+                continue;
+            };
+            let decoded = decode_dialogue_lines(&payload);
+            if decoded.is_empty() {
+                continue;
+            }
+            conversations += 1;
+            for line in decoded {
+                stmt.execute(params![
+                    fqn,
+                    line.seq as i64,
+                    line.line_id as i64,
+                    line.line_ref,
+                ])?;
+                lines += 1;
+            }
+        }
+
+        drop(stmt);
+        tx.commit()?;
+        Ok((conversations, lines))
+    }
 }
 
 /// Derive the en-us dialogue STB archive path for a `cnv.*` conversation FQN.
@@ -535,6 +591,25 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
                 PRIMARY KEY (cnv_fqn, event_kind)
             );
             CREATE INDEX IF NOT EXISTS idx_cnv_align_kind ON conversation_alignment_events(event_kind);
+
+            -- Ordered dialogue script per conversation (#285). Each row is one
+            -- dialogue line, decoded from the conversation NODE payload's
+            -- line-node markers in byte order (== dialogue order, #284 spike).
+            -- `seq` is the playback order; `line_id` is the str.cnv string's
+            -- `id1` (the per-line id; NB the `conversation_lines` view labels
+            -- the shared `id2` as "line_id"). Join to `strings` on id1 + the
+            -- `line_ref` (str.cnv base FQN) prefix for the spoken text:
+            --   JOIN strings s ON s.id1 = d.line_id
+            --                  AND s.fqn LIKE d.line_ref || '.%'
+            --                  AND s.locale = 'en-us'
+            CREATE TABLE IF NOT EXISTS conversation_dialogue (
+                cnv_fqn  TEXT NOT NULL,
+                seq      INTEGER NOT NULL,
+                line_id  INTEGER NOT NULL,
+                line_ref TEXT NOT NULL,
+                PRIMARY KEY (cnv_fqn, seq)
+            );
+            CREATE INDEX IF NOT EXISTS idx_cnv_dialogue_line ON conversation_dialogue(line_id);
         "#,
     )?;
 

--- a/kessel/src/db/passes.rs
+++ b/kessel/src/db/passes.rs
@@ -334,6 +334,15 @@ pub fn run_passes(db: &Database, ctx: &PassCtx) -> Result<PassCounts> {
         cnv_string_rows
     );
 
+    // Ordered dialogue script (#285): decode each Conversation NODE payload's
+    // line-node markers (byte order == dialogue order) into conversation_dialogue.
+    let (cnv_dialogue_convs, cnv_dialogue_lines) =
+        timed!("conversation_dialogue", db.populate_conversation_dialogue())?;
+    println!(
+        "  Conversation dialogue: {} lines across {} conversations",
+        cnv_dialogue_lines, cnv_dialogue_convs
+    );
+
     // Quest_chain via NPC giver overlap. Must run AFTER both
     // populate_quest_clusters (cluster filter) and populate_conversation_refs
     // (the conv_quest_refs / conv_npcs join surface).

--- a/kessel/src/gom_reader.rs
+++ b/kessel/src/gom_reader.rs
@@ -132,6 +132,20 @@ impl<'a> Reader<'a> {
         Reader { buf, pos }
     }
 
+    /// Current cursor position within the payload (recon probes use this to
+    /// report byte offsets). Only consumed by `kessel-discovery` recon tools,
+    /// so the production binary sees it as unused.
+    #[allow(dead_code)]
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// Read one raw byte and advance (exposed for recon probes that walk a flat
+    /// sequence of top-level `<field_id><tag><value>` triples and need the tag).
+    pub fn read_tag(&mut self) -> Result<u8> {
+        self.read_u8()
+    }
+
     fn read_u8(&mut self) -> Result<u8> {
         let b = *self
             .buf

--- a/kessel/src/schema/conversation_tree.rs
+++ b/kessel/src/schema/conversation_tree.rs
@@ -1,0 +1,120 @@
+//! Decode a conversation NODE payload into its ordered dialogue lines (#285,
+//! epic for #284-287). A `.node` prototype payload is a FLAT sequence of
+//! standalone GOM objects; each dialogue-line object opens with the absolute
+//! field marker `0x40000011_5CE87488` (the 9 bytes `CF 40 00 00 11 5C E8 74
+//! 88`, consumed by `read_number`). That field's INT64 value's low 32 bits are
+//! the line's string id; the immediately following field (`5CE87489`, a STRING)
+//! is the `str.cnv` base FQN the line's text lives under.
+//!
+//! Proven by the #284 spike: marker byte order == dialogue order == ascending
+//! `str.cnv` line id. All field ids drift across patches, so lines are located
+//! by the marker SHAPE, not a schema lookup.
+
+use crate::gom_reader::{GomValue, Reader};
+
+/// The absolute field-id marker opening every dialogue-line node object.
+const LINE_NODE_MARKER: [u8; 9] = [0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88];
+/// GOM type tag for a signed integer (the line-id field).
+const TAG_INT64: u8 = 0x02;
+/// GOM type tag for a string (the str.cnv ref field).
+const TAG_STRING: u8 = 0x06;
+
+/// One ordered dialogue line in a conversation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DialogueLine {
+    /// 0-based position in the conversation (byte order == dialogue order).
+    pub seq: u32,
+    /// The line's string id -- the low 32 bits of the marker INT64; equals the
+    /// `str.cnv` string's `id1` (its unique per-line id, not the shared `id2`).
+    pub line_id: u32,
+    /// The `str.cnv` base FQN the line's text lives under (e.g.
+    /// `str.cnv.alliance.nar_shaddaa.misc.public_taxi`).
+    pub line_ref: String,
+}
+
+/// Decode every dialogue line from a conversation NODE payload, in byte order
+/// (== dialogue order). Malformed nodes are skipped, not fatal.
+pub fn decode_dialogue_lines(payload: &[u8]) -> Vec<DialogueLine> {
+    let mut out = Vec::new();
+    let mut seq = 0u32;
+    let mut w = 0usize;
+    while w + LINE_NODE_MARKER.len() <= payload.len() {
+        if payload[w..w + LINE_NODE_MARKER.len()] == LINE_NODE_MARKER {
+            if let Some((line_id, line_ref)) = decode_node(payload, w) {
+                out.push(DialogueLine {
+                    seq,
+                    line_id,
+                    line_ref,
+                });
+                seq += 1;
+            }
+            w += LINE_NODE_MARKER.len();
+        } else {
+            w += 1;
+        }
+    }
+    out
+}
+
+/// Decode the (line_id, str.cnv ref) of the node beginning at `pos` (the marker
+/// offset). Returns `None` if the shape doesn't match (INT64 then STRING).
+fn decode_node(payload: &[u8], pos: usize) -> Option<(u32, String)> {
+    let mut r = Reader::new(payload, pos);
+    let _fid = r.read_number().ok()?; // consume the 9-byte absolute marker
+    if r.read_tag().ok()? != TAG_INT64 {
+        return None;
+    }
+    let line_id = match r.read_value(TAG_INT64).ok()? {
+        GomValue::I64(v) => v as u32, // low 32 bits == line_id (high byte is a constant)
+        _ => return None,
+    };
+    let _delta = r.read_number().ok()?; // delta field-id to the str.cnv ref (5CE87489)
+    if r.read_tag().ok()? != TAG_STRING {
+        return None;
+    }
+    match r.read_value(TAG_STRING).ok()? {
+        GomValue::Str(s) => Some((line_id, s)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_a_line_node() {
+        // marker | INT64 tag | C9 03 E8 (=1000) | delta 01 | STRING tag | len 12 | ascii
+        let mut p = vec![
+            0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88, // marker
+            TAG_INT64, 0xC9, 0x03, 0xE8, // line_id = 1000
+            0x01, // delta to next field id
+            TAG_STRING, 0x0C, // string len 12
+        ];
+        p.extend_from_slice(b"str.cnv.test");
+        let lines = decode_dialogue_lines(&p);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].seq, 0);
+        assert_eq!(lines[0].line_id, 1000);
+        assert_eq!(lines[0].line_ref, "str.cnv.test");
+    }
+
+    #[test]
+    fn line_id_is_low_32_bits() {
+        // a 5-byte INT64 with a constant high byte 0x11 -> low32 is the id
+        let mut p = vec![
+            0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88, TAG_INT64, 0xCC, 0x11, 0x00,
+            0x12, 0x46, 0xF2, // 0x11_0012_46F2 -> low32 = 0x1246F2 = 1197810
+            0x01, TAG_STRING, 0x03,
+        ];
+        p.extend_from_slice(b"abc");
+        let lines = decode_dialogue_lines(&p);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].line_id, 1_197_810);
+    }
+
+    #[test]
+    fn no_marker_yields_nothing() {
+        assert!(decode_dialogue_lines(b"no conversation markers here").is_empty());
+    }
+}

--- a/kessel/src/schema/mod.rs
+++ b/kessel/src/schema/mod.rs
@@ -1,6 +1,7 @@
 //! Schema definitions for SWTOR game objects
 
 pub mod appearance;
+pub mod conversation_tree;
 pub mod desc_tokens;
 pub mod description_anchor;
 pub mod discipline;


### PR DESCRIPTION
## Summary

Implements #285 (conversation epic #284-287): `conversation_dialogue`, the ordered dialogue script of every conversation, decoded from each Conversation NODE payload's line-node markers. Built on the #284 spike's shape-based map -- the first piece of the playable conversation tree no other SWTOR resource has.

## Acceptance criteria mapping

### 1. Shape-based line decoder
`schema/conversation_tree.rs::decode_dialogue_lines(payload) -> Vec<DialogueLine{seq,line_id,line_ref}>` scans for the absolute line-node marker `CF 40 00 00 11 5C E8 74 88` (field `0x40000011_5CE87488`, consumed by `read_number`); the INT64's low 32 bits are the `line_id`, the next field (`5CE87489`, STRING) is the `str.cnv` base FQN. Marker byte order == dialogue order (proven #284). Keyed by SHAPE, not hash (ids drift).
Evidence: unit tests `decodes_a_line_node`, `line_id_is_low_32_bits` (the real 5-byte `0x11_0012_46F2 -> 1197810` encoding), `no_marker_yields_nothing`.

### 2. Ordered-script table + populate
`conversation_dialogue(cnv_fqn, seq, line_id, line_ref)` PK `(cnv_fqn, seq)`; `populate_conversation_dialogue` decodes every canonical Conversation object's payload and inserts lines in order. Registered in `db/passes.rs` after the conversation passes.
Evidence: `db/cnv.rs`; rows join to `strings` on `s.id1 = d.line_id AND s.fqn LIKE d.line_ref || '.%'` for the spoken text (the str.cnv per-line id is `id1`; the `conversation_lines` view confusingly labels the shared `id2` as "line_id").

### 3. Oracle-validated (post-extract)
The `public_taxi` conversation reconstructs in the exact spike-proven order -- line_ids `[1197810, 1197808, 1197809, 1197811]` by `seq` -- and the id1 join yields the readable script in order ("This public taxi can take you...", "Travel to Isaac's apartment", "Walk Away"). Corpus: **384,588 lines across 9,948 conversations**; 240,235 (62%) join to extracted text (the rest reference str.cnv strings not in spice / non-spoken nodes -- stated honestly). objects/strings/conversation_npcs unchanged vs v7.

### 4. Green
3 decoder unit tests + clippy `-D warnings` + fmt. The spike's `gom_reader` recon accessors (`pos`/`read_tag`) land too -- `read_tag` is used by the decoder; `pos` is recon-only (allow(dead_code), used by kessel-discovery).

## Not done
Speaker labeling (#286) and player options + branch graph (#287) -- the spike mapped both (E0-GUID->Npc for speaker; no-Npc E0 = player option; `8FA60987`/`1FE25D3D` for branches); they build on this ordered spine. Alignment magnitudes stay runtime (polarity is in conversation_alignment_events).
