### PR TITLE
feat(cnv): label dialogue speaker (player vs NPC) per line (#286)

### DIFF
--- a/kessel/src/db/cnv.rs
+++ b/kessel/src/db/cnv.rs
@@ -474,11 +474,12 @@ impl Database {
         let tx = conn.unchecked_transaction()?;
         let mut stmt = tx.prepare_cached(
             "INSERT OR REPLACE INTO conversation_dialogue \
-             (cnv_fqn, seq, line_id, line_ref, speaker_guid, speaker_npc_fqn, is_npc) \
+             (cnv_fqn, seq, line_id, line_ref, speaker_guid, speaker_npc_fqn, speaker_role) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         )?;
 
-        let (mut conversations, mut lines, mut multi_npc) = (0u64, 0u64, 0u64);
+        let (mut conversations, mut lines, mut multi_npc, mut unresolved) =
+            (0u64, 0u64, 0u64, 0u64);
         for (fqn, b64) in &convs {
             let Ok(payload) = BASE64.decode(b64) else {
                 continue;
@@ -510,9 +511,12 @@ impl Database {
                     }
                     multi_npc += 1;
                 }
-                let (speaker_guid, speaker_npc_fqn, is_npc) = match npc_matches.first() {
-                    Some((g, npc_fqn)) => (Some((*g).clone()), Some((*npc_fqn).clone()), 1i64),
-                    None => (None, None, 0i64),
+                let (speaker_guid, speaker_npc_fqn, speaker_role) = match npc_matches.first() {
+                    Some((g, npc_fqn)) => (Some((*g).clone()), Some((*npc_fqn).clone()), "npc"),
+                    None => {
+                        unresolved += 1;
+                        (None, None, "player")
+                    }
                 };
                 stmt.execute(params![
                     fqn,
@@ -521,7 +525,7 @@ impl Database {
                     line.line_ref,
                     speaker_guid,
                     speaker_npc_fqn,
-                    is_npc,
+                    speaker_role,
                 ])?;
                 lines += 1;
             }
@@ -534,6 +538,8 @@ impl Database {
                 "  [warn] {multi_npc} dialogue lines had >1 Npc-resolving actor GUID (first-wins applied)"
             );
         }
+        // Unresolved (player/non-NPC) line count, per the #286 acceptance note.
+        eprintln!("  Conversation dialogue: {unresolved} non-NPC (player) lines of {lines}");
         Ok((conversations, lines))
     }
 }
@@ -648,10 +654,11 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
             --                  AND s.fqn LIKE d.line_ref || '.%'
             --                  AND s.locale = 'en-us'
             -- speaker_* (#286): each line node carries CF E0 actor/ref GUIDs;
-            -- the one resolving to a kind=Npc object is the speaker. is_npc=1
-            -- when an Npc speaker resolved; is_npc=0 for player/system lines
-            -- (the player pseudo-actor resolves to no Npc -- #287 marks which
-            -- of those are player options).
+            -- the one resolving to a kind=Npc object is the speaker.
+            -- speaker_role='npc' when an Npc speaker resolved (speaker_npc_fqn
+            -- set); 'player' otherwise -- the non-NPC lines, i.e. the player
+            -- character's lines/choices (the player pseudo-actor resolves to no
+            -- Npc; #287 refines which of these are explicit player options).
             CREATE TABLE IF NOT EXISTS conversation_dialogue (
                 cnv_fqn         TEXT NOT NULL,
                 seq             INTEGER NOT NULL,
@@ -659,7 +666,7 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
                 line_ref        TEXT NOT NULL,
                 speaker_guid    TEXT,
                 speaker_npc_fqn TEXT,
-                is_npc          INTEGER NOT NULL DEFAULT 0,
+                speaker_role    TEXT NOT NULL DEFAULT 'player',
                 PRIMARY KEY (cnv_fqn, seq)
             );
             CREATE INDEX IF NOT EXISTS idx_cnv_dialogue_line ON conversation_dialogue(line_id);
@@ -802,5 +809,87 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM conversation_lines", [], |r| r.get(0))
             .unwrap();
         assert_eq!(total, 1, "non-cnv strings excluded from the view");
+    }
+
+    /// Build a DB with one Conversation whose synthetic NODE payload has two
+    /// dialogue lines -- the first carries an Npc actor GUID, the second none --
+    /// plus the matching Npc object and a conversation_npcs row.
+    fn speaker_test_db() -> Database {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+        let path = temp_db_path("cnv_speaker");
+        let db = Database::with_grammar(&path, None).unwrap();
+        db.init_schema().unwrap();
+        // node 1: line 1000 + Npc actor GUID E000694F37290DFF; node 2: line 1001, no actor
+        let mut payload = vec![
+            0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88, 0x02, 0xC9, 0x03, 0xE8, 0x01,
+            0x06, 0x03, b'a', b'b', b'c', 0xCF, 0xE0, 0x00, 0x69, 0x4F, 0x37, 0x29, 0x0D, 0xFF,
+        ];
+        payload.extend_from_slice(&[
+            0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88, 0x02, 0xC9, 0x03, 0xE9, 0x01,
+            0x06, 0x03, b'd', b'e', b'f',
+        ]);
+        let json = format!("{{\"payload_b64\":\"{}\"}}", BASE64.encode(&payload));
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO objects (game_id, stable_id, payload_hash, guid, fqn, kind, is_canonical, json) \
+                 VALUES ('c1','s','p','gc','cnv.test','Conversation',1,?1)",
+                params![json],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO objects (game_id, stable_id, payload_hash, guid, fqn, kind, is_canonical, json) \
+                 VALUES ('n1','s','p','E000694F37290DFF','npc.test.speaker','Npc',1,'{}')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO conversation_npcs (cnv_fqn, npc_fqn) VALUES ('cnv.test','npc.test.speaker')",
+                [],
+            )
+            .unwrap();
+        }
+        db
+    }
+
+    #[test]
+    fn dialogue_speaker_marks_player_vs_npc() {
+        let db = speaker_test_db();
+        let (_convs, lines) = db.populate_conversation_dialogue().unwrap();
+        assert_eq!(lines, 2);
+        let conn = db.conn.lock().unwrap();
+        let npc: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM conversation_dialogue WHERE speaker_role='npc'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let player: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM conversation_dialogue WHERE speaker_role='player'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(npc, 1, "the line with an Npc actor GUID");
+        assert_eq!(player, 1, "the line with no Npc actor");
+    }
+
+    #[test]
+    fn dialogue_npc_speaker_resolves_to_a_conversation_npc() {
+        let db = speaker_test_db();
+        db.populate_conversation_dialogue().unwrap();
+        let conn = db.conn.lock().unwrap();
+        let resolved: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM conversation_dialogue d \
+                 JOIN conversation_npcs n ON n.cnv_fqn = d.cnv_fqn AND n.npc_fqn = d.speaker_npc_fqn \
+                 WHERE d.speaker_role = 'npc'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(resolved, 1, "npc speaker fqn appears in conversation_npcs");
     }
 }

--- a/kessel/src/db/cnv.rs
+++ b/kessel/src/db/cnv.rs
@@ -460,10 +460,22 @@ impl Database {
             rows
         };
 
+        // guid -> Npc fqn, to resolve each line's actor GUID to its speaker (#286).
+        let npc_by_guid: std::collections::HashMap<String, String> = {
+            let mut stmt = conn
+                .prepare("SELECT guid, fqn FROM objects WHERE kind = 'Npc' AND is_canonical = 1")?;
+            let map: std::collections::HashMap<String, String> = stmt
+                .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+                .filter_map(|r| r.ok())
+                .collect();
+            map
+        };
+
         let tx = conn.unchecked_transaction()?;
         let mut stmt = tx.prepare_cached(
             "INSERT OR REPLACE INTO conversation_dialogue \
-             (cnv_fqn, seq, line_id, line_ref) VALUES (?1, ?2, ?3, ?4)",
+             (cnv_fqn, seq, line_id, line_ref, speaker_guid, speaker_npc_fqn, is_npc) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         )?;
 
         let (mut conversations, mut lines) = (0u64, 0u64);
@@ -477,11 +489,25 @@ impl Database {
             }
             conversations += 1;
             for line in decoded {
+                // Speaker = the first actor GUID resolving to an Npc; the rest
+                // are branch/condition/quest refs (and the player pseudo-actor,
+                // which resolves to no Npc).
+                let speaker = line
+                    .actor_guids
+                    .iter()
+                    .find_map(|g| npc_by_guid.get(g).map(|fqn| (g.clone(), fqn.clone())));
+                let (speaker_guid, speaker_npc_fqn, is_npc) = match speaker {
+                    Some((g, npc_fqn)) => (Some(g), Some(npc_fqn), 1i64),
+                    None => (None, None, 0i64),
+                };
                 stmt.execute(params![
                     fqn,
                     line.seq as i64,
                     line.line_id as i64,
                     line.line_ref,
+                    speaker_guid,
+                    speaker_npc_fqn,
+                    is_npc,
                 ])?;
                 lines += 1;
             }
@@ -602,14 +628,23 @@ pub(crate) fn create_tables(tx: &Transaction) -> Result<()> {
             --   JOIN strings s ON s.id1 = d.line_id
             --                  AND s.fqn LIKE d.line_ref || '.%'
             --                  AND s.locale = 'en-us'
+            -- speaker_* (#286): each line node carries CF E0 actor/ref GUIDs;
+            -- the one resolving to a kind=Npc object is the speaker. is_npc=1
+            -- when an Npc speaker resolved; is_npc=0 for player/system lines
+            -- (the player pseudo-actor resolves to no Npc -- #287 marks which
+            -- of those are player options).
             CREATE TABLE IF NOT EXISTS conversation_dialogue (
-                cnv_fqn  TEXT NOT NULL,
-                seq      INTEGER NOT NULL,
-                line_id  INTEGER NOT NULL,
-                line_ref TEXT NOT NULL,
+                cnv_fqn         TEXT NOT NULL,
+                seq             INTEGER NOT NULL,
+                line_id         INTEGER NOT NULL,
+                line_ref        TEXT NOT NULL,
+                speaker_guid    TEXT,
+                speaker_npc_fqn TEXT,
+                is_npc          INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (cnv_fqn, seq)
             );
             CREATE INDEX IF NOT EXISTS idx_cnv_dialogue_line ON conversation_dialogue(line_id);
+            CREATE INDEX IF NOT EXISTS idx_cnv_dialogue_speaker ON conversation_dialogue(speaker_npc_fqn);
         "#,
     )?;
 

--- a/kessel/src/db/cnv.rs
+++ b/kessel/src/db/cnv.rs
@@ -478,7 +478,7 @@ impl Database {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         )?;
 
-        let (mut conversations, mut lines) = (0u64, 0u64);
+        let (mut conversations, mut lines, mut multi_npc) = (0u64, 0u64, 0u64);
         for (fqn, b64) in &convs {
             let Ok(payload) = BASE64.decode(b64) else {
                 continue;
@@ -491,13 +491,27 @@ impl Database {
             for line in decoded {
                 // Speaker = the first actor GUID resolving to an Npc; the rest
                 // are branch/condition/quest refs (and the player pseudo-actor,
-                // which resolves to no Npc).
-                let speaker = line
+                // which resolves to no Npc). Branch targets live inside the
+                // 8FA60987 List, not as bare CF E0 emissions, so first-wins
+                // targets the actor -- but flag the multi-Npc case so the
+                // assumption stays auditable across patches.
+                let npc_matches: Vec<(&String, &String)> = line
                     .actor_guids
                     .iter()
-                    .find_map(|g| npc_by_guid.get(g).map(|fqn| (g.clone(), fqn.clone())));
-                let (speaker_guid, speaker_npc_fqn, is_npc) = match speaker {
-                    Some((g, npc_fqn)) => (Some(g), Some(npc_fqn), 1i64),
+                    .filter_map(|g| npc_by_guid.get(g).map(|fqn| (g, fqn)))
+                    .collect();
+                if npc_matches.len() > 1 {
+                    if multi_npc < 5 {
+                        eprintln!(
+                            "  [warn] {fqn} seq {}: {} Npc-resolving actor GUIDs (first wins)",
+                            line.seq,
+                            npc_matches.len()
+                        );
+                    }
+                    multi_npc += 1;
+                }
+                let (speaker_guid, speaker_npc_fqn, is_npc) = match npc_matches.first() {
+                    Some((g, npc_fqn)) => (Some((*g).clone()), Some((*npc_fqn).clone()), 1i64),
                     None => (None, None, 0i64),
                 };
                 stmt.execute(params![
@@ -515,6 +529,11 @@ impl Database {
 
         drop(stmt);
         tx.commit()?;
+        if multi_npc > 0 {
+            eprintln!(
+                "  [warn] {multi_npc} dialogue lines had >1 Npc-resolving actor GUID (first-wins applied)"
+            );
+        }
         Ok((conversations, lines))
     }
 }

--- a/kessel/src/schema/conversation_tree.rs
+++ b/kessel/src/schema/conversation_tree.rs
@@ -79,8 +79,11 @@ fn scan_e0_guids(payload: &[u8], start: usize, end: usize) -> Vec<String> {
     let mut w = start;
     while w < upper {
         if payload[w] == 0xCF && payload[w + 1] == 0xE0 {
-            let g = u64::from_be_bytes(payload[w + 1..w + 9].try_into().unwrap());
-            guids.push(format!("{g:016X}"));
+            // The loop bound guarantees 8 bytes, but no unwrap in library code:
+            // skip cleanly on the impossible short slice.
+            if let Ok(arr) = <[u8; 8]>::try_from(&payload[w + 1..w + 9]) {
+                guids.push(format!("{:016X}", u64::from_be_bytes(arr)));
+            }
         }
         w += 1;
     }
@@ -161,5 +164,61 @@ mod tests {
         let lines = decode_dialogue_lines(&p);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].actor_guids, vec!["E000694F37290DFF".to_string()]);
+    }
+
+    /// A line node with no `CF E0` bytes yields an empty actor list.
+    fn line_node(line_ref: &[u8]) -> Vec<u8> {
+        let mut p = vec![
+            0xCF,
+            0x40,
+            0x00,
+            0x00,
+            0x11,
+            0x5C,
+            0xE8,
+            0x74,
+            0x88,
+            TAG_INT64,
+            0xC9,
+            0x03,
+            0xE8,
+            0x01,
+            TAG_STRING,
+            line_ref.len() as u8,
+        ];
+        p.extend_from_slice(line_ref);
+        p
+    }
+
+    #[test]
+    fn no_actor_guid_yields_empty() {
+        let lines = decode_dialogue_lines(&line_node(b"abc"));
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].actor_guids.is_empty());
+    }
+
+    #[test]
+    fn two_actor_guids_captured_in_order() {
+        let mut p = line_node(b"abc");
+        p.extend_from_slice(&[0xCF, 0xE0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        p.extend_from_slice(&[0xCF, 0xE0, 0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        let lines = decode_dialogue_lines(&p);
+        assert_eq!(
+            lines[0].actor_guids,
+            vec![
+                "E000010203040506".to_string(),
+                "E000AABBCCDDEEFF".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn guid_at_payload_boundary_is_captured() {
+        // the CF E0 GUID occupies the final 9 bytes (CF marker at len-9), the
+        // last byte exactly at payload end -- still captured, no overrun panic.
+        let mut p = line_node(b"abc");
+        p.extend_from_slice(&[0xCF, 0xE0, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        let lines = decode_dialogue_lines(&p);
+        assert_eq!(lines[0].actor_guids, vec!["E000112233445566".to_string()]);
     }
 }

--- a/kessel/src/schema/conversation_tree.rs
+++ b/kessel/src/schema/conversation_tree.rs
@@ -30,30 +30,61 @@ pub struct DialogueLine {
     /// The `str.cnv` base FQN the line's text lives under (e.g.
     /// `str.cnv.alliance.nar_shaddaa.misc.public_taxi`).
     pub line_ref: String,
+    /// The `CF E0`-prefixed actor/ref GUIDs (16-char hex) in this node's byte
+    /// range, in order -- the speaker/branch-ref candidates (#286/#287). The
+    /// one resolving to a kind=Npc object is the speaker; one resolving to no
+    /// Npc is the per-conversation player pseudo-actor.
+    pub actor_guids: Vec<String>,
 }
 
 /// Decode every dialogue line from a conversation NODE payload, in byte order
 /// (== dialogue order). Malformed nodes are skipped, not fatal.
 pub fn decode_dialogue_lines(payload: &[u8]) -> Vec<DialogueLine> {
-    let mut out = Vec::new();
-    let mut seq = 0u32;
+    // Collect line-node marker offsets first so each node's byte range
+    // [pos, next) is known for the per-node actor-GUID scan.
+    let mut positions = Vec::new();
     let mut w = 0usize;
     while w + LINE_NODE_MARKER.len() <= payload.len() {
         if payload[w..w + LINE_NODE_MARKER.len()] == LINE_NODE_MARKER {
-            if let Some((line_id, line_ref)) = decode_node(payload, w) {
-                out.push(DialogueLine {
-                    seq,
-                    line_id,
-                    line_ref,
-                });
-                seq += 1;
-            }
+            positions.push(w);
             w += LINE_NODE_MARKER.len();
         } else {
             w += 1;
         }
     }
+
+    let mut out = Vec::new();
+    let mut seq = 0u32;
+    for (i, &pos) in positions.iter().enumerate() {
+        let Some((line_id, line_ref)) = decode_node(payload, pos) else {
+            continue;
+        };
+        let end = positions.get(i + 1).copied().unwrap_or(payload.len());
+        out.push(DialogueLine {
+            seq,
+            line_id,
+            line_ref,
+            actor_guids: scan_e0_guids(payload, pos, end),
+        });
+        seq += 1;
+    }
     out
+}
+
+/// Collect the `CF E0`-prefixed 8-byte GUIDs (as 16-char uppercase hex) within
+/// `[start, end)` -- the node's speaker/branch-ref candidates.
+fn scan_e0_guids(payload: &[u8], start: usize, end: usize) -> Vec<String> {
+    let mut guids = Vec::new();
+    let upper = end.min(payload.len()).saturating_sub(8);
+    let mut w = start;
+    while w < upper {
+        if payload[w] == 0xCF && payload[w + 1] == 0xE0 {
+            let g = u64::from_be_bytes(payload[w + 1..w + 9].try_into().unwrap());
+            guids.push(format!("{g:016X}"));
+        }
+        w += 1;
+    }
+    guids
 }
 
 /// Decode the (line_id, str.cnv ref) of the node beginning at `pos` (the marker
@@ -116,5 +147,19 @@ mod tests {
     #[test]
     fn no_marker_yields_nothing() {
         assert!(decode_dialogue_lines(b"no conversation markers here").is_empty());
+    }
+
+    #[test]
+    fn captures_node_actor_guid() {
+        let mut p = vec![
+            0xCF, 0x40, 0x00, 0x00, 0x11, 0x5C, 0xE8, 0x74, 0x88, TAG_INT64, 0xC9, 0x03, 0xE8,
+            0x01, TAG_STRING, 0x03,
+        ];
+        p.extend_from_slice(b"abc");
+        // a CF E0 actor GUID within the node's byte range
+        p.extend_from_slice(&[0xCF, 0xE0, 0x00, 0x69, 0x4F, 0x37, 0x29, 0x0D, 0xFF]);
+        let lines = decode_dialogue_lines(&p);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].actor_guids, vec!["E000694F37290DFF".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Implements #286 (conversation epic): per-line speaker labeling on `conversation_dialogue`. Each dialogue line gets a `speaker_role` (`npc`/`player`) plus the resolving Npc, decoded from the node's `CF E0` actor GUID -- the #284 spike's speaker rule. Builds on #285's ordered spine; no re-decode of line ordering.

## Acceptance criteria mapping

### 1. A conversation marks both player and npc lines
The decoder captures each node's `CF E0` actor GUIDs (`DialogueLine.actor_guids`, `schema/conversation_tree.rs`); `populate_conversation_dialogue` (`db/cnv.rs`) resolves the first GUID that maps to a kind=Npc object and writes `speaker_role='npc'`, else `'player'` for the non-NPC (player-character) lines.
Evidence: test `dialogue_speaker_marks_player_vs_npc` -- a two-line synthetic conversation yields exactly one `npc` row and one `player` row.

### 2. An NPC-line speaker resolves to a conversation_npc
The resolved `speaker_npc_fqn` is the Npc object's fqn, which is the same actor recorded in `conversation_npcs` for that conversation.
Evidence: test `dialogue_npc_speaker_resolves_to_a_conversation_npc` (join asserts the npc speaker appears in `conversation_npcs`); and the re-extract cross-check below.

### 3. Rust requirements (Result, no unwrap in lib, clippy/fmt)
Speaker resolution returns via `Result`; the byte-GUID slice uses `if let Ok(arr) = <[u8;8]>::try_from(..)` rather than `unwrap` (CLAUDE.md, even where the loop bound makes it unreachable). clippy `-D warnings` + fmt clean.
Evidence: `schema/conversation_tree.rs::scan_e0_guids`; 13 conversation unit tests pass.

### 4. Re-extraction success criteria (speaker_role set; spot-check; unresolved logged)
Full re-extract: `speaker_role` populated on every dialogue row; NPC speakers resolve against `conversation_npcs` on the corpus spot-check; the non-NPC (player) line count is logged by the pass. Companion speakers are contextually correct (jaesa/pierce/quinn/vette for a Sith Warrior conversation). No emoji.
Evidence: `SELECT speaker_role, count(*)` split + the `JOIN conversation_npcs` cross-check (reported in the PR thread); the `[warn]`/non-NPC-count log lines in the pass.

## Not done
Player-OPTION detection + branch graph (#287): `speaker_role='player'` currently spans all non-NPC lines (player responses + the rare narrator/system line); #287 refines which are explicit player options via the per-conversation player pseudo-actor and the `8FA60987`/`1FE25D3D` branch structure. Alignment magnitudes stay runtime (polarity is in `conversation_alignment_events`). No re-decode of line ordering (reused from #285).